### PR TITLE
feat: add Maximo-style shell and theme tokens

### DIFF
--- a/apps/maximo-extension-ui/src/app/layout.tsx
+++ b/apps/maximo-extension-ui/src/app/layout.tsx
@@ -3,8 +3,25 @@ import '../styles/globals.css';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang="en" className="h-full">
+      <body className="min-h-screen">
+        <div className="flex min-h-screen flex-col">
+          <header className="flex h-12 items-center bg-[var(--mxc-topbar-bg)] px-4 text-[var(--mxc-topbar-fg)]">
+            <span className="font-semibold">Maximo Extension</span>
+          </header>
+          <div className="flex flex-1 overflow-hidden">
+            <nav className="w-56 shrink-0 border-r border-[var(--mxc-border)] bg-[var(--mxc-nav-bg)] p-4 text-[var(--mxc-nav-fg)]">
+              <ul>
+                <li className="font-medium">Portfolio</li>
+              </ul>
+            </nav>
+            <div className="flex-1 overflow-auto p-4">{children}</div>
+            <aside className="w-64 shrink-0 border-l border-[var(--mxc-border)] bg-[var(--mxc-drawer-bg)] p-4 text-[var(--mxc-drawer-fg)]">
+              {/* Right drawer placeholder */}
+            </aside>
+          </div>
+        </div>
+      </body>
     </html>
   );
 }

--- a/apps/maximo-extension-ui/src/app/page.tsx
+++ b/apps/maximo-extension-ui/src/app/page.tsx
@@ -1,3 +1,23 @@
 export default function Page() {
-  return <main></main>;
+  return (
+    <main>
+      <h1 className="mb-4 text-xl font-semibold">Portfolio</h1>
+      <table className="min-w-full border border-[var(--mxc-border)]">
+        <thead className="bg-[var(--mxc-nav-bg)] text-left">
+          <tr>
+            <th className="px-4 py-2">Name</th>
+            <th className="px-4 py-2">Status</th>
+            <th className="px-4 py-2">Owner</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="px-4 py-6 text-center" colSpan={3}>
+              No data
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </main>
+  );
 }

--- a/apps/maximo-extension-ui/src/styles/globals.css
+++ b/apps/maximo-extension-ui/src/styles/globals.css
@@ -1,3 +1,34 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    --mxc-bg: #f4f4f4;
+    --mxc-fg: #161616;
+    --mxc-topbar-bg: #0f62fe;
+    --mxc-topbar-fg: #ffffff;
+    --mxc-nav-bg: #ffffff;
+    --mxc-nav-fg: #161616;
+    --mxc-drawer-bg: #e0e0e0;
+    --mxc-drawer-fg: #161616;
+    --mxc-border: #e0e0e0;
+  }
+
+  .dark {
+    --mxc-bg: #161616;
+    --mxc-fg: #f4f4f4;
+    --mxc-topbar-bg: #393939;
+    --mxc-topbar-fg: #f4f4f4;
+    --mxc-nav-bg: #262626;
+    --mxc-nav-fg: #f4f4f4;
+    --mxc-drawer-bg: #393939;
+    --mxc-drawer-fg: #f4f4f4;
+    --mxc-border: #525252;
+  }
+
+  body {
+    background-color: var(--mxc-bg);
+    color: var(--mxc-fg);
+  }
+}


### PR DESCRIPTION
## Summary
- add root layout shell with top bar, nav, and right drawer placeholder
- define light/dark Maximo-like design tokens
- scaffold Portfolio page table

## Testing
- `pnpm --filter maximo-extension-ui test --run`
- `pnpm --filter maximo-extension-ui dev` (builds and serves)


------
https://chatgpt.com/codex/tasks/task_b_68a29f255ee8832297d0dc83e1b14d33