### PR TITLE
Add procurement workflow to handle shortages

### DIFF
--- a/loto/workflows/__init__.py
+++ b/loto/workflows/__init__.py
@@ -1,0 +1,5 @@
+"""Workflow orchestrators for procurement operations."""
+
+from .procurement import procure_shortages
+
+__all__ = ["procure_shortages"]

--- a/loto/workflows/procurement.py
+++ b/loto/workflows/procurement.py
@@ -1,0 +1,73 @@
+"""Procurement workflow utilities."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from loto.integrations.coupa_adapter import CoupaAdapter, DemoCoupaAdapter
+from loto.integrations.stores_adapter import DemoStoresAdapter, StoresAdapter
+
+
+def procure_shortages(
+    shortages: Iterable[dict[str, int | str]],
+    coupa_adapter: CoupaAdapter | None = None,
+    stores_adapter: StoresAdapter | None = None,
+    dry_run: bool = False,
+) -> tuple[list[dict[str, str]], str]:
+    """Process shortages via Coupa or Stores adapters.
+
+    Parameters
+    ----------
+    shortages:
+        Iterable of shortage dictionaries with keys ``part_number``,
+        ``quantity`` and ``action``.  ``action`` must be either
+        ``"purchase"`` to raise an urgent enquiry or ``"issue`` to create a
+        pick list.
+    coupa_adapter:
+        Adapter used when raising urgent enquiries.  If ``None`` or ``dry_run``
+        is true, :class:`DemoCoupaAdapter` is used.
+    stores_adapter:
+        Adapter used when issuing pick lists.  If ``None`` or ``dry_run`` is
+        true, :class:`DemoStoresAdapter` is used.
+    dry_run:
+        When true, demo adapters are used and the returned status will be
+        ``"dry-run"``.
+
+    Returns
+    -------
+    tuple[list[dict[str, str]], str]
+        A tuple containing a list of action dictionaries and a status string.
+    """
+    if dry_run or coupa_adapter is None:
+        coupa_adapter = DemoCoupaAdapter()
+    if dry_run or stores_adapter is None:
+        stores_adapter = DemoStoresAdapter()
+
+    actions: list[dict[str, str]] = []
+    for item in shortages:
+        part_number = str(item["part_number"])
+        quantity = int(item["quantity"])
+        action_type = str(item.get("action", "purchase"))
+        idempotency_key = f"{action_type}:{part_number}:{quantity}"
+
+        if action_type == "purchase":
+            rfq_id = coupa_adapter.raise_urgent_enquiry(part_number, quantity)
+            actions.append(
+                {
+                    "action": "raise_urgent_enquiry",
+                    "id": rfq_id,
+                    "idempotency_key": idempotency_key,
+                }
+            )
+        else:
+            pick_id = stores_adapter.create_pick_list(part_number, quantity)
+            actions.append(
+                {
+                    "action": "create_pick_list",
+                    "id": pick_id,
+                    "idempotency_key": idempotency_key,
+                }
+            )
+
+    status = "dry-run" if dry_run else "completed"
+    return actions, status

--- a/tests/workflows/test_procurement.py
+++ b/tests/workflows/test_procurement.py
@@ -1,0 +1,26 @@
+"""Tests for the procurement workflow."""
+
+from loto.workflows.procurement import procure_shortages
+
+
+def test_procurement_branches_and_status() -> None:
+    """Ensure shortages route to the correct adapter."""
+    shortages: list[dict[str, int | str]] = [
+        {"part_number": "P-1", "quantity": 5, "action": "purchase"},
+        {"part_number": "P-2", "quantity": 3, "action": "issue"},
+    ]
+    actions, status = procure_shortages(shortages, dry_run=True)
+    assert actions[0]["action"] == "raise_urgent_enquiry"
+    assert actions[0]["id"].startswith("RFQ-")
+    assert actions[1]["action"] == "create_pick_list"
+    assert actions[1]["id"].startswith("PL-")
+    assert status == "dry-run"
+
+
+def test_procurement_idempotency_key() -> None:
+    """Verify idempotency key combines action, part and quantity."""
+    shortages: list[dict[str, int | str]] = [
+        {"part_number": "P-3", "quantity": 2, "action": "issue"}
+    ]
+    actions, _ = procure_shortages(shortages, dry_run=True)
+    assert actions[0]["idempotency_key"] == "issue:P-3:2"


### PR DESCRIPTION
## Summary
- add `procure_shortages` workflow to raise urgent enquiries or create pick lists
- expose procurement workflow package
- cover branching and idempotency key creation with tests

## Testing
- `pre-commit run --files loto/workflows/__init__.py loto/workflows/procurement.py tests/workflows/test_procurement.py`
- `pytest tests/workflows/test_procurement.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2d6190d388322aca5ff4a40854f31