### PR TITLE
Add scheduler controls component with local state

### DIFF
--- a/apps/maximo-extension-ui/src/components/SchedulerControls.test.tsx
+++ b/apps/maximo-extension-ui/src/components/SchedulerControls.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import SchedulerControls from './SchedulerControls';
+
+test('changing α updates displayed value', () => {
+  render(<SchedulerControls />);
+  const alphaInput = screen.getByLabelText('α (spot exposure)');
+  fireEvent.change(alphaInput, { target: { value: '0.75' } });
+  expect(screen.getByTestId('alpha-display')).toHaveTextContent('0.75');
+});

--- a/apps/maximo-extension-ui/src/components/SchedulerControls.tsx
+++ b/apps/maximo-extension-ui/src/components/SchedulerControls.tsx
@@ -1,0 +1,82 @@
+'use client';
+import React, { useState } from 'react';
+
+export default function SchedulerControls() {
+  const [objective, setObjective] = useState('speed');
+  const [alpha, setAlpha] = useState(0.5);
+  const [riskTarget, setRiskTarget] = useState(0.1);
+  const [samples, setSamples] = useState(100);
+  const [seed, setSeed] = useState(0);
+
+  return (
+    <form className="space-y-4">
+      <div>
+        <label htmlFor="objective" className="mr-2">
+          Objective
+        </label>
+        <select
+          id="objective"
+          value={objective}
+          onChange={(e) => setObjective(e.target.value)}
+          className="border px-2 py-1"
+        >
+          <option value="speed">Speed</option>
+          <option value="cost">Cost</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="alpha" className="mr-2">
+          α (spot exposure)
+        </label>
+        <input
+          id="alpha"
+          type="number"
+          step="0.01"
+          value={alpha}
+          onChange={(e) => setAlpha(parseFloat(e.target.value))}
+          className="border px-2 py-1"
+        />
+        <span data-testid="alpha-display" className="ml-2">
+          {alpha}
+        </span>
+      </div>
+      <div>
+        <label htmlFor="riskTarget" className="mr-2">
+          Risk target
+        </label>
+        <input
+          id="riskTarget"
+          type="number"
+          step="0.01"
+          value={riskTarget}
+          onChange={(e) => setRiskTarget(parseFloat(e.target.value))}
+          className="border px-2 py-1"
+        />
+      </div>
+      <div>
+        <label htmlFor="samples" className="mr-2">
+          N samples
+        </label>
+        <input
+          id="samples"
+          type="number"
+          value={samples}
+          onChange={(e) => setSamples(parseInt(e.target.value, 10))}
+          className="border px-2 py-1"
+        />
+      </div>
+      <div>
+        <label htmlFor="seed" className="mr-2">
+          Seed
+        </label>
+        <input
+          id="seed"
+          type="number"
+          value={seed}
+          onChange={(e) => setSeed(parseInt(e.target.value, 10))}
+          className="border px-2 py-1"
+        />
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add SchedulerControls component with local state for objective, alpha, risk target, samples, and seed
- test alpha input updates displayed value

## Testing
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a2cdae52f88322af49bef7c854c7a3