### PR TITLE
Expose integration adapters

### DIFF
--- a/loto/integrations/__init__.py
+++ b/loto/integrations/__init__.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List
 
+from .coupa_adapter import CoupaAdapter, DemoCoupaAdapter
+from .stores_adapter import StoresAdapter, DemoStoresAdapter
+
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from ..isolation_planner import IsolationPlan
     from ..models import SimReport
@@ -96,3 +99,12 @@ class IntegrationAdapter:
         (e.g., Maximo's doclinks) or write them to disk in demo mode.
         """
         raise NotImplementedError("attach_artifacts is not implemented yet")
+
+
+__all__ = [
+    "IntegrationAdapter",
+    "CoupaAdapter",
+    "DemoCoupaAdapter",
+    "StoresAdapter",
+    "DemoStoresAdapter",
+]


### PR DESCRIPTION
## Summary
- export Coupa and Stores integration adapters from `loto.integrations`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a2c56192b88322aac07d7432465133