### PR TITLE
feat(ui): add conflicts skeleton

### DIFF
--- a/apps/maximo-extension-ui/src/app/conflicts/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/conflicts/page.test.tsx
@@ -1,0 +1,13 @@
+import { render, fireEvent } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import Page from './page';
+
+test('renders candidate table and toggles selection', () => {
+  const { getAllByRole } = render(<Page />);
+  const checkboxes = getAllByRole('checkbox') as HTMLInputElement[];
+  expect(checkboxes.length).toBeGreaterThan(0);
+  const first = checkboxes[0];
+  expect(first.checked).toBe(false);
+  fireEvent.click(first);
+  expect(first.checked).toBe(true);
+});

--- a/apps/maximo-extension-ui/src/app/conflicts/page.tsx
+++ b/apps/maximo-extension-ui/src/app/conflicts/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+
+type Candidate = {
+  id: number;
+  deltaTime: string;
+  deltaCost: string;
+  readiness: string;
+  isolation: boolean;
+};
+
+const candidates: Candidate[] = [
+  {
+    id: 1,
+    deltaTime: '+1d',
+    deltaCost: '+$100',
+    readiness: 'High',
+    isolation: true
+  },
+  {
+    id: 2,
+    deltaTime: '-2d',
+    deltaCost: '-$50',
+    readiness: 'Medium',
+    isolation: false
+  },
+  {
+    id: 3,
+    deltaTime: '+3d',
+    deltaCost: '+$200',
+    readiness: 'Low',
+    isolation: true
+  }
+];
+
+export default function ConflictsPage() {
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  const toggle = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <main>
+      <h1 className="mb-4 text-xl font-semibold">Conflicts & Bundling</h1>
+      <table className="min-w-full border border-[var(--mxc-border)]">
+        <thead className="bg-[var(--mxc-nav-bg)] text-left">
+          <tr>
+            <th className="px-4 py-2"></th>
+            <th className="px-4 py-2">ΔTime</th>
+            <th className="px-4 py-2">ΔCost</th>
+            <th className="px-4 py-2">Readiness</th>
+            <th className="px-4 py-2">Isolation subset?</th>
+          </tr>
+        </thead>
+        <tbody>
+          {candidates.map((c) => (
+            <tr key={c.id}>
+              <td className="px-4 py-2">
+                <input
+                  type="checkbox"
+                  checked={selected.has(c.id)}
+                  onChange={() => toggle(c.id)}
+                />
+              </td>
+              <td className="px-4 py-2">{c.deltaTime}</td>
+              <td className="px-4 py-2">{c.deltaCost}</td>
+              <td className="px-4 py-2">{c.readiness}</td>
+              <td className="px-4 py-2">{c.isolation ? 'Yes' : 'No'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        className="mt-4 rounded border border-[var(--mxc-border)] px-4 py-2"
+        onClick={() => console.log('Recommend', Array.from(selected))}
+      >
+        Recommend
+      </button>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- scaffold Conflicts & Bundling page with candidate table and Recommend button stub
- add tests ensuring checkboxes toggle selection

## Testing
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_b_68a2a5a0ac8c8322826dbbaf85ea6f19