### PR TITLE
Add reachability check in SimEngine and test stimulus timing

### DIFF
--- a/loto/sim_engine.py
+++ b/loto/sim_engine.py
@@ -17,8 +17,8 @@ from typing import Dict, List
 
 import networkx as nx  # type: ignore
 
+from .models import IsolationPlan, SimReport, SimResultItem, Stimulus
 from .rule_engine import RulePack
-from .models import IsolationPlan, Stimulus, SimReport, SimResultItem
 
 
 class SimEngine:
@@ -174,11 +174,10 @@ class SimEngine:
             offending_path: List[str] | None = None
             for domain, graph in applied_graphs.items():
                 path = shortest_path(graph)
-                if path is not None and (
-                    offending_path is None or len(path) < len(offending_path)
-                ):
-                    offending_path = path
+                if path is not None:
                     offending_domain = domain
+                    offending_path = path
+                    break
 
             success = offending_path is None
             impact = 0.0 if success else 1.0

--- a/tests/test_sim_stimuli.py
+++ b/tests/test_sim_stimuli.py
@@ -1,7 +1,7 @@
 import networkx as nx
 
-from loto.sim_engine import SimEngine
 from loto.models import IsolationAction, IsolationPlan, Stimulus
+from loto.sim_engine import SimEngine
 
 
 def build_graph():
@@ -28,9 +28,11 @@ def test_valid_plan_pass():
     engine = SimEngine()
     applied = engine.apply(plan, {"steam": g})
 
-    report = engine.run_stimuli(applied, make_stimuli())
+    stims = make_stimuli()
+    report = engine.run_stimuli(applied, stims)
 
     assert all(r.success for r in report.results)
+    assert report.total_time_s == sum(s.duration_s for s in stims)
 
 
 def test_tampered_plan_fail():
@@ -39,6 +41,8 @@ def test_tampered_plan_fail():
     engine = SimEngine()
     applied = engine.apply(plan, {"steam": g})
 
-    report = engine.run_stimuli(applied, make_stimuli())
+    stims = make_stimuli()
+    report = engine.run_stimuli(applied, stims)
 
     assert all(not r.success for r in report.results)
+    assert report.total_time_s == sum(s.duration_s for s in stims)


### PR DESCRIPTION
## Summary
- stop simulation on the first reachable path and include the offending domain/path
- accumulate stimulus duration into `SimReport.total_time_s`
- test that simulation passes/fails correctly and duration is summed

## Testing
- `pre-commit run --files loto/sim_engine.py tests/test_sim_stimuli.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a2a2bb6db883229a0efabdf80c273c