### PR TITLE
Add portfolio page with KPI cards and blueprint table

### DIFF
--- a/apps/maximo-extension-ui/src/app/portfolio/page.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import KpiCards, { KpiItem } from '../../components/KpiCards';
+
+const kpis: KpiItem[] = [
+  { label: 'Blueprints', value: 3 },
+  { label: 'Active', value: 2 },
+  { label: 'Completed', value: 1 }
+];
+
+const blueprints = [
+  { name: 'Pump replacement', status: 'Active', owner: 'Jane' },
+  { name: 'Motor upgrade', status: 'Draft', owner: 'John' },
+  { name: 'Energy audit', status: 'Completed', owner: 'Ben' }
+];
+
+export default function PortfolioPage() {
+  const [dense, setDense] = useState(false);
+
+  return (
+    <main>
+      <h1 className="mb-4 text-xl font-semibold">Portfolio</h1>
+      <KpiCards items={kpis} />
+      <div className="mb-2 text-sm">
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={dense}
+            onChange={(e) => setDense(e.target.checked)}
+          />
+          Dense table
+        </label>
+      </div>
+      <table className="min-w-full border border-[var(--mxc-border)]">
+        <thead className="bg-[var(--mxc-nav-bg)] text-left">
+          <tr>
+            <th className="px-4 py-2">Name</th>
+            <th className="px-4 py-2">Status</th>
+            <th className="px-4 py-2">Owner</th>
+          </tr>
+        </thead>
+        <tbody>
+          {blueprints.map((bp) => (
+            <tr key={bp.name} className={dense ? 'text-sm' : undefined}>
+              <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{bp.name}</td>
+              <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{bp.status}</td>
+              <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{bp.owner}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/components/KpiCards.test.tsx
+++ b/apps/maximo-extension-ui/src/components/KpiCards.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import KpiCards from './KpiCards';
+
+const kpis = [
+  { label: 'Active', value: 1 },
+  { label: 'Completed', value: 2 }
+];
+
+test('renders KPI labels', () => {
+  render(<KpiCards items={kpis} />);
+  expect(screen.getByText('Active')).toBeInTheDocument();
+  expect(screen.getByText('Completed')).toBeInTheDocument();
+});
+

--- a/apps/maximo-extension-ui/src/components/KpiCards.tsx
+++ b/apps/maximo-extension-ui/src/components/KpiCards.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export interface KpiItem {
+  label: string;
+  value: string | number;
+}
+
+interface KpiCardsProps {
+  items: KpiItem[];
+}
+
+export default function KpiCards({ items }: KpiCardsProps) {
+  return (
+    <div className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+      {items.map(({ label, value }) => (
+        <div
+          key={label}
+          className="rounded border border-[var(--mxc-border)] p-4 text-center"
+        >
+          <div className="text-2xl font-semibold">{value}</div>
+          <div className="mt-2 text-sm">{label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/stories/Portfolio.stories.tsx
+++ b/apps/maximo-extension-ui/src/stories/Portfolio.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import Page from '../app/portfolio/page';
+
+const meta: Meta<typeof Page> = {
+  title: 'Portfolio/Page',
+  component: Page
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+


### PR DESCRIPTION
## Summary
- build reusable `KpiCards` component for displaying KPI metrics
- add portfolio page that shows KPI cards and a blueprint table with density toggle
- include Storybook story and smoke test for KPIs

## Testing
- `pnpm -F maximo-extension-ui test --run`


------
https://chatgpt.com/codex/tasks/task_b_68a2a2d5a37c8322a5320b5e9eddc2e3