### PR TITLE
feat: add Maximo theme tokens and tests

### DIFF
--- a/apps/maximo-extension-ui/src/components/Button.test.tsx
+++ b/apps/maximo-extension-ui/src/components/Button.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import Button from './Button';
+
+test('matches snapshot', () => {
+  const { container } = render(<Button>Click</Button>);
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/apps/maximo-extension-ui/src/components/Button.tsx
+++ b/apps/maximo-extension-ui/src/components/Button.tsx
@@ -1,0 +1,18 @@
+import React, { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  className?: string;
+};
+
+export default function Button({ className, ...props }: ButtonProps) {
+  return (
+    <button
+      className={clsx(
+        'rounded-[var(--mxc-radius-sm)] bg-[var(--mxc-topbar-bg)] px-4 py-2 text-[var(--mxc-topbar-fg)] shadow-[var(--mxc-shadow-sm)]',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/maximo-extension-ui/src/components/KpiCards.test.tsx
+++ b/apps/maximo-extension-ui/src/components/KpiCards.test.tsx
@@ -13,3 +13,8 @@ test('renders KPI labels', () => {
   expect(screen.getByText('Completed')).toBeInTheDocument();
 });
 
+test('matches snapshot', () => {
+  const { container } = render(<KpiCards items={kpis} />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+

--- a/apps/maximo-extension-ui/src/components/KpiCards.tsx
+++ b/apps/maximo-extension-ui/src/components/KpiCards.tsx
@@ -15,7 +15,7 @@ export default function KpiCards({ items }: KpiCardsProps) {
       {items.map(({ label, value }) => (
         <div
           key={label}
-          className="rounded border border-[var(--mxc-border)] p-4 text-center"
+          className="rounded-[var(--mxc-radius-md)] border border-[var(--mxc-border)] p-4 text-center shadow-[var(--mxc-shadow-sm)]"
         >
           <div className="text-2xl font-semibold">{value}</div>
           <div className="mt-2 text-sm">{label}</div>

--- a/apps/maximo-extension-ui/src/components/__snapshots__/Button.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/components/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matches snapshot 1`] = `
+<button
+  class="rounded-[var(--mxc-radius-sm)] bg-[var(--mxc-topbar-bg)] px-4 py-2 text-[var(--mxc-topbar-fg)] shadow-[var(--mxc-shadow-sm)]"
+>
+  Click
+</button>
+`;

--- a/apps/maximo-extension-ui/src/components/__snapshots__/KpiCards.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/components/__snapshots__/KpiCards.test.tsx.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matches snapshot 1`] = `
+<div
+  class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-3"
+>
+  <div
+    class="rounded-[var(--mxc-radius-md)] border border-[var(--mxc-border)] p-4 text-center shadow-[var(--mxc-shadow-sm)]"
+  >
+    <div
+      class="text-2xl font-semibold"
+    >
+      1
+    </div>
+    <div
+      class="mt-2 text-sm"
+    >
+      Active
+    </div>
+  </div>
+  <div
+    class="rounded-[var(--mxc-radius-md)] border border-[var(--mxc-border)] p-4 text-center shadow-[var(--mxc-shadow-sm)]"
+  >
+    <div
+      class="text-2xl font-semibold"
+    >
+      2
+    </div>
+    <div
+      class="mt-2 text-sm"
+    >
+      Completed
+    </div>
+  </div>
+</div>
+`;

--- a/apps/maximo-extension-ui/src/styles/globals.css
+++ b/apps/maximo-extension-ui/src/styles/globals.css
@@ -1,32 +1,10 @@
+@import './theme-maximo.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --mxc-bg: #f4f4f4;
-    --mxc-fg: #161616;
-    --mxc-topbar-bg: #0f62fe;
-    --mxc-topbar-fg: #ffffff;
-    --mxc-nav-bg: #ffffff;
-    --mxc-nav-fg: #161616;
-    --mxc-drawer-bg: #e0e0e0;
-    --mxc-drawer-fg: #161616;
-    --mxc-border: #e0e0e0;
-  }
-
-  .dark {
-    --mxc-bg: #161616;
-    --mxc-fg: #f4f4f4;
-    --mxc-topbar-bg: #393939;
-    --mxc-topbar-fg: #f4f4f4;
-    --mxc-nav-bg: #262626;
-    --mxc-nav-fg: #f4f4f4;
-    --mxc-drawer-bg: #393939;
-    --mxc-drawer-fg: #f4f4f4;
-    --mxc-border: #525252;
-  }
-
   body {
     background-color: var(--mxc-bg);
     color: var(--mxc-fg);

--- a/apps/maximo-extension-ui/src/styles/theme-maximo.css
+++ b/apps/maximo-extension-ui/src/styles/theme-maximo.css
@@ -1,0 +1,41 @@
+:root {
+  /* Palette */
+  --mxc-bg: #f4f4f4;
+  --mxc-fg: #161616;
+  --mxc-topbar-bg: #0f62fe;
+  --mxc-topbar-fg: #ffffff;
+  --mxc-nav-bg: #ffffff;
+  --mxc-nav-fg: #161616;
+  --mxc-drawer-bg: #e0e0e0;
+  --mxc-drawer-fg: #161616;
+  --mxc-border: #e0e0e0;
+
+  /* Radii */
+  --mxc-radius-sm: 2px;
+  --mxc-radius-md: 4px;
+  --mxc-radius-lg: 8px;
+
+  /* Shadows */
+  --mxc-shadow-sm: 0 1px 2px rgba(0,0,0,0.1);
+  --mxc-shadow-md: 0 2px 4px rgba(0,0,0,0.1);
+  --mxc-shadow-lg: 0 4px 8px rgba(0,0,0,0.1);
+
+  /* Chips */
+  --mxc-chip-bg: #e0e0e0;
+  --mxc-chip-fg: #161616;
+  --mxc-chip-radius: 16px;
+}
+
+.dark {
+  --mxc-bg: #161616;
+  --mxc-fg: #f4f4f4;
+  --mxc-topbar-bg: #393939;
+  --mxc-topbar-fg: #f4f4f4;
+  --mxc-nav-bg: #262626;
+  --mxc-nav-fg: #f4f4f4;
+  --mxc-drawer-bg: #393939;
+  --mxc-drawer-fg: #f4f4f4;
+  --mxc-border: #525252;
+  --mxc-chip-bg: #393939;
+  --mxc-chip-fg: #f4f4f4;
+}


### PR DESCRIPTION
## Summary
- extract Maximo palette, radii, shadow, chip tokens
- wire tokens into Tailwind and apply to card and button
- add snapshot tests for card and button

## Testing
- `pnpm --filter maximo-extension-ui exec vitest run`


------
https://chatgpt.com/codex/tasks/task_b_68a2a5afa4b48322aaa485c1aa70b4c8