### PR TITLE
Add impact configuration loader and demo config maps

### DIFF
--- a/demo/redundancy_map.yaml
+++ b/demo/redundancy_map.yaml
@@ -1,0 +1,4 @@
+UnitA: SPOF
+UnitB:
+  scheme: N+1
+  nplus: 2

--- a/demo/unit_map.yaml
+++ b/demo/unit_map.yaml
@@ -1,0 +1,16 @@
+units:
+  UnitA:
+    rated: 100
+    area: North
+    assets:
+      - uA
+  UnitB:
+    rated: 90
+    area: North
+    assets:
+      - uB1
+      - uB2
+penalties:
+  local1:
+    mw: 5
+    area: South

--- a/loto/impact_config.py
+++ b/loto/impact_config.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Set
+
+import yaml  # type: ignore
+
+
+@dataclass
+class ImpactConfig:
+    """Configuration for :class:`loto.impact.ImpactEngine`.
+
+    Attributes
+    ----------
+    asset_units:
+        Mapping of asset identifier to unit name.
+    unit_data:
+        Per-unit information including rating and redundancy scheme.
+    unit_areas:
+        Mapping of unit name to area.
+    penalties:
+        Mapping of asset identifier to MW penalty applied when unavailable.
+    asset_areas:
+        Mapping of penalty asset to area.
+    unknown_units:
+        Set of unit names with missing or inconsistent data.
+    unknown_penalties:
+        Set of penalty asset identifiers with missing information.
+    """
+
+    asset_units: Dict[str, str]
+    unit_data: Dict[str, Dict[str, Any]]
+    unit_areas: Dict[str, str]
+    penalties: Dict[str, float]
+    asset_areas: Dict[str, str]
+    unknown_units: Set[str]
+    unknown_penalties: Set[str]
+
+
+def load_impact_config(
+    unit_map: str | Path, redundancy_map: str | Path
+) -> ImpactConfig:
+    """Load impact configuration from YAML files.
+
+    Parameters
+    ----------
+    unit_map:
+        Path to the unit map describing units, their ratings, areas and
+        asset membership.  The file is expected to have the following
+        structure::
+
+            units:
+              <unit_name>:
+                rated: <MW>
+                area: <area_name>
+                assets: [<asset_id>, ...]
+            penalties:
+              <asset_id>:
+                mw: <MW>
+                area: <area_name>
+
+    redundancy_map:
+        Path to the redundancy map describing redundancy schemes per
+        unit.  The value for each unit can either be a simple string such
+        as ``"SPOF"`` or a mapping with ``scheme`` and ``nplus`` keys for
+        ``N+1`` configurations.
+
+    Returns
+    -------
+    ImpactConfig
+        Parsed configuration along with sets of unknown units or penalty
+        assets that were missing required information.
+    """
+
+    unit_map_path = Path(unit_map)
+    redundancy_map_path = Path(redundancy_map)
+
+    with unit_map_path.open() as f:
+        um_data = yaml.safe_load(f) or {}
+
+    units_info = um_data.get("units", {})
+    penalties_info = um_data.get("penalties", {})
+
+    asset_units: Dict[str, str] = {}
+    unit_data: Dict[str, Dict[str, Any]] = {}
+    unit_areas: Dict[str, str] = {}
+    penalties: Dict[str, float] = {}
+    asset_areas: Dict[str, str] = {}
+    unknown_units: Set[str] = set()
+    unknown_penalties: Set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Units and their assets
+    # ------------------------------------------------------------------
+    for unit, info in units_info.items():
+        rated = info.get("rated")
+        area = info.get("area")
+        assets = info.get("assets", [])
+        if rated is None or area is None:
+            unknown_units.add(unit)
+            continue
+        unit_data[unit] = {"rated": float(rated)}
+        unit_areas[unit] = str(area)
+        for asset in assets:
+            asset_units[str(asset)] = unit
+
+    # ------------------------------------------------------------------
+    # Penalty assets not tied to units
+    # ------------------------------------------------------------------
+    for asset, info in penalties_info.items():
+        mw = info.get("mw")
+        area = info.get("area")
+        if mw is None or area is None:
+            unknown_penalties.add(asset)
+            continue
+        penalties[asset] = float(mw)
+        asset_areas[asset] = str(area)
+
+    # ------------------------------------------------------------------
+    # Redundancy / derate scheme
+    # ------------------------------------------------------------------
+    with redundancy_map_path.open() as f:
+        red_data = yaml.safe_load(f) or {}
+
+    for unit, info in red_data.items():
+        if isinstance(info, str):
+            scheme = info
+            nplus = None
+        else:
+            scheme = info.get("scheme")
+            nplus = info.get("nplus")
+        if unit not in unit_data:
+            unknown_units.add(unit)
+            continue
+        scheme = str(scheme).upper() if scheme is not None else None
+        if scheme is None:
+            unknown_units.add(unit)
+            continue
+        unit_data[unit]["scheme"] = scheme
+        if scheme == "N+1":
+            unit_data[unit]["nplus"] = int(nplus or 1)
+
+    # units defined without redundancy scheme
+    missing_scheme = set(unit_data) - set(red_data)
+    unknown_units.update(missing_scheme)
+
+    return ImpactConfig(
+        asset_units=asset_units,
+        unit_data=unit_data,
+        unit_areas=unit_areas,
+        penalties=penalties,
+        asset_areas=asset_areas,
+        unknown_units=unknown_units,
+        unknown_penalties=unknown_penalties,
+    )
+
+
+__all__ = ["ImpactConfig", "load_impact_config"]

--- a/tests/test_impact_config.py
+++ b/tests/test_impact_config.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from loto.impact_config import load_impact_config
+
+
+def test_load_demo_config():
+    cfg = load_impact_config(
+        Path("demo/unit_map.yaml"), Path("demo/redundancy_map.yaml")
+    )
+    assert cfg.asset_units == {"uA": "UnitA", "uB1": "UnitB", "uB2": "UnitB"}
+    assert cfg.unit_data == {
+        "UnitA": {"rated": 100.0, "scheme": "SPOF"},
+        "UnitB": {"rated": 90.0, "scheme": "N+1", "nplus": 2},
+    }
+    assert cfg.unit_areas == {"UnitA": "North", "UnitB": "North"}
+    assert cfg.penalties == {"local1": 5.0}
+    assert cfg.asset_areas == {"local1": "South"}
+    assert cfg.unknown_units == set()
+    assert cfg.unknown_penalties == set()
+
+
+def test_missing_redundancy_flagged(tmp_path):
+    tmp_redundancy = tmp_path / "redundancy.yaml"
+    tmp_redundancy.write_text("UnitA: SPOF\n")
+    cfg = load_impact_config(Path("demo/unit_map.yaml"), tmp_redundancy)
+    assert "UnitB" in cfg.unknown_units


### PR DESCRIPTION
## Summary
- add `load_impact_config` helper to parse unit maps, redundancy schemes, and penalties
- include demo YAML maps for units, redundancy, and penalty assets
- test that configuration loads correctly and flags missing entries

## Testing
- `pre-commit run --files loto/impact_config.py tests/test_impact_config.py demo/unit_map.yaml demo/redundancy_map.yaml`
- `pytest tests/test_impact_config.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a25c8b1d6c832295772a19143c7e43