### PR TITLE
Add discrete-event scheduling engine

### DIFF
--- a/loto/scheduling/des_engine.py
+++ b/loto/scheduling/des_engine.py
@@ -1,0 +1,154 @@
+"""Discrete-event scheduling engine."""
+
+from __future__ import annotations
+
+import heapq
+import random
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, Mapping
+
+
+@dataclass
+class Task:
+    """Represents a schedulable task.
+
+    Parameters
+    ----------
+    duration:
+        Either a constant duration in time units or a callable accepting
+        ``random.Random`` and returning the duration.  Durations are
+        interpreted as integer time units.
+    predecessors:
+        IDs of tasks that must complete before this task may start.
+    resources:
+        Mapping of resource names to the quantity required.
+    calendar:
+        Optional predicate returning ``True`` when work may be performed at
+        a given time.
+    gate:
+        Optional predicate that must evaluate to ``True`` for the task to
+        start.  Gates receive the global ``state`` mapping supplied to
+        :func:`run`.
+    """
+
+    duration: int | Callable[[random.Random], int]
+    predecessors: Iterable[str] = field(default_factory=list)
+    resources: Mapping[str, int] = field(default_factory=dict)
+    calendar: Callable[[int], bool] | None = None
+    gate: Callable[[Mapping[str, Any]], bool] | None = None
+
+
+@dataclass
+class RunResult:
+    """Result of a scheduling run."""
+
+    starts: Dict[str, int]
+    ends: Dict[str, int]
+    queues: Dict[str, list[str]]
+    violations: list[str]
+    seed: int
+
+
+def _duration(task: Task, rng: random.Random) -> int:
+    dur = task.duration
+    if callable(dur):
+        return int(dur(rng))
+    return int(dur)
+
+
+def run(
+    tasks: Mapping[str, Task],
+    resource_caps: Mapping[str, int],
+    state: Mapping[str, Any] | None = None,
+    seed: int | None = None,
+) -> RunResult:
+    """Run a simple discrete-event schedule.
+
+    Parameters
+    ----------
+    tasks:
+        Mapping of task ID to :class:`Task` specification.
+    resource_caps:
+        Mapping of resource name to available capacity.
+    state:
+        Optional state mapping consulted by task gate predicates.
+    seed:
+        Optional seed for duration sampling.
+    """
+
+    rng = random.Random(seed)
+    seed = seed if seed is not None else 0
+    state = state or {}
+
+    time = 0
+    starts: Dict[str, int] = {}
+    ends: Dict[str, int] = {}
+    remaining = set(tasks.keys())
+    running: list[tuple[int, str]] = []  # heap of (end_time, task_id)
+    available = dict(resource_caps)
+    queues: dict[str, list[str]] = defaultdict(list)
+    violations: list[str] = []
+
+    while remaining or running:
+        started: list[str] = []
+        for tid in sorted(remaining):
+            task = tasks[tid]
+            if any(pred not in ends for pred in task.predecessors):
+                continue
+            if task.gate and not task.gate(state):
+                continue
+            if task.calendar and not task.calendar(time):
+                continue
+
+            missing = [
+                res
+                for res, req in task.resources.items()
+                if available.get(res, 0) < req
+            ]
+            if missing:
+                for res in missing:
+                    if tid not in queues[res]:
+                        queues[res].append(tid)
+                continue
+
+            # start task
+            starts[tid] = time
+            dur = _duration(task, rng)
+            end_time = time + dur
+            heapq.heappush(running, (end_time, tid))
+            for res, req in task.resources.items():
+                available[res] = available.get(res, 0) - req
+            started.append(tid)
+
+        for tid in started:
+            remaining.remove(tid)
+
+        if running:
+            next_time, tid = heapq.heappop(running)
+            time = next_time
+            ends[tid] = time
+            task = tasks[tid]
+            for res, req in task.resources.items():
+                available[res] = available.get(res, 0) + req
+            # handle other tasks completing at same time
+            while running and running[0][0] == time:
+                next_time, tid = heapq.heappop(running)
+                ends[tid] = time
+                task = tasks[tid]
+                for res, req in task.resources.items():
+                    available[res] = available.get(res, 0) + req
+        elif remaining:
+            # No tasks running; advance time.  If all tasks are gated, stop.
+            gated: list[str] = []
+            for tid in remaining:
+                gate = tasks[tid].gate
+                if gate and not gate(state):
+                    gated.append(tid)
+            if len(gated) == len(remaining):
+                violations.extend(sorted(gated))
+                break
+            # otherwise advance to next integer time until calendars open
+            time += 1
+
+    return RunResult(starts, ends, dict(queues), violations, seed)

--- a/tests/scheduling/test_des_engine.py
+++ b/tests/scheduling/test_des_engine.py
@@ -1,0 +1,36 @@
+from loto.scheduling.des_engine import Task, run
+
+
+def test_deterministic_schedule_with_precedence():
+    tasks = {
+        "t1": Task(duration=4),
+        "t2": Task(duration=3, predecessors=["t1"]),
+        "t3": Task(duration=2, predecessors=["t1"]),
+    }
+    result = run(tasks, {})
+    assert result.starts == {"t1": 0, "t2": 4, "t3": 4}
+    assert result.ends == {"t1": 4, "t2": 7, "t3": 6}
+    assert result.queues == {}
+    assert result.violations == []
+
+
+def test_queues_form_under_contention():
+    tasks = {
+        "a": Task(duration=3, resources={"crew": 1}),
+        "b": Task(duration=2, resources={"crew": 1}),
+        "c": Task(duration=1, resources={"crew": 1}),
+    }
+    result = run(tasks, {"crew": 1})
+    assert result.starts == {"a": 0, "b": 3, "c": 5}
+    assert result.ends == {"a": 3, "b": 5, "c": 6}
+    assert result.queues == {"crew": ["b", "c"]}
+
+
+def test_calendar_blocks_outside_work_windows():
+    def cal(t: int) -> bool:
+        return 5 <= t < 10
+
+    tasks = {"a": Task(duration=2, calendar=cal)}
+    result = run(tasks, {})
+    assert result.starts == {"a": 5}
+    assert result.ends == {"a": 7}


### PR DESCRIPTION
## Summary
- implement discrete-event simulator honoring task precedence, resources, gates, and calendars
- expose Task and RunResult dataclasses
- add test suite covering precedence, queueing, and calendar blocking
- refine idle gating check to satisfy type checks

## Testing
- `pre-commit run --files loto/scheduling/des_engine.py tests/scheduling/test_des_engine.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a2413443f88322bac6b000c228b524