### PR TITLE
Implement RuleEngine load and hashing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
-        additional_dependencies: []
+        additional_dependencies: [types-PyYAML]

--- a/tests/rules/test_rulepack_source.py
+++ b/tests/rules/test_rulepack_source.py
@@ -1,5 +1,3 @@
-import pytest
-
 from loto import models, rule_engine
 
 
@@ -7,5 +5,5 @@ def test_ruleengine_hash_accepts_models_rulepack():
     assert rule_engine.RulePack is models.RulePack
     engine = rule_engine.RuleEngine()
     pack = models.RulePack()
-    with pytest.raises(NotImplementedError):
-        engine.hash(pack)
+    digest = engine.hash(pack)
+    assert isinstance(digest, str) and digest


### PR DESCRIPTION
## Summary
- implement YAML/JSON loading with schema validation in `RuleEngine`
- add stable SHA-256 hash generation for rule packs
- include types-PyYAML in pre-commit mypy configuration and adjust tests

## Testing
- `pre-commit run --files loto/rule_engine.py .pre-commit-config.yaml tests/rules/test_rulepack_source.py`
- `pytest tests/rules`


------
https://chatgpt.com/codex/tasks/task_b_68a2958cca948322af90f6a82ca474ef