### PR TITLE
Implement DDBB expansion with verification selection

### DIFF
--- a/loto/isolation_planner.py
+++ b/loto/isolation_planner.py
@@ -50,26 +50,83 @@ class IsolationPlanner:
     ) -> IsolationPlan:
         """Compute a minimal cut-set isolation plan for the given asset.
 
+        This intentionally tiny implementation focuses on expanding the
+        double-block-and-bleed (DDBB) rule for steam networks.  The planner
+        searches the provided graph for the two closest block valves, the
+        closest bleed, any nearby drains or vents, and a PT/TT node for
+        verification.  Actions are returned in the order required by the
+        specification: blocks → bleed → drains → verification.
+
         Parameters
         ----------
-        graphs: Dict[str, nx.MultiDiGraph]
-            Mapping of domain names to connectivity graphs.
-        asset_tag: str
-            The tag of the asset to isolate.
-        rule_pack: RulePack
-            The rule pack containing domain-specific isolation rules.
+        graphs:
+            Mapping of domain names to connectivity graphs.  Only the
+            ``"steam"`` domain is examined.
+        asset_tag:
+            Tag of the asset to isolate.  The asset must exist in the graph
+            as a node identifier.
+        rule_pack:
+            Unused placeholder for future rule-based logic.  Present for API
+            compatibility.
 
         Returns
         -------
         IsolationPlan
-            The computed isolation plan including isolation actions and
-            verification steps.
-
-        Notes
-        -----
-        This stub does not contain the actual algorithm for computing
-        minimal cut sets. Developers should implement graph search
-        algorithms (e.g., max-flow/min-cut) and apply domain rules
-        accordingly.
+            Structured list of isolation actions and verification steps.
         """
-        raise NotImplementedError("IsolationPlanner.compute() is not implemented yet")
+
+        # Retrieve the steam domain graph.
+        graph = graphs.get("steam")
+        if graph is None:
+            raise ValueError("steam domain graph is required")
+
+        if asset_tag not in graph:
+            raise ValueError(f"asset '{asset_tag}' not present in graph")
+
+        # Compute shortest path lengths from the asset to all other nodes.
+        distances = nx.single_source_shortest_path_length(graph, asset_tag)
+
+        def _candidates(types: set[str]) -> List[tuple[int, float, str]]:
+            """Return candidate nodes of the given types.
+
+            Each candidate is represented as ``(distance, -health_score, id)`` so
+            that sorting yields nearest nodes and, for equal distances, those with
+            higher ``health_score`` first.
+            """
+
+            out: List[tuple[int, float, str]] = []
+            for node, data in graph.nodes(data=True):
+                if data.get("type") in types and node in distances:
+                    health = float(data.get("health_score", 0.0))
+                    out.append((distances[node], -health, node))
+            out.sort()
+            return out
+
+        # Select two closest block valves with health-score tie break.
+        block_nodes = [n for _, _, n in _candidates({"block"})[:2]]
+
+        # Closest bleed valve.
+        bleed_nodes = _candidates({"bleed"})
+        bleed = bleed_nodes[0][2] if bleed_nodes else None
+
+        # Closest drain or vent.
+        drain_nodes = _candidates({"drain", "vent"})
+        drain = drain_nodes[0][2] if drain_nodes else None
+
+        # Verification: nearest PT or TT.
+        verify_nodes = _candidates({"pt", "tt"})
+        verify = verify_nodes[0][2] if verify_nodes else None
+
+        actions: List[Dict[str, str]] = []
+        for node in block_nodes:
+            actions.append({"component": node, "action": "CLOSE"})
+        if bleed:
+            actions.append({"component": bleed, "action": "OPEN"})
+        if drain:
+            actions.append({"component": drain, "action": "OPEN"})
+
+        verifications: List[Dict[str, str]] = []
+        if verify:
+            verifications.append({"component": verify, "action": "VERIFY"})
+
+        return IsolationPlan(plan={"steam": actions}, verifications=verifications)

--- a/tests/test_planner_ddbb.py
+++ b/tests/test_planner_ddbb.py
@@ -1,0 +1,53 @@
+import networkx as nx
+
+from loto.isolation_planner import IsolationPlanner
+from loto.rule_engine import RulePack
+
+
+def build_graph():
+    g = nx.MultiDiGraph()
+    # Asset node
+    g.add_node("asset", type="asset")
+    # Block valves with varying health scores
+    g.add_node("block1", type="block", health_score=80)
+    g.add_node("block2", type="block", health_score=90)
+    g.add_node("block3", type="block", health_score=70)
+    # Bleed
+    g.add_node("bleed1", type="bleed", health_score=50)
+    # Drain and vent
+    g.add_node("drain1", type="drain", health_score=40)
+    g.add_node("vent2", type="vent", health_score=30)
+    # Instrumentation for verification
+    g.add_node("pt1", type="pt", health_score=20)
+    g.add_node("tt1", type="tt", health_score=25)
+
+    edges = [
+        ("asset", "block1"), ("block1", "asset"),
+        ("asset", "block2"), ("block2", "asset"),
+        ("asset", "block3"), ("block3", "asset"),
+        ("asset", "bleed1"), ("bleed1", "asset"),
+        ("asset", "drain1"), ("drain1", "asset"),
+        ("bleed1", "vent2"), ("vent2", "bleed1"),
+        ("block1", "pt1"), ("pt1", "block1"),
+        ("asset", "tt1"), ("tt1", "asset"),
+    ]
+    g.add_edges_from(edges)
+    return g
+
+
+def test_ddbb_expansion_ordering():
+    planner = IsolationPlanner()
+    rule_pack = RulePack(version="1.0", metadata={}, domains={})
+    graph = build_graph()
+
+    plan = planner.compute({"steam": graph}, asset_tag="asset", rule_pack=rule_pack)
+
+    # Expected ordering: two blocks, bleed, drain
+    assert plan.plan["steam"] == [
+        {"component": "block2", "action": "CLOSE"},
+        {"component": "block1", "action": "CLOSE"},
+        {"component": "bleed1", "action": "OPEN"},
+        {"component": "drain1", "action": "OPEN"},
+    ]
+    # Only the nearest PT/TT is used for verification
+    assert plan.verifications == [{"component": "tt1", "action": "VERIFY"}]


### PR DESCRIPTION
## Summary
- expand IsolationPlanner to compute steam DDBB plans, selecting nearest blocks, bleed, drains, and PT/TT verification with explicit actions
- add unit test asserting block-bleed-drain ordering and verification placement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a17b832fcc8322abb2f08ba753affe