### PR TITLE
Implement price model and hedging utilities

### DIFF
--- a/loto/pricing/hedge.py
+++ b/loto/pricing/hedge.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 from .model import PriceSeries, normalize
 
+__all__ = ["Hedge"]
+
 
 @dataclass
 class Hedge:

--- a/loto/pricing/hedge.py
+++ b/loto/pricing/hedge.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .model import PriceSeries, normalize
+
+
+@dataclass
+class Hedge:
+    """Blend market prices with a hedging curve via an exposure ``alpha``."""
+
+    hedge: PriceSeries
+    alpha: float
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.alpha <= 1.0:
+            raise ValueError("alpha must be between 0 and 1")
+        self.hedge = normalize(self.hedge)
+
+    def blend(self, prices: PriceSeries) -> PriceSeries:
+        """Return a series of hedged prices."""
+
+        prices = normalize(prices)
+        if not prices.index.equals(self.hedge.index):
+            prices, hedge = prices.align(self.hedge, join="outer")
+            prices = prices.ffill()
+            hedge = hedge.ffill()
+        else:
+            hedge = self.hedge
+        return (1.0 - self.alpha) * prices + self.alpha * hedge

--- a/loto/pricing/model.py
+++ b/loto/pricing/model.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from .providers import _prepare_series
+
+PriceSeries = pd.Series
+
+
+def normalize(series: pd.Series) -> PriceSeries:
+    """Normalise ``series`` to the canonical :class:`PriceSeries`.
+
+    The series is resampled to five‑minute buckets and converted to the
+    ``Pacific/Auckland`` timezone, matching the conventions used by the pricing
+    providers.
+    """
+
+    if not isinstance(series, pd.Series):
+        raise ValueError("series must be a pandas Series")
+    return _prepare_series(series.copy())
+
+
+@dataclass
+class PriceModel:
+    """Simple price model holding low/med/high scenarios.
+
+    The model can return a specific scenario by name or randomly sample one of
+    the scenarios using an optional random number generator.
+    """
+
+    low: PriceSeries
+    med: PriceSeries
+    high: PriceSeries
+
+    def __post_init__(self) -> None:
+        self.low = normalize(self.low)
+        self.med = normalize(self.med)
+        self.high = normalize(self.high)
+
+    def sample(
+        self,
+        level: str | None = None,
+        *,
+        rng: Optional[np.random.Generator] = None,
+    ) -> PriceSeries:
+        """Return a scenario series.
+
+        If ``level`` is provided it must be ``"low"``, ``"med"`` or ``"high"``.
+        Otherwise a scenario is chosen at random using ``rng``.
+        """
+
+        mapping = {"low": self.low, "med": self.med, "high": self.high}
+        if level is not None:
+            key = level.lower()
+            if key not in mapping:
+                raise ValueError("level must be one of 'low', 'med', or 'high'")
+            return mapping[key].copy()
+
+        if rng is None:
+            rng = np.random.default_rng()
+        key = rng.choice(["low", "med", "high"])
+        return mapping[key].copy()

--- a/loto/pricing/model.py
+++ b/loto/pricing/model.py
@@ -5,10 +5,10 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+from pandas import Series as PriceSeries
 
 from .providers import _prepare_series
 
-PriceSeries = pd.Series
 __all__ = ["PriceSeries", "normalize", "PriceModel"]
 
 

--- a/loto/pricing/model.py
+++ b/loto/pricing/model.py
@@ -9,6 +9,7 @@ import pandas as pd
 from .providers import _prepare_series
 
 PriceSeries = pd.Series
+__all__ = ["PriceSeries", "normalize", "PriceModel"]
 
 
 def normalize(series: pd.Series) -> PriceSeries:

--- a/tests/pricing/test_model_hedge.py
+++ b/tests/pricing/test_model_hedge.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pandas.testing as pdt
+
+from loto.pricing.hedge import Hedge
+from loto.pricing.model import PriceModel, normalize
+
+
+def _series(values):
+    idx = pd.date_range("2024-01-01", periods=len(values), freq="5min")
+    return pd.Series(values, index=idx)
+
+
+def test_sampler_and_hedge():
+    low = _series([10, 10, 10])
+    med = _series([20, 20, 20])
+    high = _series([30, 30, 30])
+
+    model = PriceModel(low=low, med=med, high=high)
+    # Explicit scenario selection
+    high_sample = model.sample(level="high")
+
+    assert high_sample.index.tz.zone == "Pacific/Auckland"
+    pdt.assert_series_equal(high_sample, model.high)
+
+    hedge = _series([5, 5, 5])
+    hedger = Hedge(hedge=hedge, alpha=0.25)
+    blended = hedger.blend(high_sample)
+
+    expected = 0.75 * model.high + 0.25 * normalize(hedge)
+    pdt.assert_series_equal(blended, expected)


### PR DESCRIPTION
## Summary
- add `PriceModel` for low/med/high scenarios with normalization to a common price series
- support hedging via `Hedge` class blending prices with exposure α
- include unit tests for model sampling and hedging blend

## Testing
- `pytest tests/pricing/test_model_hedge.py -q`
- `pytest tests/pricing -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_b_68a265d4f2a88322ad5c4f7d36ce9d2d