### PR TITLE
feat(ui): add materials panel component

### DIFF
--- a/apps/maximo-extension-ui/package.json
+++ b/apps/maximo-extension-ui/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "vitest",
+    "test": "vitest run",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/apps/maximo-extension-ui/src/components/MaterialsPanel.tsx
+++ b/apps/maximo-extension-ui/src/components/MaterialsPanel.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+export type MaterialStatus = 'ready' | 'short' | 'ordered';
+
+export interface MaterialItem {
+  item: string;
+  required: number;
+  onHand: number;
+  eta?: string;
+  status: MaterialStatus;
+}
+
+interface MaterialsPanelProps {
+  items: MaterialItem[];
+}
+
+const statusStyles: Record<MaterialStatus, { icon: string; label: string; color: string }> = {
+  ready: { icon: '✓', label: 'Ready', color: 'text-green-600' },
+  short: { icon: '⚠️', label: 'Short', color: 'text-red-600' },
+  ordered: { icon: '⏳', label: 'Ordered', color: 'text-blue-600' }
+};
+
+export default function MaterialsPanel({ items }: MaterialsPanelProps) {
+  return (
+    <div className="overflow-hidden rounded-[var(--mxc-radius-md)] border border-[var(--mxc-border)]">
+      <table className="min-w-full divide-y divide-[var(--mxc-border)] text-sm">
+        <thead className="bg-[var(--mxc-bg)]">
+          <tr>
+            <th scope="col" className="px-4 py-2 text-left font-medium">
+              Item
+            </th>
+            <th scope="col" className="px-4 py-2 text-right font-medium">
+              Required
+            </th>
+            <th scope="col" className="px-4 py-2 text-right font-medium">
+              On-hand
+            </th>
+            <th scope="col" className="px-4 py-2 text-left font-medium">
+              ETA
+            </th>
+            <th scope="col" className="px-4 py-2 text-left font-medium">
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--mxc-border)]">
+          {items.map(({ item, required, onHand, eta, status }) => {
+            const { icon, label, color } = statusStyles[status];
+            return (
+              <tr key={item} className="bg-[var(--mxc-bg)]">
+                <td className="px-4 py-2">{item}</td>
+                <td className="px-4 py-2 text-right">{required}</td>
+                <td className="px-4 py-2 text-right">{onHand}</td>
+                <td className="px-4 py-2">{eta ?? '—'}</td>
+                <td className="px-4 py-2">
+                  <span className={`flex items-center gap-1 font-medium ${color}`}>
+                    <span aria-hidden="true">{icon}</span>
+                    <span>{label}</span>
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/stories/MaterialsPanel.stories.tsx
+++ b/apps/maximo-extension-ui/src/stories/MaterialsPanel.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import MaterialsPanel, { MaterialItem } from '../components/MaterialsPanel';
+
+const meta: Meta<typeof MaterialsPanel> = {
+  title: 'Components/MaterialsPanel',
+  component: MaterialsPanel
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const baseItem: Omit<MaterialItem, 'status'> = {
+  item: 'Widget',
+  required: 5,
+  onHand: 5,
+  eta: '—'
+};
+
+export const Ready: Story = {
+  args: {
+    items: [{ ...baseItem, status: 'ready' }]
+  }
+};
+
+export const Short: Story = {
+  args: {
+    items: [{ ...baseItem, onHand: 0, status: 'short' }]
+  }
+};
+
+export const Ordered: Story = {
+  args: {
+    items: [{ ...baseItem, onHand: 0, eta: 'Tomorrow', status: 'ordered' }]
+  }
+};
+


### PR DESCRIPTION
## Summary
- add materials panel component listing item quantities and status
- document materials panel states in Storybook
- run vitest once during frontend tests

## Testing
- `pnpm --filter maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a2c1707c7c83229c75ee9f477778bc