### PR TITLE
feat(cli): add demo mode and PDF output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ test:
 	pytest
 
 run-demo:
-	python -m loto.cli --help
+	python -m loto.cli --demo

--- a/demo/drains.csv
+++ b/demo/drains.csv
@@ -1,0 +1,2 @@
+domain,tag,kind
+steam,DRAIN1,drain

--- a/demo/line_list.csv
+++ b/demo/line_list.csv
@@ -1,0 +1,3 @@
+domain,from_tag,to_tag,line_tag
+steam,source,VALVE1,L1
+steam,VALVE1,A,L2

--- a/demo/rules.yaml
+++ b/demo/rules.yaml
@@ -1,0 +1,2 @@
+domain_rules: []
+verification_rules: []

--- a/demo/sources.csv
+++ b/demo/sources.csv
@@ -1,0 +1,2 @@
+domain,tag,kind
+steam,source,boiler

--- a/demo/valves.csv
+++ b/demo/valves.csv
@@ -1,0 +1,2 @@
+domain,tag,fail_state,kind
+steam,VALVE1,FC,gate


### PR DESCRIPTION
## Summary
- add --demo flag to CLI with built-in sample data
- generate JSON and PDF outputs
- add sample CSV/YAML demo files and run-demo target

## Testing
- `pytest`
- `make run-demo`

------
https://chatgpt.com/codex/tasks/task_b_68a2d3e3db508322b6e777ff340099ef