### PR TITLE
feat: add portfolio and work order hooks

### DIFF
--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
@@ -1,8 +1,9 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { test, expect } from 'vitest';
 import Page from './page';
 
-test('renders 4 tabs', () => {
-  const { getAllByRole } = render(<Page params={{ wo: 'WO-1' }} />);
-  expect(getAllByRole('tab')).toHaveLength(4);
+test('renders 4 tabs', async () => {
+  render(<Page params={{ wo: 'WO-1' }} />);
+  const tabs = await screen.findAllByRole('tab');
+  expect(tabs).toHaveLength(4);
 });

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -1,23 +1,19 @@
 'use client';
 
 import { useState } from 'react';
-import {
-  WorkOrderSummary,
-  PlanStep,
-  SimulationResult,
-  ImpactRecord
-} from '../../../types/api';
+import { PlanStep, SimulationResult, ImpactRecord } from '../../../types/api';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useWorkOrder } from '../../../lib/hooks';
 
 const tabs = ['Plan', 'P&ID', 'Simulation', 'Impact'];
 
-export default function PlannerPage({ params }: { params: { wo: string } }) {
-  const [activeTab, setActiveTab] = useState('Plan');
+const queryClient = new QueryClient();
 
-  const workOrder: WorkOrderSummary = {
-    id: params.wo,
-    description: 'Example work order',
-    status: 'WAPPR'
-  };
+function PlannerContent({ wo }: { wo: string }) {
+  const [activeTab, setActiveTab] = useState('Plan');
+  const { data: workOrder } = useWorkOrder(wo);
+
+  if (!workOrder) return null;
 
   const plan: PlanStep[] = [
     { step: 1, description: 'Example step', resources: 'None' }
@@ -128,6 +124,14 @@ export default function PlannerPage({ params }: { params: { wo: string } }) {
         </aside>
       </div>
     </main>
+  );
+}
+
+export default function PlannerPage({ params }: { params: { wo: string } }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <PlannerContent wo={params.wo} />
+    </QueryClientProvider>
   );
 }
 

--- a/apps/maximo-extension-ui/src/app/portfolio/page.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.tsx
@@ -1,15 +1,15 @@
 'use client';
 
 import { useState } from 'react';
-import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import KpiCards from '../../components/KpiCards';
-import { fetchPortfolio } from '../../mocks/portfolio';
+import { usePortfolio } from '../../lib/hooks';
 
 const queryClient = new QueryClient();
 
 function PortfolioContent() {
   const [dense, setDense] = useState(false);
-  const { data } = useQuery({ queryKey: ['portfolio'], queryFn: fetchPortfolio });
+  const { data } = usePortfolio();
 
   if (!data) return null;
 

--- a/apps/maximo-extension-ui/src/lib/hooks.test.tsx
+++ b/apps/maximo-extension-ui/src/lib/hooks.test.tsx
@@ -1,0 +1,27 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { test, expect } from 'vitest';
+import { usePortfolio, useWorkOrder } from './hooks';
+
+function createWrapper() {
+  const queryClient = new QueryClient();
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+test('usePortfolio returns mocked data', async () => {
+  const { result } = renderHook(() => usePortfolio(), { wrapper: createWrapper() });
+  expect(result.current.isLoading).toBe(true);
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  expect(result.current.data?.workOrders).toHaveLength(3);
+});
+
+test('useWorkOrder returns mocked data', async () => {
+  const { result } = renderHook(() => useWorkOrder('WO-1'), { wrapper: createWrapper() });
+  expect(result.current.isLoading).toBe(true);
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  expect(result.current.data?.id).toBe('WO-1');
+});
+

--- a/apps/maximo-extension-ui/src/lib/hooks.ts
+++ b/apps/maximo-extension-ui/src/lib/hooks.ts
@@ -1,0 +1,19 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { fetchPortfolio, type PortfolioData } from '../mocks/portfolio';
+import { fetchWorkOrder } from '../mocks/workorder';
+import type { WorkOrderSummary } from '../types/api';
+
+/**
+ * Query hook for portfolio data.
+ */
+export function usePortfolio(): UseQueryResult<PortfolioData> {
+  return useQuery({ queryKey: ['portfolio'], queryFn: fetchPortfolio });
+}
+
+/**
+ * Query hook for an individual work order.
+ * @param id Work order identifier
+ */
+export function useWorkOrder(id: string): UseQueryResult<WorkOrderSummary> {
+  return useQuery({ queryKey: ['workOrder', id], queryFn: () => fetchWorkOrder(id) });
+}

--- a/apps/maximo-extension-ui/src/mocks/workorder.ts
+++ b/apps/maximo-extension-ui/src/mocks/workorder.ts
@@ -1,0 +1,10 @@
+import { WorkOrderSummary } from '../types/api';
+
+export async function fetchWorkOrder(id: string): Promise<WorkOrderSummary> {
+  return {
+    id,
+    description: 'Example work order',
+    status: 'WAPPR'
+  };
+}
+


### PR DESCRIPTION
## Summary
- add React Query hooks for portfolio and work order data
- use hooks in portfolio and planner pages
- test hook loading and success states

## Testing
- `pnpm --filter maximo-extension-ui test`

------
https://chatgpt.com/codex/tasks/task_b_68a2d3d5a61c83228c1219b9b1103c45