### PR TITLE
refactor: source RulePack from models

### DIFF
--- a/loto/rule_engine.py
+++ b/loto/rule_engine.py
@@ -21,31 +21,9 @@ method stubs. Detailed logic will be implemented in future iterations.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
 
-
-@dataclass
-class RulePack:
-    """A simple data container for a loaded rule pack.
-
-    Attributes
-    ----------
-    version: str
-        The semantic version of the rule pack.
-    metadata: Dict[str, Any]
-        Arbitrary metadata associated with the rule pack (e.g., site name,
-        update timestamp).
-    domains: Dict[str, Any]
-        Domain-specific rules (e.g., steam, condensate). The structure of
-        each domain entry depends on the rule schema and is not enforced
-        here.
-    """
-
-    version: str
-    metadata: Dict[str, Any]
-    domains: Dict[str, Any]
+from .models import RulePack
 
 
 class RuleEngine:

--- a/tests/rules/test_rulepack_source.py
+++ b/tests/rules/test_rulepack_source.py
@@ -1,0 +1,11 @@
+import pytest
+
+from loto import models, rule_engine
+
+
+def test_ruleengine_hash_accepts_models_rulepack():
+    assert rule_engine.RulePack is models.RulePack
+    engine = rule_engine.RuleEngine()
+    pack = models.RulePack()
+    with pytest.raises(NotImplementedError):
+        engine.hash(pack)

--- a/tests/test_planner_min_cut.py
+++ b/tests/test_planner_min_cut.py
@@ -18,7 +18,7 @@ def test_min_cut_blocks_targets():
     g.add_edge('A', 't2', is_isolation_point=True)
 
     planner = IsolationPlanner()
-    pack = RulePack(version='1', metadata={}, domains={})
+    pack = RulePack()
     plan = planner.compute({'process': g}, asset_tag='asset', rule_pack=pack)
 
     assert set(plan.plan['process']) == {('A', 't1'), ('A', 't2')}


### PR DESCRIPTION
## Summary
- remove internal RulePack dataclass from rule engine
- reference models.RulePack instead and add regression test
- adjust min-cut planner test for new RulePack

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a28a7debe4832294673a838d800131