### PR TITLE
feat: add compatibility shim for integrations

### DIFF
--- a/loto/integrations.py
+++ b/loto/integrations.py
@@ -1,0 +1,3 @@
+"""Backward-compatibility shim for moved integrations package."""
+
+from .integrations import *  # type: ignore  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add backward-compatibility shim that re-exports symbols from new `loto.integrations` package

## Testing
- `pre-commit run --files loto/integrations.py`
- `python -m mypy loto`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a2c56df5c88322935c9ed26bdb4747