### PR TITLE
refactor portfolio page to fetch mock data

### DIFF
--- a/apps/maximo-extension-ui/src/app/portfolio/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.test.tsx
@@ -1,0 +1,8 @@
+import { render, waitFor } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import Page from './page';
+
+test('renders blueprint rows from mock', async () => {
+  const { getAllByRole } = render(<Page />);
+  await waitFor(() => expect(getAllByRole('row')).toHaveLength(4));
+});

--- a/apps/maximo-extension-ui/src/app/portfolio/page.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.tsx
@@ -1,27 +1,33 @@
 'use client';
 
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import KpiCards, { KpiItem } from '../../components/KpiCards';
+import KpiCards from '../../components/KpiCards';
+import { fetchPortfolio, PortfolioData } from '../../mocks/portfolio';
 
-const kpis: KpiItem[] = [
-  { label: 'Blueprints', value: 3 },
-  { label: 'Active', value: 2 },
-  { label: 'Completed', value: 1 }
-];
-
-const blueprints = [
-  { name: 'Pump replacement', status: 'Active', owner: 'Jane' },
-  { name: 'Motor upgrade', status: 'Draft', owner: 'John' },
-  { name: 'Energy audit', status: 'Completed', owner: 'Ben' }
-];
+const queryClient = new QueryClient();
 
 export default function PortfolioPage() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Content />
+    </QueryClientProvider>
+  );
+}
+
+function Content() {
   const [dense, setDense] = useState(false);
+  const { data } = useQuery<PortfolioData>({
+    queryKey: ['portfolio'],
+    queryFn: fetchPortfolio
+  });
+
+  if (!data) return null;
 
   return (
     <main>
       <h1 className="mb-4 text-xl font-semibold">Portfolio</h1>
-      <KpiCards items={kpis} />
+      <KpiCards items={data.kpis} />
       <div className="mb-2 text-sm">
         <label className="inline-flex items-center gap-2">
           <input
@@ -41,7 +47,7 @@ export default function PortfolioPage() {
           </tr>
         </thead>
         <tbody>
-          {blueprints.map((bp) => (
+          {data.blueprints.map((bp) => (
             <tr key={bp.name} className={dense ? 'text-sm' : undefined}>
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{bp.name}</td>
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{bp.status}</td>

--- a/apps/maximo-extension-ui/src/mocks/portfolio.ts
+++ b/apps/maximo-extension-ui/src/mocks/portfolio.ts
@@ -1,0 +1,27 @@
+import { KpiItem } from '../components/KpiCards';
+
+export interface Blueprint {
+  name: string;
+  status: string;
+  owner: string;
+}
+
+export interface PortfolioData {
+  kpis: KpiItem[];
+  blueprints: Blueprint[];
+}
+
+export async function fetchPortfolio(): Promise<PortfolioData> {
+  return {
+    kpis: [
+      { label: 'Blueprints', value: 3 },
+      { label: 'Active', value: 2 },
+      { label: 'Completed', value: 1 }
+    ],
+    blueprints: [
+      { name: 'Pump replacement', status: 'Active', owner: 'Jane' },
+      { name: 'Motor upgrade', status: 'Draft', owner: 'John' },
+      { name: 'Energy audit', status: 'Completed', owner: 'Ben' }
+    ]
+  };
+}


### PR DESCRIPTION
## Summary
- replace static portfolio data with React Query fetch
- add local mock data provider
- test portfolio table row rendering

## Testing
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a2c5a3e6808322af28d65667a5f402