### PR TITLE
Add FastAPI service shell

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,28 @@
+# API Service
+
+This directory contains a minimal [FastAPI](https://fastapi.tiangolo.com/) service for loto.
+
+## Endpoints
+
+- `GET /healthz` – basic health check (excluded from OpenAPI schema).
+- `POST /blueprint` – placeholder accepting a CSV upload or work order ID.
+- `POST /schedule` – placeholder endpoint for creating schedules.
+- `GET /workorders/{id}` – mock endpoint returning a work order.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r apps/api/requirements.txt
+```
+
+## Running
+
+Start the development server:
+
+```bash
+uvicorn apps.api.main:app --reload
+```
+
+OpenAPI documentation is available at `/docs` and lists the three placeholder endpoints.

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from fastapi import FastAPI, File, UploadFile
+
+app = FastAPI(title="loto API")
+
+
+@app.get("/healthz", include_in_schema=False)
+async def healthz() -> dict[str, str]:
+    """Health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.post("/blueprint")
+async def post_blueprint(
+    csv: Optional[UploadFile] = File(default=None),
+    workorder_id: Optional[str] = None,
+) -> dict[str, str]:
+    """Placeholder for blueprint upload or work order reference."""
+    return {"detail": "Not implemented"}
+
+
+@app.post("/schedule")
+async def post_schedule(payload: dict) -> dict[str, str]:
+    """Placeholder for schedule creation."""
+    _ = payload  # suppress unused variable warning
+    return {"detail": "Not implemented"}
+
+
+@app.get("/workorders/{workorder_id}")
+async def get_workorder(workorder_id: str) -> dict[str, str]:
+    """Mock work order fetch."""
+    return {"workorder_id": workorder_id, "status": "mocked"}

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-multipart


### PR DESCRIPTION
## Summary
- scaffold basic FastAPI app under apps/api
- document API service setup and usage
- declare requirements for the API service

## Testing
- `pre-commit run --files apps/api/main.py apps/api/README.md apps/api/requirements.txt`
- `pip install -e .[dev]`
- `pytest`
- `pip install -r apps/api/requirements.txt`
- `uvicorn apps.api.main:app --port 8001` (health check and OpenAPI)


------
https://chatgpt.com/codex/tasks/task_b_68a2da3b5ff48322973e249b486ea919