### PR TITLE
Add Coupa and Stores adapter stubs

### DIFF
--- a/loto/integrations/__init__.py
+++ b/loto/integrations/__init__.py
@@ -12,10 +12,11 @@ Only method signatures are provided here, to be fleshed out later.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
-from .isolation_planner import IsolationPlan
-from .models import SimReport
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from ..isolation_planner import IsolationPlan
+    from ..models import SimReport
 
 
 class IntegrationAdapter:

--- a/loto/integrations/coupa_adapter.py
+++ b/loto/integrations/coupa_adapter.py
@@ -1,0 +1,40 @@
+"""Coupa procurement adapter stubs.
+
+This module defines an abstract interface for raising urgent enquiries via
+Coupa and a demo implementation used for dry runs.  The real implementation
+would call the Coupa API to raise a request for quotation (RFQ).
+"""
+
+from __future__ import annotations
+
+import abc
+import uuid
+
+
+class CoupaAdapter(abc.ABC):
+    """Abstract interface for Coupa interactions."""
+
+    @abc.abstractmethod
+    def raise_urgent_enquiry(self, part_number: str, quantity: int) -> str:
+        """Raise an urgent enquiry (RFQ) for a part.
+
+        Parameters
+        ----------
+        part_number:
+            Identifier for the required part.
+        quantity:
+            Number of units required.
+
+        Returns
+        -------
+        str
+            Identifier of the raised RFQ.
+        """
+
+
+class DemoCoupaAdapter(CoupaAdapter):
+    """Dry-run Coupa adapter that fabricates RFQ identifiers."""
+
+    def raise_urgent_enquiry(self, part_number: str, quantity: int) -> str:
+        """Simulate raising an RFQ and return its identifier."""
+        return f"RFQ-{uuid.uuid4().hex[:8]}"

--- a/loto/integrations/stores_adapter.py
+++ b/loto/integrations/stores_adapter.py
@@ -1,0 +1,39 @@
+"""Stores warehouse adapter stubs.
+
+This module defines an abstract interface for creating pick lists in the
+warehouse and a demo implementation used for dry runs.
+"""
+
+from __future__ import annotations
+
+import abc
+import uuid
+
+
+class StoresAdapter(abc.ABC):
+    """Abstract interface for warehouse interactions."""
+
+    @abc.abstractmethod
+    def create_pick_list(self, part_number: str, quantity: int) -> str:
+        """Create a pick list for the requested part.
+
+        Parameters
+        ----------
+        part_number:
+            Identifier for the part to be picked.
+        quantity:
+            Number of units to pick.
+
+        Returns
+        -------
+        str
+            Identifier of the generated pick list.
+        """
+
+
+class DemoStoresAdapter(StoresAdapter):
+    """Dry-run stores adapter that fabricates pick list identifiers."""
+
+    def create_pick_list(self, part_number: str, quantity: int) -> str:
+        """Simulate creating a pick list and return its identifier."""
+        return f"PL-{uuid.uuid4().hex[:8]}"

--- a/tests/test_integrations_adapters.py
+++ b/tests/test_integrations_adapters.py
@@ -1,0 +1,28 @@
+"""Tests for Coupa and Stores adapter stubs."""
+
+from loto.integrations.coupa_adapter import DemoCoupaAdapter
+from loto.integrations.stores_adapter import DemoStoresAdapter
+
+
+def test_coupa_demo_adapter_returns_rfq_id() -> None:
+    """Simulate a shortage and ensure an RFQ identifier is produced."""
+    available = 0
+    needed = 5
+    adapter = DemoCoupaAdapter()
+    if available < needed:
+        rfq_id = adapter.raise_urgent_enquiry("P-100", needed)
+    else:
+        rfq_id = ""
+    assert rfq_id.startswith("RFQ-")
+
+
+def test_stores_demo_adapter_returns_pick_list_id() -> None:
+    """Simulate a shortage and ensure a pick list identifier is produced."""
+    available = 0
+    needed = 3
+    adapter = DemoStoresAdapter()
+    if available < needed:
+        pick_id = adapter.create_pick_list("P-100", needed)
+    else:
+        pick_id = ""
+    assert pick_id.startswith("PL-")


### PR DESCRIPTION
## Summary
- convert `loto.integrations` into a package
- add Coupa adapter interface with a demo RFQ implementation
- add Stores adapter interface with a demo pick-list implementation
- cover adapters with unit tests simulating shortages

## Testing
- `pre-commit run --files loto/integrations/__init__.py loto/integrations/coupa_adapter.py loto/integrations/stores_adapter.py tests/test_integrations_adapters.py`
- `pytest tests/test_integrations_adapters.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2c158fb4c8322b714b646702f1a86