### PR TITLE
feat(portfolio): mock fetch for portfolio data

### DIFF
--- a/apps/maximo-extension-ui/src/app/portfolio/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen, within } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import Page from './page';
+
+test('renders work orders from mock fetch', async () => {
+  render(<Page />);
+  await screen.findByText('Pump replacement');
+  const [, tbody] = screen.getAllByRole('rowgroup');
+  const rows = within(tbody).getAllByRole('row');
+  expect(rows).toHaveLength(3);
+});

--- a/apps/maximo-extension-ui/src/app/portfolio/page.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.tsx
@@ -1,43 +1,22 @@
 'use client';
 
 import { useState } from 'react';
-import KpiCards, { KpiItem } from '../../components/KpiCards';
-import { WorkOrderSummary } from '../../types/api';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import KpiCards from '../../components/KpiCards';
+import { fetchPortfolio } from '../../mocks/portfolio';
 
-const kpis: KpiItem[] = [
-  { label: 'Blueprints', value: 3 },
-  { label: 'Active', value: 2 },
-  { label: 'Completed', value: 1 }
-];
+const queryClient = new QueryClient();
 
-const workOrders: WorkOrderSummary[] = [
-  {
-    id: 'WO-1',
-    description: 'Pump replacement',
-    status: 'Active',
-    owner: 'Jane'
-  },
-  {
-    id: 'WO-2',
-    description: 'Motor upgrade',
-    status: 'Draft',
-    owner: 'John'
-  },
-  {
-    id: 'WO-3',
-    description: 'Energy audit',
-    status: 'Completed',
-    owner: 'Ben'
-  }
-];
-
-export default function PortfolioPage() {
+function PortfolioContent() {
   const [dense, setDense] = useState(false);
+  const { data } = useQuery({ queryKey: ['portfolio'], queryFn: fetchPortfolio });
+
+  if (!data) return null;
 
   return (
     <main>
       <h1 className="mb-4 text-xl font-semibold">Portfolio</h1>
-      <KpiCards items={kpis} />
+      <KpiCards items={data.kpis} />
       <div className="mb-2 text-sm">
         <label className="inline-flex items-center gap-2">
           <input
@@ -57,7 +36,7 @@ export default function PortfolioPage() {
           </tr>
         </thead>
         <tbody>
-          {workOrders.map((wo) => (
+          {data.workOrders.map((wo) => (
             <tr key={wo.id} className={dense ? 'text-sm' : undefined}>
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.description}</td>
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.status}</td>
@@ -67,6 +46,14 @@ export default function PortfolioPage() {
         </tbody>
       </table>
     </main>
+  );
+}
+
+export default function PortfolioPage() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <PortfolioContent />
+    </QueryClientProvider>
   );
 }
 

--- a/apps/maximo-extension-ui/src/mocks/portfolio.ts
+++ b/apps/maximo-extension-ui/src/mocks/portfolio.ts
@@ -1,0 +1,37 @@
+import { KpiItem } from '../components/KpiCards';
+import { WorkOrderSummary } from '../types/api';
+
+export interface PortfolioData {
+  kpis: KpiItem[];
+  workOrders: WorkOrderSummary[];
+}
+
+export async function fetchPortfolio(): Promise<PortfolioData> {
+  return {
+    kpis: [
+      { label: 'Blueprints', value: 3 },
+      { label: 'Active', value: 2 },
+      { label: 'Completed', value: 1 }
+    ],
+    workOrders: [
+      {
+        id: 'WO-1',
+        description: 'Pump replacement',
+        status: 'Active',
+        owner: 'Jane'
+      },
+      {
+        id: 'WO-2',
+        description: 'Motor upgrade',
+        status: 'Draft',
+        owner: 'John'
+      },
+      {
+        id: 'WO-3',
+        description: 'Energy audit',
+        status: 'Completed',
+        owner: 'Ben'
+      }
+    ]
+  };
+}


### PR DESCRIPTION
## Summary
- fetch portfolio kpis and work orders via React Query
- add local mock provider for portfolio data
- verify portfolio page renders 3 work order rows

## Testing
- `pnpm --filter maximo-extension-ui test`

------
https://chatgpt.com/codex/tasks/task_b_68a2cb7714b88322964565f51521db12