### PR TITLE
Add CSV price curve loader for scheduling

### DIFF
--- a/loto/scheduling/price_input.py
+++ b/loto/scheduling/price_input.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+import csv
+from datetime import datetime
+
+Point = Tuple[float, float]
+
+
+def load_price_curve(path: str | Path) -> List[Point]:
+    """Return price curve from ``path`` as ``(hour, price)`` pairs.
+
+    The CSV at ``path`` is expected to contain two columns: a timestamp and
+    a price value denominated in $/MWh.  Timestamps are parsed using
+    :func:`datetime.fromisoformat` and converted into hours relative to the
+    first entry.
+    """
+
+    path = Path(path)
+    rows: List[Tuple[datetime, float]] = []
+    with path.open(newline="") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) < 2:
+                continue
+            ts_str, price_str = row[0], row[1]
+            try:
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                price = float(price_str)
+            except ValueError:
+                # Skip header or malformed lines
+                continue
+            rows.append((ts, price))
+
+    if not rows:
+        return []
+
+    rows.sort(key=lambda x: x[0])
+    t0 = rows[0][0]
+    curve: List[Point] = [
+        ((ts - t0).total_seconds() / 3600.0, price) for ts, price in rows
+    ]
+    return curve

--- a/tests/scheduling/test_price_input.py
+++ b/tests/scheduling/test_price_input.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+from loto.scheduling.price_input import load_price_curve
+from loto.scheduling.objective import integrate_cost
+
+
+def test_csv_loader_produces_expected_cost(tmp_path: Path) -> None:
+    csv_path = tmp_path / "price.csv"
+    csv_path.write_text(
+        "timestamp,price\n"
+        "2024-01-01T00:00:00,10\n"
+        "2024-01-01T01:00:00,20\n"
+        "2024-01-01T02:00:00,30\n"
+    )
+
+    price_curve = load_price_curve(csv_path)
+    # constant 1 MW power over two hours
+    power_curve = [(0.0, 1.0), (2.0, 1.0)]
+
+    assert price_curve == [(0.0, 10.0), (1.0, 20.0), (2.0, 30.0)]
+    cost = integrate_cost(power_curve, price_curve)
+    assert cost == pytest.approx(40.0)


### PR DESCRIPTION
## Summary
- add `load_price_curve` to parse timestamp and price CSV into hour-based curve
- test that loaded curve integrates to expected cost

## Testing
- `pytest tests/scheduling/test_price_input.py -q`
- `pytest tests/scheduling/test_objective_price.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a2cd86c1e88322bf746bba6a25074f