### PR TITLE
feat: add materials workflow buttons

### DIFF
--- a/apps/maximo-extension-ui/src/components/ActionBar.tsx
+++ b/apps/maximo-extension-ui/src/components/ActionBar.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import Button from './Button';
+
+export default function ActionBar() {
+  const [rfqRaised, setRfqRaised] = useState(false);
+  const [pickListIssued, setPickListIssued] = useState(false);
+  const [parked, setParked] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const raiseRFQ = () => {
+    setRfqRaised(true);
+    setToast('RFQ raised');
+  };
+
+  const issuePickList = () => {
+    setPickListIssued(true);
+    setToast('Pick list issued');
+  };
+
+  const parkWo = () => {
+    setParked(true);
+    setToast('Work order parked');
+  };
+
+  const unparkWo = () => {
+    setParked(false);
+    setToast('Work order unparked');
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-2">
+        <Button aria-label="Raise RFQ" onClick={raiseRFQ} disabled={rfqRaised}>
+          Raise RFQ
+        </Button>
+        <Button aria-label="Issue pick list" onClick={issuePickList} disabled={pickListIssued}>
+          Issue pick list
+        </Button>
+        {!parked ? (
+          <Button aria-label="Park WO" onClick={parkWo}>
+            Park WO
+          </Button>
+        ) : (
+          <Button aria-label="Unpark" onClick={unparkWo}>
+            Unpark
+          </Button>
+        )}
+      </div>
+      {toast && (
+        <div role="status" aria-live="polite" className="text-sm">
+          {toast}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/components/MaterialsPanel.test.tsx
+++ b/apps/maximo-extension-ui/src/components/MaterialsPanel.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { test, expect, afterEach } from 'vitest';
+import MaterialsPanel from './MaterialsPanel';
+
+const items = [
+  { item: 'Widget', required: 1, onHand: 0, eta: 'tomorrow', status: 'short' as const }
+];
+
+afterEach(() => cleanup());
+
+test('renders workflow buttons with aria labels', () => {
+  render(<MaterialsPanel items={items} />);
+  expect(screen.getByLabelText('Raise RFQ')).toBeInTheDocument();
+  expect(screen.getByLabelText('Issue pick list')).toBeInTheDocument();
+  expect(screen.getByLabelText('Park WO')).toBeInTheDocument();
+});
+
+test('click flows update state and show toasts', () => {
+  render(<MaterialsPanel items={items} />);
+
+  const raiseBtn = screen.getByLabelText('Raise RFQ');
+  fireEvent.click(raiseBtn);
+  expect(screen.getByRole('status')).toHaveTextContent('RFQ raised');
+  expect(raiseBtn).toBeDisabled();
+
+  const pickListBtn = screen.getByLabelText('Issue pick list');
+  fireEvent.click(pickListBtn);
+  expect(screen.getByRole('status')).toHaveTextContent('Pick list issued');
+  expect(pickListBtn).toBeDisabled();
+
+  const parkBtn = screen.getByLabelText('Park WO');
+  fireEvent.click(parkBtn);
+  expect(screen.getByRole('status')).toHaveTextContent('Work order parked');
+  expect(screen.queryByLabelText('Park WO')).toBeNull();
+  const unparkBtn = screen.getByLabelText('Unpark');
+  fireEvent.click(unparkBtn);
+  expect(screen.getByRole('status')).toHaveTextContent('Work order unparked');
+  expect(screen.getByLabelText('Park WO')).toBeInTheDocument();
+});
+

--- a/apps/maximo-extension-ui/src/components/MaterialsPanel.tsx
+++ b/apps/maximo-extension-ui/src/components/MaterialsPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { InventoryItem, InventoryStatus } from '../types/api';
+import ActionBar from './ActionBar';
 
 interface MaterialsPanelProps {
   items: InventoryItem[];
@@ -13,47 +14,50 @@ const statusStyles: Record<InventoryStatus, { icon: string; label: string; color
 
 export default function MaterialsPanel({ items }: MaterialsPanelProps) {
   return (
-    <div className="overflow-hidden rounded-[var(--mxc-radius-md)] border border-[var(--mxc-border)]">
-      <table className="min-w-full divide-y divide-[var(--mxc-border)] text-sm">
-        <thead className="bg-[var(--mxc-bg)]">
-          <tr>
-            <th scope="col" className="px-4 py-2 text-left font-medium">
-              Item
-            </th>
-            <th scope="col" className="px-4 py-2 text-right font-medium">
-              Required
-            </th>
-            <th scope="col" className="px-4 py-2 text-right font-medium">
-              On-hand
-            </th>
-            <th scope="col" className="px-4 py-2 text-left font-medium">
-              ETA
-            </th>
-            <th scope="col" className="px-4 py-2 text-left font-medium">
-              Status
-            </th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-[var(--mxc-border)]">
-          {items.map(({ item, required, onHand, eta, status }) => {
-            const { icon, label, color } = statusStyles[status];
-            return (
-              <tr key={item} className="bg-[var(--mxc-bg)]">
-                <td className="px-4 py-2">{item}</td>
-                <td className="px-4 py-2 text-right">{required}</td>
-                <td className="px-4 py-2 text-right">{onHand}</td>
-                <td className="px-4 py-2">{eta ?? '—'}</td>
-                <td className="px-4 py-2">
-                  <span className={`flex items-center gap-1 font-medium ${color}`}>
-                    <span aria-hidden="true">{icon}</span>
-                    <span>{label}</span>
-                  </span>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+    <div className="flex flex-col gap-4">
+      <div className="overflow-hidden rounded-[var(--mxc-radius-md)] border border-[var(--mxc-border)]">
+        <table className="min-w-full divide-y divide-[var(--mxc-border)] text-sm">
+          <thead className="bg-[var(--mxc-bg)]">
+            <tr>
+              <th scope="col" className="px-4 py-2 text-left font-medium">
+                Item
+              </th>
+              <th scope="col" className="px-4 py-2 text-right font-medium">
+                Required
+              </th>
+              <th scope="col" className="px-4 py-2 text-right font-medium">
+                On-hand
+              </th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">
+                ETA
+              </th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[var(--mxc-border)]">
+            {items.map(({ item, required, onHand, eta, status }) => {
+              const { icon, label, color } = statusStyles[status];
+              return (
+                <tr key={item} className="bg-[var(--mxc-bg)]">
+                  <td className="px-4 py-2">{item}</td>
+                  <td className="px-4 py-2 text-right">{required}</td>
+                  <td className="px-4 py-2 text-right">{onHand}</td>
+                  <td className="px-4 py-2">{eta ?? '—'}</td>
+                  <td className="px-4 py-2">
+                    <span className={`flex items-center gap-1 font-medium ${color}`}>
+                      <span aria-hidden="true">{icon}</span>
+                      <span>{label}</span>
+                    </span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <ActionBar />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add ActionBar with Raise RFQ, Issue pick list, Park WO, and Unpark workflow actions
- show deterministic toast messages and toggle parked state
- test materials workflow buttons and aria labels

## Testing
- `pnpm --filter maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a2d628e6888322b5dd1fdee0ffb073