### PR TITLE
Add pricing providers and tests

### DIFF
--- a/loto/pricing/__init__.py
+++ b/loto/pricing/__init__.py
@@ -1,0 +1,5 @@
+"""Pricing providers for external price curves."""
+
+from .providers import CsvProvider, Em6Provider, StaticCurveProvider
+
+__all__ = ["CsvProvider", "Em6Provider", "StaticCurveProvider"]

--- a/loto/pricing/providers.py
+++ b/loto/pricing/providers.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+# Timezone used for all price series
+TZ = "Pacific/Auckland"
+FREQ = "5min"  # five minute buckets
+
+
+def _prepare_series(series: pd.Series) -> pd.Series:
+    """Return series resampled to 5-minute buckets in the target timezone.
+
+    The input index must be datetime-like. If the index lacks timezone
+    information it is assumed to be naive and will be localized to the
+    target timezone. Existing timezones are converted.
+    """
+
+    if not isinstance(series.index, pd.DatetimeIndex):
+        raise ValueError("Series index must be datetime like")
+
+    idx = series.index
+    if idx.tz is None:
+        idx = idx.tz_localize(TZ)
+    else:
+        idx = idx.tz_convert(TZ)
+    series.index = idx
+    series = series.sort_index()
+
+    # Forward fill within 5 minute resampling buckets
+    series = series.resample(FREQ).ffill()
+    return series
+
+
+@dataclass
+class CsvProvider:
+    """Load price series from a CSV file.
+
+    The CSV is expected to have at least two columns: timestamp and value. The
+    first column is parsed as datetimes and the second as the price value.
+    """
+
+    path: Path
+    _cache: Optional[pd.Series] = None
+
+    def load(self) -> pd.Series:
+        if self._cache is None:
+            path = Path(self.path)
+            if not path.exists():
+                raise FileNotFoundError(f"CSV file not found: {path}")
+
+            df = pd.read_csv(path)
+            if df.shape[1] < 2:
+                raise ValueError("CSV must have at least two columns")
+
+            try:
+                ts = pd.to_datetime(df.iloc[:, 0])
+            except Exception as exc:  # pragma: no cover - defensive
+                raise ValueError("Invalid timestamp column") from exc
+
+            series = pd.Series(df.iloc[:, 1].values, index=ts)
+            self._cache = _prepare_series(series)
+
+        return self._cache.copy()
+
+
+class Em6Provider:
+    """Stubbed EM6 provider reading from a CSV cache on disk."""
+
+    _cache: dict[str, pd.Series] = {}
+
+    def __init__(
+        self,
+        *,
+        region: str | None = None,
+        node: str | None = None,
+        cache_dir: Path | str = Path("."),
+    ) -> None:
+        if (region is None and node is None) or (
+            region is not None and node is not None
+        ):
+            raise ValueError("Provide exactly one of region or node")
+        self.region = region
+        self.node = node
+        self.cache_dir = Path(cache_dir)
+
+    def _cache_key(self) -> str:
+        return f"region:{self.region}" if self.region else f"node:{self.node}"
+
+    def load(self) -> pd.Series:
+        key = self._cache_key()
+        if key in self._cache:
+            return self._cache[key].copy()
+
+        filename = f"{self.region}.csv" if self.region else f"{self.node}.csv"
+        path = self.cache_dir / filename
+        if not path.exists():
+            raise FileNotFoundError(f"Cached data not found for {key}: {path}")
+
+        df = pd.read_csv(path)
+        if df.shape[1] < 2:
+            raise ValueError("CSV must have at least two columns")
+
+        try:
+            ts = pd.to_datetime(df.iloc[:, 0])
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError("Invalid timestamp column") from exc
+
+        series = pd.Series(df.iloc[:, 1].values, index=ts)
+        series = _prepare_series(series)
+        self._cache[key] = series
+        return series.copy()
+
+
+@dataclass
+class StaticCurveProvider:
+    """Return a static curve provided as a pandas Series."""
+
+    curve: pd.Series
+
+    def load(self) -> pd.Series:
+        if not isinstance(self.curve, pd.Series):
+            raise ValueError("curve must be a pandas Series")
+        return _prepare_series(self.curve.copy())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "requests",
     "typer",
     "python-dotenv",
+    "pandas",
 ]
 
 [project.optional-dependencies]

--- a/tests/pricing/test_providers.py
+++ b/tests/pricing/test_providers.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from loto.pricing.providers import CsvProvider, Em6Provider, StaticCurveProvider
+
+
+def _write_sample(path):
+    idx = pd.date_range("2024-01-01", periods=3, freq="15min", tz="UTC")
+    df = pd.DataFrame({"ts": idx, "price": [1.0, 2.0, 3.0]})
+    df.to_csv(path, index=False)
+
+
+def test_csv_provider(tmp_path):
+    path = tmp_path / "curve.csv"
+    _write_sample(path)
+
+    provider = CsvProvider(path)
+    series = provider.load()
+
+    assert series.index.tz.zone == "Pacific/Auckland"
+    assert (series.index[1] - series.index[0]).seconds == 300
+    # first three buckets all carry initial value due to ffill
+    assert series.iloc[0] == series.iloc[1] == series.iloc[2]
+
+
+def test_static_curve_provider():
+    idx = pd.date_range("2024-01-01", periods=2, freq="15min", tz="UTC")
+    curve = pd.Series([10.0, 20.0], index=idx)
+
+    provider = StaticCurveProvider(curve)
+    series = provider.load()
+
+    assert series.index.tz.zone == "Pacific/Auckland"
+    assert (series.index[1] - series.index[0]).seconds == 300
+
+
+def test_em6_provider_cache(monkeypatch, tmp_path):
+    path = tmp_path / "A.csv"
+    _write_sample(path)
+
+    provider = Em6Provider(region="A", cache_dir=tmp_path)
+
+    calls: list[str] = []
+    original = pd.read_csv
+
+    def spy(p, *args, **kwargs):
+        calls.append(Path(p).name)
+        return original(p, *args, **kwargs)
+
+    monkeypatch.setattr(pd, "read_csv", spy)
+
+    s1 = provider.load()
+    s2 = provider.load()
+
+    assert s1.equals(s2)
+    # only one read
+    assert calls == ["A.csv"]
+
+
+def test_bad_input_errors(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        CsvProvider(tmp_path / "missing.csv").load()
+
+    with pytest.raises(ValueError):
+        Em6Provider(region="A", node="B")
+
+    with pytest.raises(ValueError):
+        StaticCurveProvider([1, 2, 3]).load()


### PR DESCRIPTION
## Summary
- introduce pricing provider module with CSV, static, and EM6-backed providers
- support 5‑min Pacific/Auckland buckets and caching for EM6 data
- cover providers with unit tests and add pandas dependency

## Testing
- `pre-commit run --files loto/pricing/__init__.py loto/pricing/providers.py tests/pricing/test_providers.py pyproject.toml`
- `pytest tests/pricing/test_providers.py`


------
https://chatgpt.com/codex/tasks/task_b_68a261d227408322aa27d12e0942a763