### PR TITLE
feat(ui): add front-end API data types

### DIFF
--- a/apps/maximo-extension-ui/src/app/conflicts/page.tsx
+++ b/apps/maximo-extension-ui/src/app/conflicts/page.tsx
@@ -1,16 +1,9 @@
 'use client';
 
 import { useState } from 'react';
+import { SimulationResult } from '../../types/api';
 
-type Candidate = {
-  id: number;
-  deltaTime: string;
-  deltaCost: string;
-  readiness: string;
-  isolation: boolean;
-};
-
-const candidates: Candidate[] = [
+const candidates: SimulationResult[] = [
   {
     id: 1,
     deltaTime: '+1d',

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -1,15 +1,47 @@
 'use client';
 
 import { useState } from 'react';
+import {
+  WorkOrderSummary,
+  PlanStep,
+  SimulationResult,
+  ImpactRecord
+} from '../../../types/api';
 
 const tabs = ['Plan', 'P&ID', 'Simulation', 'Impact'];
 
 export default function PlannerPage({ params }: { params: { wo: string } }) {
   const [activeTab, setActiveTab] = useState('Plan');
 
+  const workOrder: WorkOrderSummary = {
+    id: params.wo,
+    description: 'Example work order',
+    status: 'WAPPR'
+  };
+
+  const plan: PlanStep[] = [
+    { step: 1, description: 'Example step', resources: 'None' }
+  ];
+
+  const simulations: SimulationResult[] = [
+    {
+      id: 1,
+      deltaTime: '+1d',
+      deltaCost: '+$100',
+      readiness: 'High',
+      isolation: true
+    }
+  ];
+
+  const impact: ImpactRecord[] = [
+    { metric: 'Downtime (hrs)', before: 10, after: 8, delta: -2 }
+  ];
+
   return (
     <main className="h-full">
-      <h1 className="mb-4 text-xl font-semibold">WO Planner: {params.wo}</h1>
+      <h1 className="mb-4 text-xl font-semibold">
+        WO Planner: {workOrder.id}
+      </h1>
       <div className="flex h-full">
         <div className="flex-1 pr-4">
           <div role="tablist" className="mb-4 border-b">
@@ -35,17 +67,61 @@ export default function PlannerPage({ params }: { params: { wo: string } }) {
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <td className="px-4 py-2">1</td>
-                  <td className="px-4 py-2">Example step</td>
-                  <td className="px-4 py-2">None</td>
-                </tr>
+                {plan.map((p) => (
+                  <tr key={p.step}>
+                    <td className="px-4 py-2">{p.step}</td>
+                    <td className="px-4 py-2">{p.description}</td>
+                    <td className="px-4 py-2">{p.resources}</td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           )}
           {activeTab === 'P&ID' && <div>P&amp;ID placeholder</div>}
-          {activeTab === 'Simulation' && <div>Simulation placeholder</div>}
-          {activeTab === 'Impact' && <div>Impact placeholder</div>}
+          {activeTab === 'Simulation' && (
+            <table className="min-w-full border border-[var(--mxc-border)]">
+              <thead className="bg-[var(--mxc-nav-bg)] text-left">
+                <tr>
+                  <th className="px-4 py-2">ΔTime</th>
+                  <th className="px-4 py-2">ΔCost</th>
+                  <th className="px-4 py-2">Readiness</th>
+                  <th className="px-4 py-2">Isolation subset?</th>
+                </tr>
+              </thead>
+              <tbody>
+                {simulations.map((s) => (
+                  <tr key={s.id}>
+                    <td className="px-4 py-2">{s.deltaTime}</td>
+                    <td className="px-4 py-2">{s.deltaCost}</td>
+                    <td className="px-4 py-2">{s.readiness}</td>
+                    <td className="px-4 py-2">{s.isolation ? 'Yes' : 'No'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+          {activeTab === 'Impact' && (
+            <table className="min-w-full border border-[var(--mxc-border)]">
+              <thead className="bg-[var(--mxc-nav-bg)] text-left">
+                <tr>
+                  <th className="px-4 py-2">Metric</th>
+                  <th className="px-4 py-2">Before</th>
+                  <th className="px-4 py-2">After</th>
+                  <th className="px-4 py-2">Δ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {impact.map((i) => (
+                  <tr key={i.metric}>
+                    <td className="px-4 py-2">{i.metric}</td>
+                    <td className="px-4 py-2">{i.before}</td>
+                    <td className="px-4 py-2">{i.after}</td>
+                    <td className="px-4 py-2">{i.delta}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
         <aside className="w-64 shrink-0 border-l border-[var(--mxc-border)] bg-[var(--mxc-drawer-bg)] p-4 text-[var(--mxc-drawer-fg)]">
           Warnings placeholder

--- a/apps/maximo-extension-ui/src/app/portfolio/page.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import KpiCards, { KpiItem } from '../../components/KpiCards';
+import { WorkOrderSummary } from '../../types/api';
 
 const kpis: KpiItem[] = [
   { label: 'Blueprints', value: 3 },
@@ -9,10 +10,25 @@ const kpis: KpiItem[] = [
   { label: 'Completed', value: 1 }
 ];
 
-const blueprints = [
-  { name: 'Pump replacement', status: 'Active', owner: 'Jane' },
-  { name: 'Motor upgrade', status: 'Draft', owner: 'John' },
-  { name: 'Energy audit', status: 'Completed', owner: 'Ben' }
+const workOrders: WorkOrderSummary[] = [
+  {
+    id: 'WO-1',
+    description: 'Pump replacement',
+    status: 'Active',
+    owner: 'Jane'
+  },
+  {
+    id: 'WO-2',
+    description: 'Motor upgrade',
+    status: 'Draft',
+    owner: 'John'
+  },
+  {
+    id: 'WO-3',
+    description: 'Energy audit',
+    status: 'Completed',
+    owner: 'Ben'
+  }
 ];
 
 export default function PortfolioPage() {
@@ -35,17 +51,17 @@ export default function PortfolioPage() {
       <table className="min-w-full border border-[var(--mxc-border)]">
         <thead className="bg-[var(--mxc-nav-bg)] text-left">
           <tr>
-            <th className="px-4 py-2">Name</th>
+            <th className="px-4 py-2">Description</th>
             <th className="px-4 py-2">Status</th>
             <th className="px-4 py-2">Owner</th>
           </tr>
         </thead>
         <tbody>
-          {blueprints.map((bp) => (
-            <tr key={bp.name} className={dense ? 'text-sm' : undefined}>
-              <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{bp.name}</td>
-              <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{bp.status}</td>
-              <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{bp.owner}</td>
+          {workOrders.map((wo) => (
+            <tr key={wo.id} className={dense ? 'text-sm' : undefined}>
+              <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.description}</td>
+              <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.status}</td>
+              <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.owner}</td>
             </tr>
           ))}
         </tbody>

--- a/apps/maximo-extension-ui/src/components/MaterialsPanel.tsx
+++ b/apps/maximo-extension-ui/src/components/MaterialsPanel.tsx
@@ -1,20 +1,11 @@
 import React from 'react';
-
-export type MaterialStatus = 'ready' | 'short' | 'ordered';
-
-export interface MaterialItem {
-  item: string;
-  required: number;
-  onHand: number;
-  eta?: string;
-  status: MaterialStatus;
-}
+import { InventoryItem, InventoryStatus } from '../types/api';
 
 interface MaterialsPanelProps {
-  items: MaterialItem[];
+  items: InventoryItem[];
 }
 
-const statusStyles: Record<MaterialStatus, { icon: string; label: string; color: string }> = {
+const statusStyles: Record<InventoryStatus, { icon: string; label: string; color: string }> = {
   ready: { icon: '✓', label: 'Ready', color: 'text-green-600' },
   short: { icon: '⚠️', label: 'Short', color: 'text-red-600' },
   ordered: { icon: '⏳', label: 'Ordered', color: 'text-blue-600' }

--- a/apps/maximo-extension-ui/src/stories/MaterialsPanel.stories.tsx
+++ b/apps/maximo-extension-ui/src/stories/MaterialsPanel.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import MaterialsPanel, { MaterialItem } from '../components/MaterialsPanel';
+import MaterialsPanel from '../components/MaterialsPanel';
+import { InventoryItem } from '../types/api';
 
 const meta: Meta<typeof MaterialsPanel> = {
   title: 'Components/MaterialsPanel',
@@ -11,7 +12,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const baseItem: Omit<MaterialItem, 'status'> = {
+const baseItem: Omit<InventoryItem, 'status'> = {
   item: 'Widget',
   required: 5,
   onHand: 5,

--- a/apps/maximo-extension-ui/src/types/api.ts
+++ b/apps/maximo-extension-ui/src/types/api.ts
@@ -1,0 +1,39 @@
+export interface WorkOrderSummary {
+  id: string;
+  description: string;
+  status: string;
+  owner?: string;
+  plannedStart?: string;
+  plannedFinish?: string;
+}
+
+export interface PlanStep {
+  step: number;
+  description: string;
+  resources: string;
+}
+
+export interface SimulationResult {
+  id: number;
+  deltaTime: string;
+  deltaCost: string;
+  readiness: string;
+  isolation: boolean;
+}
+
+export interface ImpactRecord {
+  metric: string;
+  before: number;
+  after: number;
+  delta: number;
+}
+
+export type InventoryStatus = 'ready' | 'short' | 'ordered';
+
+export interface InventoryItem {
+  item: string;
+  required: number;
+  onHand: number;
+  eta?: string;
+  status: InventoryStatus;
+}


### PR DESCRIPTION
## Summary
- define TypeScript interfaces for work orders, plans, simulations, impacts, and inventory
- update UI components to consume the new data contracts

## Testing
- `pnpm -F maximo-extension-ui test`
- `pnpm -F maximo-extension-ui build`


------
https://chatgpt.com/codex/tasks/task_b_68a2c58907d08322aeae1f07aa8210ad