### PR TITLE
Implement invariant checks for source-asset paths

### DIFF
--- a/loto/models.py
+++ b/loto/models.py
@@ -131,6 +131,15 @@ class SimResultItem(BaseModel):
     stimulus: Stimulus = Field(..., description="Stimulus that was simulated")
     success: bool = Field(..., description="Whether the simulation succeeded")
     impact: float = Field(..., description="Impact score (unitless)")
+    domain: Optional[str] = Field(
+        None, description="Domain containing any invariant violation"
+    )
+    path: Optional[List[str]] = Field(
+        None, description="Shortest offending path if a violation occurred"
+    )
+    hint: Optional[str] = Field(
+        None, description="Suggested remediation for the violation"
+    )
 
     class Config:
         extra = "forbid"

--- a/loto/sim_engine.py
+++ b/loto/sim_engine.py
@@ -170,16 +170,29 @@ class SimEngine:
             if stim.name not in supported:
                 continue
 
-            offending: List[str] | None = None
-            for graph in applied_graphs.values():
+            offending_domain: str | None = None
+            offending_path: List[str] | None = None
+            for domain, graph in applied_graphs.items():
                 path = shortest_path(graph)
-                if path is not None:
-                    if offending is None or len(path) < len(offending):
-                        offending = path
+                if path is not None and (
+                    offending_path is None or len(path) < len(offending_path)
+                ):
+                    offending_path = path
+                    offending_domain = domain
 
-            success = offending is None
+            success = offending_path is None
             impact = 0.0 if success else 1.0
-            results.append(SimResultItem(stimulus=stim, success=success, impact=impact))
+            hint = None if success else "extra isolation required"
+            results.append(
+                SimResultItem(
+                    stimulus=stim,
+                    success=success,
+                    impact=impact,
+                    domain=offending_domain,
+                    path=offending_path,
+                    hint=hint,
+                )
+            )
             total_time += getattr(stim, "duration_s", 0.0)
 
         return SimReport(results=results, total_time_s=total_time)

--- a/tests/sim/test_invariants.py
+++ b/tests/sim/test_invariants.py
@@ -1,0 +1,45 @@
+import networkx as nx
+from loto.sim_engine import SimEngine
+from loto.models import IsolationAction, IsolationPlan, Stimulus
+
+
+def build_graph():
+    g = nx.MultiDiGraph()
+    g.add_node("source", is_source=True)
+    g.add_node("valve1")
+    g.add_node("asset", tag="asset")
+    g.add_edge("source", "valve1", is_isolation_point=True)
+    g.add_edge("valve1", "asset")
+    return g
+
+
+def test_invariants_pass_when_isolated():
+    g = build_graph()
+    plan = IsolationPlan(
+        plan_id="p1",
+        actions=[IsolationAction(component_id="steam:source->valve1", method="lock")],
+    )
+    engine = SimEngine()
+    applied = engine.apply(plan, {"steam": g})
+    stim = Stimulus(name="REMOTE_OPEN", magnitude=1.0, duration_s=1.0)
+
+    report = engine.run_stimuli(applied, [stim])
+    res = report.results[0]
+    assert res.success
+    assert res.path is None
+    assert res.domain is None
+
+
+def test_reports_shortest_offending_path_and_domain():
+    g = build_graph()
+    plan = IsolationPlan(plan_id="p1", actions=[])
+    engine = SimEngine()
+    applied = engine.apply(plan, {"steam": g})
+    stim = Stimulus(name="REMOTE_OPEN", magnitude=1.0, duration_s=1.0)
+
+    report = engine.run_stimuli(applied, [stim])
+    res = report.results[0]
+    assert not res.success
+    assert res.domain == "steam"
+    assert res.path == ["source", "valve1", "asset"]
+    assert "extra isolation" in res.hint


### PR DESCRIPTION
## Summary
- Extend simulation result model with optional domain, path, and hint fields
- Detect open source-to-asset paths during stimuli runs and return shortest offending path with remediation hint
- Add tests covering invariant success and failure scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a29aa53394832282d57942fe54633c