### PR TITLE
Support impact payload in renderer JSON and add round-trip test

### DIFF
--- a/loto/renderer.py
+++ b/loto/renderer.py
@@ -122,7 +122,7 @@ class Renderer:
         self,
         plan: IsolationPlan,
         sim_report: SimReport,
-        impact: Dict[str, Any] | None = None,
+        impact: Mapping[str, Any] | None = None,
     ) -> Dict[str, Any]:
         """Serialize the plan and simulation report to a JSON-friendly dict.
 
@@ -132,7 +132,7 @@ class Renderer:
             The isolation plan to serialize.
         sim_report: SimReport
             The simulation report to serialize.
-        impact: Dict[str, Any] | None
+        impact: Mapping[str, Any] | None
             Optional impact information (e.g., unavailable assets, unit
             derates) to include in the JSON output.
 
@@ -150,7 +150,7 @@ class Renderer:
         stable order for snapshot tests.
         """
 
-        def _sorted_dict(data: Dict[str, Any]) -> Dict[str, Any]:
+        def _sorted_dict(data: Mapping[str, Any]) -> Dict[str, Any]:
             """Recursively sort dictionary keys for deterministic output."""
 
             items: list[tuple[str, Any]] = []

--- a/tests/test_renderer_json.py
+++ b/tests/test_renderer_json.py
@@ -1,0 +1,24 @@
+import json
+
+from loto.models import IsolationPlan, SimReport
+from loto.renderer import Renderer
+
+
+def test_to_json_round_trip_and_optional_impact():
+    plan = IsolationPlan(plan_id="p", actions=[])
+    sim_report = SimReport(results=[], total_time_s=0.0)
+    renderer = Renderer()
+
+    base_payload = renderer.to_json(plan, sim_report)
+    assert list(base_payload.keys()) == ["plan", "simulation"]
+    assert "impact" not in base_payload
+    rt_base = json.loads(json.dumps(base_payload))
+    assert list(rt_base.keys()) == ["plan", "simulation"]
+
+    impact_data = {"b": 2, "a": 1}
+    impact_payload = renderer.to_json(plan, sim_report, impact=impact_data)
+    assert list(impact_payload.keys()) == ["plan", "simulation", "impact"]
+    assert list(impact_payload["impact"].keys()) == ["a", "b"]
+    rt_impact = json.loads(json.dumps(impact_payload))
+    assert list(rt_impact.keys()) == ["plan", "simulation", "impact"]
+    assert list(rt_impact["impact"].keys()) == ["a", "b"]


### PR DESCRIPTION
## Summary
- allow `Renderer.to_json` to accept optional impact mapping
- test JSON round-tripping and stable key ordering with optional impact data

## Testing
- `pre-commit run --files loto/renderer.py tests/test_renderer_json.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a2a2d05808832286cf030a07d0dd3c