### PR TITLE
Implement simulation graph isolation apply

### DIFF
--- a/tests/test_sim_apply.py
+++ b/tests/test_sim_apply.py
@@ -1,55 +1,55 @@
 import networkx as nx
 
-from loto.sim_engine import SimEngine
 from loto.isolation_planner import IsolationPlan
+from loto.sim_engine import SimEngine
 
 
 def build_graph():
     g = nx.MultiDiGraph()
-    g.add_node('source', is_source=True)
-    g.add_node('valve1')
-    g.add_node('target', tag='asset')
-    g.add_node('drain')
-    g.add_node('vent')
-    g.add_node('bypass')
+    g.add_node("source", is_source=True)
+    g.add_node("valve1")
+    g.add_node("target", tag="asset")
+    g.add_node("drain")
+    g.add_node("vent")
+    g.add_node("bypass")
 
     # Isolation edge to be removed
-    g.add_edge('source', 'valve1', is_isolation_point=True, fail_state='FC')
+    g.add_edge("source", "valve1", is_isolation_point=True, fail_state="FC")
     # Edge with fail-open default
-    g.add_edge('valve1', 'target', fail_state='FO')
+    g.add_edge("valve1", "target", fail_state="FO")
     # Drain and vent edges
-    g.add_edge('target', 'drain', kind='drain')
-    g.add_edge('target', 'vent', kind='vent')
+    g.add_edge("target", "drain", kind="drain")
+    g.add_edge("target", "vent", kind="vent")
     # Edge to test fail-closed default
-    g.add_edge('source', 'bypass', fail_state='FC')
+    g.add_edge("source", "bypass", fail_state="FC")
     return g
 
 
 def test_apply_removes_edges_and_sets_states():
     original = build_graph()
-    plan = IsolationPlan(plan={'steam': [('source', 'valve1')]}, verifications=[])
+    plan = IsolationPlan(plan={"steam": [("source", "valve1")]}, verifications=[])
 
     engine = SimEngine()
-    applied = engine.apply(plan, {'steam': original})
+    applied = engine.apply(plan, {"steam": original})
 
     # Original graph is untouched
-    assert original.has_edge('source', 'valve1')
-    assert 'state' not in original.get_edge_data('valve1', 'target')[0]
-    assert 'state' not in original.get_edge_data('source', 'bypass')[0]
+    assert original.has_edge("source", "valve1")
+    assert "state" not in original.get_edge_data("valve1", "target")[0]
+    assert "state" not in original.get_edge_data("source", "bypass")[0]
 
-    g = applied['steam']
+    g = applied["steam"]
 
     # Isolation edge removed
-    assert not g.has_edge('source', 'valve1')
+    assert not g.has_edge("source", "valve1")
     assert g.number_of_edges() == original.number_of_edges() - 1
 
     # Drains and vents are opened
-    assert g.get_edge_data('target', 'drain')[0]['state'] == 'open'
-    assert g.get_edge_data('target', 'vent')[0]['state'] == 'open'
+    assert g.get_edge_data("target", "drain")[0]["state"] == "open"
+    assert g.get_edge_data("target", "vent")[0]["state"] == "open"
 
     # FO/FC defaults applied
-    assert g.get_edge_data('valve1', 'target')[0]['state'] == 'open'
-    assert g.get_edge_data('source', 'bypass')[0]['state'] == 'closed'
+    assert g.get_edge_data("valve1", "target")[0]["state"] == "open"
+    assert g.get_edge_data("source", "bypass")[0]["state"] == "closed"
 
     # Graph validity: nodes preserved
     assert set(g.nodes()) == set(original.nodes())


### PR DESCRIPTION
## Summary
- implement `SimEngine.apply` to clone graphs, remove isolation edges, open drains/vents, and apply fail-state defaults
- add regression test validating graph mutation logic

## Testing
- `pre-commit run --files loto/sim_engine.py tests/test_sim_apply.py`
- `pytest tests/test_sim_apply.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a287f6b430832284d7992f6f306be6