### PR TITLE
feat: add custom error hierarchy

### DIFF
--- a/loto/errors.py
+++ b/loto/errors.py
@@ -1,0 +1,82 @@
+"""Custom error hierarchy for the LOTO package.
+
+This module defines a small hierarchy of exceptions used throughout the
+project.  Each error exposes two pieces of information:
+
+``code``
+    A short machine readable error code.  The tests exercise that this code
+    is preserved and surfaced in the string representation of the
+    exception.
+``hint``
+    A human readable explanation of the problem or a hint to the user.
+
+The base :class:`LotoError` stores these attributes and formats them into the
+exception message.  The various subclasses simply provide semantic meaning
+for the type of failure that occurred (configuration, rules processing,
+graph building, planning, integrations and rendering).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class LotoError(Exception):
+    """Base class for package specific errors.
+
+    Parameters
+    ----------
+    code:
+        Short error code that identifies the failure.
+    hint:
+        Human readable message to help diagnose the issue.
+    """
+
+    code: str
+    hint: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple assignment
+        # Exception expects to be initialised with a message.  We include the
+        # error code in the message so that ``str(exc)`` exposes it directly.
+        msg = f"[{self.code}] {self.hint}"
+        super().__init__(msg)
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        # Ensures the formatted message always contains the error code.
+        return f"[{self.code}] {self.hint}"
+
+
+class ConfigError(LotoError):
+    """Problems with configuration files or environment."""
+
+
+class RulesError(LotoError):
+    """Errors related to rule packs or rule evaluation."""
+
+
+class GraphError(LotoError):
+    """Failures when building or manipulating graphs."""
+
+
+class PlanError(LotoError):
+    """Issues arising during isolation plan computation."""
+
+
+class IntegrationError(LotoError):
+    """Errors when communicating with external systems."""
+
+
+class RenderError(LotoError):
+    """Failures while rendering documents or reports."""
+
+
+__all__ = [
+    "LotoError",
+    "ConfigError",
+    "RulesError",
+    "GraphError",
+    "PlanError",
+    "IntegrationError",
+    "RenderError",
+]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,33 @@
+import pytest
+
+from loto.errors import (
+    ConfigError,
+    GraphError,
+    IntegrationError,
+    LotoError,
+    PlanError,
+    RenderError,
+    RulesError,
+)
+
+
+@pytest.mark.parametrize(
+    "exc_cls",
+    [ConfigError, RulesError, GraphError, PlanError, IntegrationError, RenderError],
+)
+def test_error_subclassing(exc_cls: type[LotoError]) -> None:
+    err = exc_cls("E001", "something went wrong")
+    assert isinstance(err, LotoError)
+    assert err.code == "E001"
+    assert err.hint == "something went wrong"
+    # The string representation should include both the code and hint
+    msg = str(err)
+    assert "E001" in msg and "something went wrong" in msg
+
+
+def test_loto_error_str_contains_code() -> None:
+    err = LotoError("X99", "oops")
+    assert err.code == "X99"
+    assert err.hint == "oops"
+    assert "X99" in str(err)
+    assert "oops" in str(err)


### PR DESCRIPTION
## Summary
- add `LotoError` base exception with code/hint metadata
- implement specific error subclasses for configuration, rules, graphs, plans, integrations, and rendering
- add tests verifying error attributes and message formatting

## Testing
- `python -m pytest tests/test_errors.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1262e38248322b4b7dcca67f4b840