### PR TITLE
Add demo WAPR adapter for permit data

### DIFF
--- a/loto/integrations/__init__.py
+++ b/loto/integrations/__init__.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from .coupa_adapter import CoupaAdapter, DemoCoupaAdapter
 from .stores_adapter import StoresAdapter, DemoStoresAdapter
+from .wapr_adapter import WaprAdapter, DemoWaprAdapter
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from ..isolation_planner import IsolationPlan
@@ -107,4 +108,6 @@ __all__ = [
     "DemoCoupaAdapter",
     "StoresAdapter",
     "DemoStoresAdapter",
+    "WaprAdapter",
+    "DemoWaprAdapter",
 ]

--- a/loto/integrations/wapr_adapter.py
+++ b/loto/integrations/wapr_adapter.py
@@ -1,0 +1,43 @@
+"""WAPR permit-to-work adapter stubs.
+
+This module defines an abstract interface for retrieving permit data from
+WAPR and a demo implementation that serves fixture data for testing and
+dry-run scenarios.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Any, Dict, List
+
+
+class WaprAdapter(abc.ABC):
+    """Abstract interface for WAPR interactions."""
+
+    @abc.abstractmethod
+    def fetch_permit(self, work_order_id: str) -> Dict[str, Any]:
+        """Fetch permit data for a work order.
+
+        Parameters
+        ----------
+        work_order_id:
+            Identifier of the work order whose permit is requested.
+
+        Returns
+        -------
+        Dict[str, Any]
+            A dictionary of permit details including applied isolations.
+        """
+
+
+class DemoWaprAdapter(WaprAdapter):
+    """Dry-run WAPR adapter that returns fixture permit data."""
+
+    _FIXTURE_PERMITS: Dict[str, Dict[str, List[str]]] = {
+        "WO-100": {"applied_isolations": ["ISO-1", "ISO-2"]},
+        "WO-200": {"applied_isolations": ["ISO-3"]},
+    }
+
+    def fetch_permit(self, work_order_id: str) -> Dict[str, Any]:
+        """Return fixture permit data for the given work order."""
+        return self._FIXTURE_PERMITS.get(work_order_id, {"applied_isolations": []})

--- a/tests/test_integrations_adapters.py
+++ b/tests/test_integrations_adapters.py
@@ -2,6 +2,7 @@
 
 from loto.integrations.coupa_adapter import DemoCoupaAdapter
 from loto.integrations.stores_adapter import DemoStoresAdapter
+from loto.integrations.wapr_adapter import DemoWaprAdapter
 
 
 def test_coupa_demo_adapter_returns_rfq_id() -> None:
@@ -26,3 +27,10 @@ def test_stores_demo_adapter_returns_pick_list_id() -> None:
     else:
         pick_id = ""
     assert pick_id.startswith("PL-")
+
+
+def test_wapr_demo_adapter_returns_fixture_permit() -> None:
+    """Ensure fixture permit data is returned for a work order."""
+    adapter = DemoWaprAdapter()
+    permit = adapter.fetch_permit("WO-100")
+    assert permit == {"applied_isolations": ["ISO-1", "ISO-2"]}


### PR DESCRIPTION
## Summary
- implement read-only WAPR adapter with demo permit fixtures
- expose WAPR adapter via integration package
- test WAPR adapter returns applied isolations for work orders

## Testing
- `pytest -q tests/test_integrations_adapters.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2d3c4587483229062c45465d52cf2