### PR TITLE
feat: add unit derate curve helper

### DIFF
--- a/tests/impact/test_curve.py
+++ b/tests/impact/test_curve.py
@@ -1,0 +1,12 @@
+import pytest
+
+from loto.impact import unit_derate_curve
+from loto.scheduling.objective import integrate_mwh
+
+
+def test_unit_derate_curve_integral():
+    start = 1.0
+    end = 3.5
+    mw = 20.0
+    curve = unit_derate_curve(start, end, mw)
+    assert integrate_mwh(curve) == pytest.approx(mw * (end - start))


### PR DESCRIPTION
## Summary
- expose `unit_derate_curve` helper to build step-wise derate curves
- add regression test validating MW·h integral

## Testing
- `pre-commit run --files loto/impact.py tests/impact/test_curve.py`
- `pytest tests/impact/test_curve.py -q`
- `pytest tests/test_impact_engine.py tests/scheduling/test_objective.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a29ab9e9888322a1f39fd80201ac1e