### PR TITLE
Add parts availability gate and tests

### DIFF
--- a/loto/scheduling/gates.py
+++ b/loto/scheduling/gates.py
@@ -67,6 +67,32 @@ def shared_isolation(key: str) -> Callable[[State], bool]:
     return predicate
 
 
+def parts_available(wo_id: str) -> Callable[[State], bool]:
+    """Return a predicate requiring parts for ``wo_id`` to be available.
+
+    The event ``state`` is expected to expose a ``"parts"`` collection –
+    either a mapping from work order IDs to truthy availability flags or a
+    set of work order IDs that currently have parts on hand.  The predicate
+    evaluates to ``True`` when ``wo_id`` is present and truthy in that
+    collection.
+    """
+
+    def predicate(state: State) -> bool:
+        parts = state.get("parts")
+        if isinstance(parts, dict):
+            return bool(parts.get(wo_id))
+        if isinstance(parts, set):
+            return wo_id in parts
+        if parts is None:
+            return False
+        try:
+            return wo_id in parts
+        except TypeError:
+            return False
+
+    return predicate
+
+
 def compose_gates(*preds: Callable[[State], bool]) -> Callable[[State], bool]:
     """Combine multiple gate predicates using logical AND.
 

--- a/tests/scheduling/test_des_engine_parts_gate.py
+++ b/tests/scheduling/test_des_engine_parts_gate.py
@@ -1,0 +1,24 @@
+from loto.scheduling.des_engine import Task, run
+from loto.scheduling.gates import parts_available
+
+
+def test_task_waits_for_parts_gate():
+    gate = parts_available("wo-1")
+    tasks = {
+        "prep": Task(duration=3),
+        "aux": Task(duration=2),
+        "main": Task(duration=1, predecessors=["prep"], gate=gate),
+    }
+
+    state = {"parts": set()}
+    result = run(tasks, {}, state)
+    assert result.starts == {"prep": 0, "aux": 0}
+    assert result.ends == {"aux": 2, "prep": 3}
+    assert result.violations == ["main"]
+    assert "main" not in result.starts
+
+    state["parts"].add("wo-1")
+    result = run(tasks, {}, state)
+    assert result.starts == {"prep": 0, "aux": 0, "main": 3}
+    assert result.ends == {"aux": 2, "prep": 3, "main": 4}
+    assert result.violations == []

--- a/tests/scheduling/test_gates.py
+++ b/tests/scheduling/test_gates.py
@@ -1,6 +1,7 @@
 from loto.scheduling.gates import (
     compose_gates,
     hold_point,
+    parts_available,
     permit_gate,
     shared_isolation,
 )
@@ -11,6 +12,14 @@ def test_permit_gate():
     state = {"permit": False}
     assert not gate(state)
     state["permit"] = True
+    assert gate(state)
+
+
+def test_parts_available():
+    gate = parts_available("wo-1")
+    state = {"parts": {}}
+    assert not gate(state)
+    state["parts"]["wo-1"] = True
     assert gate(state)
 
 


### PR DESCRIPTION
## Summary
- add `parts_available` gate predicate for work order parts
- cover predicate and scheduling integration with tests

## Testing
- `pre-commit run --files loto/scheduling/gates.py tests/scheduling/test_gates.py tests/scheduling/test_des_engine_parts_gate.py`
- `pytest tests/scheduling/test_gates.py tests/scheduling/test_des_engine_parts_gate.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2c1258bcc83228e6b3d8a783a6da9