### PR TITLE
feat: add conflicts list mock

### DIFF
--- a/apps/maximo-extension-ui/src/components/ConflictsList.test.tsx
+++ b/apps/maximo-extension-ui/src/components/ConflictsList.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import ConflictsList from './ConflictsList';
+
+test('click sets recommended items', async () => {
+  const candidates = [
+    { id: '1', label: 'Candidate 1', explanation: 'First option' },
+    { id: '2', label: 'Candidate 2', explanation: 'Second option' },
+    { id: '3', label: 'Candidate 3', explanation: 'Third option' }
+  ];
+  const { container } = render(<ConflictsList candidates={candidates} />);
+  fireEvent.click(screen.getByText('Select recommended set'));
+  await waitFor(() => {
+    expect(screen.getByLabelText('Candidate 1')).toBeChecked();
+    expect(screen.getByLabelText('Candidate 3')).toBeChecked();
+  });
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/apps/maximo-extension-ui/src/components/ConflictsList.tsx
+++ b/apps/maximo-extension-ui/src/components/ConflictsList.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { fetchRecommendedSet } from '../mocks/bundling';
+
+interface Candidate {
+  id: string;
+  label: string;
+  explanation: string;
+}
+
+interface ConflictsListProps {
+  candidates: Candidate[];
+}
+
+export default function ConflictsList({ candidates }: ConflictsListProps) {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const handleRecommend = async () => {
+    const rec = await fetchRecommendedSet();
+    setSelected(rec);
+  };
+
+  return (
+    <div>
+      <ul>
+        {candidates.map(({ id, label, explanation }) => (
+          <li key={id} className="mb-2">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={selected.includes(id)}
+                onChange={() => toggle(id)}
+                aria-label={label}
+              />
+              <span>{label}</span>
+            </label>
+            <p className="ml-6 text-sm text-gray-600">{explanation}</p>
+          </li>
+        ))}
+      </ul>
+      <button onClick={handleRecommend}>Select recommended set</button>
+    </div>
+  );
+}

--- a/apps/maximo-extension-ui/src/components/__snapshots__/ConflictsList.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/components/__snapshots__/ConflictsList.test.tsx.snap
@@ -1,0 +1,71 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`click sets recommended items 1`] = `
+<div>
+  <ul>
+    <li
+      class="mb-2"
+    >
+      <label
+        class="flex items-center gap-2"
+      >
+        <input
+          aria-label="Candidate 1"
+          type="checkbox"
+        />
+        <span>
+          Candidate 1
+        </span>
+      </label>
+      <p
+        class="ml-6 text-sm text-gray-600"
+      >
+        First option
+      </p>
+    </li>
+    <li
+      class="mb-2"
+    >
+      <label
+        class="flex items-center gap-2"
+      >
+        <input
+          aria-label="Candidate 2"
+          type="checkbox"
+        />
+        <span>
+          Candidate 2
+        </span>
+      </label>
+      <p
+        class="ml-6 text-sm text-gray-600"
+      >
+        Second option
+      </p>
+    </li>
+    <li
+      class="mb-2"
+    >
+      <label
+        class="flex items-center gap-2"
+      >
+        <input
+          aria-label="Candidate 3"
+          type="checkbox"
+        />
+        <span>
+          Candidate 3
+        </span>
+      </label>
+      <p
+        class="ml-6 text-sm text-gray-600"
+      >
+        Third option
+      </p>
+    </li>
+  </ul>
+  <button>
+    Select recommended set
+  </button>
+</div>
+`;

--- a/apps/maximo-extension-ui/src/mocks/bundling.ts
+++ b/apps/maximo-extension-ui/src/mocks/bundling.ts
@@ -1,0 +1,3 @@
+export async function fetchRecommendedSet(): Promise<string[]> {
+  return ['1', '3'];
+}


### PR DESCRIPTION
## Summary
- add ConflictsList component rendering candidates and recommended set button
- introduce bundling mock to return recommended candidate ids
- test selecting recommended set and snapshot

## Testing
- `pnpm test -- -u`


------
https://chatgpt.com/codex/tasks/task_b_68a2d16d8a208322b6e81da176ade7f3