### PR TITLE
feat(ui): refine conflicts table layout

### DIFF
--- a/apps/maximo-extension-ui/src/app/conflicts/page.tsx
+++ b/apps/maximo-extension-ui/src/app/conflicts/page.tsx
@@ -52,7 +52,7 @@ export default function ConflictsPage() {
   return (
     <main>
       <h1 className="mb-4 text-xl font-semibold">Conflicts & Bundling</h1>
-      <table className="min-w-full border border-[var(--mxc-border)]">
+      <table className="w-full border border-[var(--mxc-border)]">
         <thead className="bg-[var(--mxc-nav-bg)] text-left">
           <tr>
             <th className="px-4 py-2"></th>
@@ -70,6 +70,7 @@ export default function ConflictsPage() {
                   type="checkbox"
                   checked={selected.has(c.id)}
                   onChange={() => toggle(c.id)}
+                  aria-label={`Select candidate ${c.id}`}
                 />
               </td>
               <td className="px-4 py-2">{c.deltaTime}</td>


### PR DESCRIPTION
## Summary
- add conflicts table skeleton with ΔTime, ΔCost, Readiness, and Isolation subset columns
- stub Recommend button logging selected rows
- mark checkboxes with aria-label for accessibility

## Testing
- `pnpm --filter maximo-extension-ui test src/app/conflicts/page.test.tsx --run`


------
https://chatgpt.com/codex/tasks/task_b_68a2a9149d1c8322b16ba09aac1ccddd