### PR TITLE
Add JSON logging setup with context binding

### DIFF
--- a/loto/logging_setup.py
+++ b/loto/logging_setup.py
@@ -1,0 +1,109 @@
+"""Structured JSON logging utilities for LOTO.
+
+This module configures the root logger to emit JSON formatted log lines and
+provides a small convenience wrapper with a ``bind`` method for attaching
+context to subsequent log records. It is intentionally lightweight and avoids
+external dependencies such as structlog.
+
+Usage
+-----
+>>> from loto.logging_setup import get_logger, init_logging
+>>> init_logging(verbosity=1)
+>>> log = get_logger().bind(wo="WO1", asset="A-1", rule_hash="deadbeef")
+>>> log.info("starting")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import Any, Dict, Mapping, MutableMapping, Optional, cast
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as single-line JSON."""
+
+    #: Logging record attributes that should not be included in the JSON output.
+    _reserved = {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        data: Dict[str, Any] = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        for key, value in record.__dict__.items():
+            if key not in self._reserved:
+                data[key] = value
+        return json.dumps(data, ensure_ascii=False)
+
+
+class ContextLogger(logging.LoggerAdapter):
+    """Logger adapter supporting ``bind`` similar to structlog."""
+
+    def bind(self, **new_context: Any) -> "ContextLogger":
+        merged = {**(self.extra or {}), **new_context}
+        return ContextLogger(self.logger, merged)
+
+    def process(
+        self, msg: Any, kwargs: MutableMapping[str, Any]
+    ) -> tuple[Any, MutableMapping[str, Any]]:
+        """Merge bound context with any ``extra`` provided at log call time."""
+
+        extra: Dict[str, Any] = dict(self.extra or {})
+        user_extra = kwargs.get("extra")
+        if user_extra is not None:
+            extra.update(cast(Mapping[str, Any], user_extra))
+        kwargs["extra"] = extra
+        return msg, kwargs
+
+
+def get_logger(name: Optional[str] = None) -> ContextLogger:
+    """Return a :class:`ContextLogger` wrapping the named logger."""
+
+    base = logging.getLogger(name)
+    return ContextLogger(base, {})
+
+
+def init_logging(verbosity: int = 0) -> None:
+    """Initialise JSON logging for the CLI.
+
+    Parameters
+    ----------
+    verbosity:
+        Verbosity level. ``0`` maps to ``WARNING``; ``1`` maps to ``INFO``;
+        ``2`` or higher maps to ``DEBUG``.
+    """
+
+    level = logging.WARNING
+    if verbosity >= 2:
+        level = logging.DEBUG
+    elif verbosity == 1:
+        level = logging.INFO
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+
+    # ``force=True`` ensures reconfiguration when called multiple times.
+    logging.basicConfig(level=level, handlers=[handler], force=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,10 @@
 """Pytest configuration for the loto package."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the project root is on ``sys.path`` so that ``import loto`` works when
+# tests are executed without installing the package.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,35 @@
+import json
+
+from loto.logging_setup import get_logger, init_logging
+
+
+def test_json_log_contains_context(capsys):
+    init_logging(verbosity=1)
+    logger = get_logger().bind(wo="WO-1", asset="A-1", rule_hash="deadbeef")
+    logger.info("planning start")
+
+    captured = capsys.readouterr().out.strip()
+    assert captured, "No log output captured"
+    data = json.loads(captured)
+    assert data["wo"] == "WO-1"
+    assert data["asset"] == "A-1"
+    assert data["rule_hash"] == "deadbeef"
+    assert data["message"] == "planning start"
+    assert data["level"] == "INFO"
+
+
+def test_verbosity_respected(capsys):
+    # Verbosity 0 should suppress INFO
+    init_logging(verbosity=0)
+    log = get_logger()
+    log.info("info message")
+    assert capsys.readouterr().out == ""
+
+    # Verbosity 2 should show DEBUG
+    init_logging(verbosity=2)
+    log = get_logger()
+    log.debug("debug message")
+    out = capsys.readouterr().out.strip()
+    data = json.loads(out)
+    assert data["message"] == "debug message"
+    assert data["level"] == "DEBUG"


### PR DESCRIPTION
## Summary
- add `logging_setup` module providing JSON formatted logs and context binding
- expose `init_logging` for CLI verbosity control
- test structured logging and verbosity behavior

## Testing
- `pre-commit run --files loto/logging_setup.py tests/test_logging.py tests/conftest.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1263d2b008322a2d96a4724a989cb