### PR TITLE
Add inventory gate for assembled tasks

### DIFF
--- a/loto/scheduling/assemble.py
+++ b/loto/scheduling/assemble.py
@@ -1,0 +1,62 @@
+"""Helpers for assembling schedulable tasks from a work order."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from ..inventory import InventoryStatus
+from ..models import IsolationPlan
+from . import gates
+from .des_engine import Task
+
+InventoryFn = Callable[[object], InventoryStatus]
+
+
+def from_work_order(
+    work_order: object,
+    plan: IsolationPlan,
+    check_parts: InventoryFn | None = None,
+) -> dict[str, Task]:
+    """Return schedulable tasks for ``work_order``.
+
+    Each :class:`~loto.models.IsolationAction` in ``plan`` becomes a sequential
+    :class:`Task`.  When ``check_parts`` is provided and indicates that parts
+    are missing, a :func:`gates.parts_available` predicate is attached to each
+    task so execution will wait for parts to arrive.
+
+    Parameters
+    ----------
+    work_order:
+        Object exposing an ``id`` attribute identifying the work order.
+    plan:
+        Isolation plan describing ordered actions.
+    check_parts:
+        Optional callable returning an :class:`~loto.inventory.InventoryStatus`
+        for ``work_order``.
+
+    Returns
+    -------
+    dict[str, Task]
+        Mapping of task identifier to :class:`Task`.
+    """
+
+    tasks: dict[str, Task] = {}
+    prev: str | None = None
+    for idx, action in enumerate(plan.actions):
+        tid = f"{plan.plan_id}-{idx}"
+        predecessors = [prev] if prev else []
+        dur = int(action.duration_s or 1)
+        tasks[tid] = Task(duration=dur, predecessors=predecessors)
+        prev = tid
+
+    if check_parts:
+        status = check_parts(work_order)
+        if status.blocked:
+            wo_id = getattr(work_order, "id", "")
+            gate = gates.parts_available(wo_id)
+            for task in tasks.values():
+                task.gate = (
+                    gate if task.gate is None else gates.compose_gates(task.gate, gate)
+                )
+
+    return tasks

--- a/tests/scheduling/test_assemble_parts_gate.py
+++ b/tests/scheduling/test_assemble_parts_gate.py
@@ -1,0 +1,38 @@
+from loto.inventory import InventoryStatus
+from loto.models import IsolationAction, IsolationPlan
+from loto.scheduling.assemble import from_work_order
+from loto.scheduling.des_engine import run
+
+
+class _WO:
+    def __init__(self, wo_id: str) -> None:
+        self.id = wo_id
+        self.reservations: list[object] = []
+
+
+def test_tasks_wait_for_inventory_gate():
+    wo = _WO("wo-1")
+    plan = IsolationPlan(
+        plan_id="p1",
+        actions=[IsolationAction(component_id="c", method="lock", duration_s=1)],
+    )
+
+    status = InventoryStatus(blocked=True)
+
+    def check_parts(_: object) -> InventoryStatus:
+        return status
+
+    tasks = from_work_order(wo, plan, check_parts)
+    assert tasks["p1-0"].gate is not None
+
+    state = {"parts": set()}
+    if check_parts(wo).ready:
+        state["parts"].add(wo.id)
+    result = run(tasks, {}, state)
+    assert "p1-0" not in result.starts
+
+    status.blocked = False
+    if check_parts(wo).ready:
+        state["parts"].add(wo.id)
+    result = run(tasks, {}, state)
+    assert result.starts == {"p1-0": 0}


### PR DESCRIPTION
## Summary
- build schedulable tasks from a work order and plan
- block tasks with a parts-availability gate until inventory is ready
- test that tasks wait for parts before starting

## Testing
- `pre-commit run --files loto/scheduling/assemble.py tests/scheduling/test_assemble_parts_gate.py`
- `pytest tests/scheduling/test_assemble_parts_gate.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a2d60bc4748322b5046639f5ab99cd