### PR TITLE
Add hat roster CSV parser and calendar adapter

### DIFF
--- a/loto/scheduling/roster_input.py
+++ b/loto/scheduling/roster_input.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+"""Utilities for reading hat availability rosters.
+
+This module parses a simple CSV describing when a particular hat (resource) is
+available to work.  Each row in the CSV describes a shift:
+
+```
+hat,start,stop,breaks,ot
+crew,5,10,"7-8",false
+```
+
+`start` and `stop` are integer time units where the hat is available.  The
+optional ``breaks`` column may contain one or more ``start-stop`` pairs separated
+by semicolons.  Break periods are removed from the availability windows.
+
+The primary entry points are :func:`read_hat_roster` which returns availability
+windows for each hat and :func:`calendar_adapter` which converts those windows
+into a predicate suitable for :class:`des_engine.Task`'s ``calendar`` field.
+"""
+
+from collections import defaultdict
+import csv
+from typing import Callable, Iterable, Mapping, Sequence
+
+
+Interval = tuple[int, int]
+
+
+def _parse_breaks(spec: str | None) -> list[Interval]:
+    """Parse a ``breaks`` specification into intervals.
+
+    ``spec`` should contain semicolon separated ``start-stop`` pairs.
+    Empty or ``None`` values return an empty list.
+    """
+
+    if not spec:
+        return []
+    breaks: list[Interval] = []
+    for part in spec.split(";"):
+        part = part.strip()
+        if not part:
+            continue
+        start_s, stop_s = part.split("-")
+        breaks.append((int(start_s), int(stop_s)))
+    return breaks
+
+
+def _subtract_breaks(interval: Interval, breaks: Sequence[Interval]) -> list[Interval]:
+    """Remove ``breaks`` from ``interval`` returning availability windows."""
+
+    start, stop = interval
+    result: list[Interval] = []
+    cursor = start
+    for bstart, bstop in sorted(breaks):
+        if bstop <= cursor or bstart >= stop:
+            continue
+        if bstart > cursor:
+            result.append((cursor, bstart))
+        cursor = max(cursor, bstop)
+    if cursor < stop:
+        result.append((cursor, stop))
+    return result
+
+
+def read_hat_roster(path: str) -> dict[str, list[Interval]]:
+    """Read a hat availability CSV.
+
+    Parameters
+    ----------
+    path:
+        File path to CSV containing columns ``hat``, ``start``, ``stop`` and
+        optional ``breaks`` and ``ot``.  ``start``/``stop`` are interpreted as
+        integer time units.
+    """
+
+    availability: dict[str, list[Interval]] = defaultdict(list)
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            hat = row["hat"]
+            start = int(row["start"])
+            stop = int(row["stop"])
+            breaks = _parse_breaks(row.get("breaks"))
+            windows = _subtract_breaks((start, stop), breaks)
+            availability[hat].extend(windows)
+    return dict(availability)
+
+
+def resource_caps_timeline(
+    roster: Mapping[str, Iterable[Interval]],
+) -> dict[int, dict[str, int]]:
+    """Construct a time-indexed resource capacity timeline.
+
+    The returned mapping associates each integer time with a mapping of hat name
+    to the number of available workers wearing that hat.
+    """
+
+    timeline: dict[int, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for hat, intervals in roster.items():
+        for start, stop in intervals:
+            for t in range(start, stop):
+                timeline[t][hat] = timeline[t].get(hat, 0) + 1
+    # convert nested defaultdicts to normal dicts
+    return {t: dict(caps) for t, caps in timeline.items()}
+
+
+def calendar_adapter(intervals: Iterable[Interval]) -> Callable[[int], bool]:
+    """Return a ``Task.calendar`` predicate for the given intervals."""
+
+    windows = list(intervals)
+
+    def _calendar(t: int) -> bool:
+        for start, stop in windows:
+            if start <= t < stop:
+                return True
+        return False
+
+    return _calendar

--- a/tests/scheduling/test_roster_input.py
+++ b/tests/scheduling/test_roster_input.py
@@ -1,0 +1,21 @@
+from loto.scheduling import roster_input
+from loto.scheduling.des_engine import Task, run
+
+
+def test_calendar_respects_shift(tmp_path):
+    csv_path = tmp_path / "hats.csv"
+    csv_path.write_text("hat,start,stop,breaks,ot\ncrew,5,10,,false\n")
+
+    roster = roster_input.read_hat_roster(csv_path)
+    cal = roster_input.calendar_adapter(roster["crew"])
+
+    # closes outside the shift
+    assert not cal(4)
+    assert cal(5)
+    assert cal(9)
+    assert not cal(10)
+
+    tasks = {"a": Task(duration=2, calendar=cal)}
+    result = run(tasks, {})
+    assert result.starts == {"a": 5}
+    assert result.ends == {"a": 7}


### PR DESCRIPTION
## Summary
- add utilities to load hat availability from CSV and build resource timelines
- provide calendar adapter for use with des_engine Task
- test that generated calendar permits work only during defined shifts

## Testing
- `pytest tests/scheduling/test_roster_input.py::test_calendar_respects_shift -q`

------
https://chatgpt.com/codex/tasks/task_b_68a2cd992ee48322804b0660569e1a52