### PR TITLE
Add basic CLI orchestration with JSON output

### DIFF
--- a/loto/cli.py
+++ b/loto/cli.py
@@ -75,7 +75,8 @@ def main(argv: Optional[list[str]] = None) -> None:
     except Exception:  # pragma: no cover - graceful fallback
         from .models import RulePack
 
-        rule_pack = RulePack()
+        # Explicitly set default fields to satisfy type checkers
+        rule_pack = RulePack(domain_rules=[], verification_rules=[], risk_policies=None)
 
     # Build graphs from CSVs.  The builder is currently unimplemented, so fall
     # back to a minimal graph that contains a single source feeding the asset.


### PR DESCRIPTION
## Summary
- orchestrate rule loading, graph building, planning, simulation and rendering in `loto.cli`
- write JSON plan output to configurable directory with safe fallbacks

## Testing
- `python -m loto.cli --asset A --rules demo/rules.yaml --line-list demo/lines.csv --valves demo/valves.csv --drains demo/drains.csv`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a29f0040c08322b3426169bace91ec