### PR TITLE
Add price-weighted cost integration for scheduling objective

### DIFF
--- a/loto/scheduling/objective.py
+++ b/loto/scheduling/objective.py
@@ -8,11 +8,15 @@ Two pieces of functionality are provided:
     Integrate a piecewise linear power curve expressed as ``(time, MW)``
     pairs to obtain an energy measure in megawatt hours (MW·h).
 
-``objective``
-    Compute a scalar objective combining makespan, the MW·h integral and an
-    optional late completion penalty::
+``integrate_cost``
+    Integrate a piecewise linear power curve weighted by a price curve to
+    obtain an expected cost.
 
-        J = makespan + \u03bb * MW_h + \u03c1 * late_penalty
+``objective``
+    Compute a scalar objective combining makespan, an energy- or cost-based
+    integral and an optional late completion penalty::
+
+        J = makespan + \u03bb * integral + \u03c1 * late_penalty
 
     where ``late_penalty`` is ``1`` when the supplied ``deadline`` is exceeded
     and ``0`` otherwise.
@@ -21,7 +25,6 @@ Two pieces of functionality are provided:
 from __future__ import annotations
 
 from typing import Sequence, Tuple
-
 
 Point = Tuple[float, float]
 
@@ -46,12 +49,60 @@ def integrate_mwh(curve: Sequence[Point]) -> float:
     return total
 
 
+def integrate_cost(curve: Sequence[Point], price: Sequence[Point]) -> float:
+    """Return the cost integral of ``curve`` weighted by ``price``.
+
+    The supplied ``curve`` and ``price`` are treated as piecewise linear
+    functions.  ``curve`` provides power in megawatts while ``price`` supplies
+    an associated price (for instance in $/MW·h).  The returned value is the
+    integral of the product of these two functions.
+
+    Parameters
+    ----------
+    curve:
+        Ordered sequence of ``(time, MW)`` pairs.
+    price:
+        Ordered sequence of ``(time, price)`` pairs.
+    """
+
+    if len(curve) < 2 or len(price) < 2:
+        return 0.0
+
+    def interp(data: Sequence[Point], t: float) -> float:
+        # Linear interpolation within ``data``.  Values outside the supplied
+        # range use the nearest endpoint.
+        for (t0, v0), (t1, v1) in zip(data, data[1:]):
+            if t0 <= t <= t1:
+                if t1 == t0:
+                    return v0
+                return v0 + (v1 - v0) * (t - t0) / (t1 - t0)
+        return data[0][1] if t < data[0][0] else data[-1][1]
+
+    times = sorted({t for t, _ in curve} | {t for t, _ in price})
+    total = 0.0
+    for t0, t1 in zip(times, times[1:]):
+        p0 = interp(curve, t0)
+        p1 = interp(curve, t1)
+        q0 = interp(price, t0)
+        q1 = interp(price, t1)
+        dt = t1 - t0
+        dp = (p1 - p0) / dt
+        dq = (q1 - q0) / dt
+        total += (
+            p0 * q0 * dt
+            + 0.5 * (p0 * dq + q0 * dp) * dt * dt
+            + (1.0 / 3.0) * dp * dq * dt * dt * dt
+        )
+    return total
+
+
 def objective(
     makespan: float,
     curve: Sequence[Point],
     lam: float,
     rho: float,
     deadline: float | None = None,
+    price: Sequence[Point] | None = None,
 ) -> float:
     """Return the combined scheduling objective.
 
@@ -60,16 +111,20 @@ def objective(
     makespan:
         Completion time of the schedule.
     curve:
-        Power curve used when computing the MW·h integral.
+        Power curve used when computing the MW·h integral or cost.
     lam:
-        Weight applied to the MW·h term.
+        Weight applied to the integral term.
     rho:
         Penalty weight applied if the schedule exceeds ``deadline``.
     deadline:
         Optional deadline for completion.  If provided and ``makespan`` is
         greater than ``deadline`` a unit late penalty is incurred.
+    price:
+        Optional price curve used to weight ``curve`` when computing an
+        expected cost.  When ``None`` the integral is interpreted purely in
+        energy terms (MW·h).
     """
 
-    mwh = integrate_mwh(curve)
+    total = integrate_cost(curve, price) if price is not None else integrate_mwh(curve)
     late = 1.0 if (deadline is not None and makespan > deadline) else 0.0
-    return float(makespan) + lam * mwh + rho * late
+    return float(makespan) + lam * total + rho * late

--- a/tests/scheduling/test_objective_price.py
+++ b/tests/scheduling/test_objective_price.py
@@ -1,0 +1,25 @@
+import pytest
+
+from loto.scheduling.objective import integrate_cost, objective
+
+
+def test_cost_integral_known_curves():
+    tri = [(0.0, 0.0), (1.0, 1.0), (2.0, 0.0)]
+    price_const = [(0.0, 2.0), (2.0, 2.0)]
+    assert integrate_cost(tri, price_const) == pytest.approx(2.0)
+
+    step = [(0.0, 2.0), (3.0, 2.0)]
+    price_ramp = [(0.0, 0.0), (3.0, 6.0)]
+    assert integrate_cost(step, price_ramp) == pytest.approx(18.0)
+
+
+def test_objective_uses_delta_cost():
+    curve = [(0.0, 1.0), (1.0, 1.0)]
+    price_lo = [(0.0, 1.0), (1.0, 1.0)]
+    price_hi = [(0.0, 2.0), (1.0, 2.0)]
+    lam = 4.0
+    rho = 0.0
+    base = objective(1.0, curve, lam, rho, price=price_lo)
+    high = objective(1.0, curve, lam, rho, price=price_hi)
+    delta_cost = integrate_cost(curve, price_hi) - integrate_cost(curve, price_lo)
+    assert high - base == pytest.approx(lam * delta_cost)


### PR DESCRIPTION
## Summary
- support price-weighted integration via `integrate_cost`
- extend scheduling objective to account for price curves
- test cost integration and delta-cost comparisons

## Testing
- `pre-commit run --files loto/scheduling/objective.py tests/scheduling/test_objective_price.py`
- `pytest tests/scheduling/test_objective.py tests/scheduling/test_objective_price.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a26c2c935c8322881517d0390f6c13