### PR TITLE
Add bundling support to JSON renderer

### DIFF
--- a/loto/renderer.py
+++ b/loto/renderer.py
@@ -123,6 +123,8 @@ class Renderer:
         plan: IsolationPlan,
         sim_report: SimReport,
         impact: Mapping[str, Any] | None = None,
+        bundling_picks: list[str] | None = None,
+        bundling_params: Mapping[str, Any] | None = None,
     ) -> Dict[str, Any]:
         """Serialize the plan and simulation report to a JSON-friendly dict.
 
@@ -135,6 +137,12 @@ class Renderer:
         impact: Mapping[str, Any] | None
             Optional impact information (e.g., unavailable assets, unit
             derates) to include in the JSON output.
+        bundling_picks: list[str] | None
+            Optional list of bundle pick identifiers. The list is sorted to
+            ensure deterministic output.
+        bundling_params: Mapping[str, Any] | None
+            Optional bundle parameters. Keys are recursively sorted for
+            deterministic output.
 
         Returns
         -------
@@ -168,5 +176,13 @@ class Renderer:
 
         if impact:
             payload["impact"] = _sorted_dict(dict(impact))
+
+        if bundling_picks or bundling_params:
+            bundle_payload: Dict[str, Any] = {}
+            if bundling_picks:
+                bundle_payload["picks"] = sorted(bundling_picks)
+            if bundling_params:
+                bundle_payload["params"] = _sorted_dict(dict(bundling_params))
+            payload["bundling"] = bundle_payload
 
         return payload

--- a/loto/templates/pack.md
+++ b/loto/templates/pack.md
@@ -1,0 +1,3 @@
+# Isolation Pack
+
+Deterministic stub template for future WeasyPrint rendering.

--- a/tests/test_renderer_json.py
+++ b/tests/test_renderer_json.py
@@ -22,3 +22,29 @@ def test_to_json_round_trip_and_optional_impact():
     rt_impact = json.loads(json.dumps(impact_payload))
     assert list(rt_impact.keys()) == ["plan", "simulation", "impact"]
     assert list(rt_impact["impact"].keys()) == ["a", "b"]
+
+
+def test_to_json_with_bundling():
+    plan = IsolationPlan(plan_id="p", actions=[])
+    sim_report = SimReport(results=[], total_time_s=0.0)
+    renderer = Renderer()
+
+    bundling = {
+        "picks": ["b", "a"],
+        "params": {"y": 2, "x": 1},
+    }
+
+    payload = renderer.to_json(
+        plan,
+        sim_report,
+        bundling_picks=bundling["picks"],
+        bundling_params=bundling["params"],
+    )
+
+    assert list(payload.keys()) == ["plan", "simulation", "bundling"]
+    assert payload["bundling"]["picks"] == ["a", "b"]
+    assert list(payload["bundling"]["params"].keys()) == ["x", "y"]
+
+    rt_payload = json.loads(json.dumps(payload))
+    assert rt_payload["bundling"]["picks"] == ["a", "b"]
+    assert list(rt_payload["bundling"]["params"].keys()) == ["x", "y"]


### PR DESCRIPTION
## Summary
- include optional bundling picks and params in `Renderer.to_json`
- add deterministic `pack.md` template stub for future PDF generation
- test JSON bundling output

## Testing
- `pre-commit run --files loto/renderer.py tests/test_renderer_json.py loto/templates/pack.md`
- `pytest tests/test_renderer_json.py`

------
https://chatgpt.com/codex/tasks/task_b_68a2d1831e508322ac5ccbf10e7c87c7