### PR TITLE
Add graph validation and tests

### DIFF
--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -58,3 +58,95 @@ def test_build_graphs_from_demo_csvs(tmp_path):
     assert steam.nodes["V1"]["is_isolation_point"] is True
     assert steam.nodes["V1"]["fail_state"] == "CLOSED"
     assert steam.nodes["V1"]["kind"] == "MV"
+
+
+def test_validate_happy_path(tmp_path):
+    line_df = pd.DataFrame(
+        [{"domain": "steam", "from_tag": "S1", "to_tag": "V1", "line_tag": "L1"}]
+    )
+    valve_df = pd.DataFrame(
+        [{"domain": "steam", "tag": "V1", "fail_state": "CLOSED", "kind": "MV"}]
+    )
+    drain_df = pd.DataFrame(columns=["domain", "tag", "kind"])
+
+    line_path = tmp_path / "lines.csv"
+    valve_path = tmp_path / "valves.csv"
+    drain_path = tmp_path / "drains.csv"
+    line_df.to_csv(line_path, index=False)
+    valve_df.to_csv(valve_path, index=False)
+    drain_df.to_csv(drain_path, index=False)
+
+    builder = GraphBuilder()
+    graphs = builder.from_csvs(line_path, valve_path, drain_path)
+    issues = builder.validate(graphs)
+
+    assert issues == []
+
+
+def test_validate_detects_dangling_node(tmp_path):
+    line_df = pd.DataFrame(
+        [{"domain": "steam", "from_tag": "S1", "to_tag": "D1", "line_tag": "L1"}]
+    )
+    valve_df = pd.DataFrame(
+        [{"domain": "steam", "tag": "V1", "fail_state": "CLOSED", "kind": "MV"}]
+    )  # V1 is not connected
+    drain_df = pd.DataFrame([{"domain": "steam", "tag": "D1", "kind": "drain"}])
+
+    line_path = tmp_path / "lines.csv"
+    valve_path = tmp_path / "valves.csv"
+    drain_path = tmp_path / "drains.csv"
+    line_df.to_csv(line_path, index=False)
+    valve_df.to_csv(valve_path, index=False)
+    drain_df.to_csv(drain_path, index=False)
+
+    builder = GraphBuilder()
+    graphs = builder.from_csvs(line_path, valve_path, drain_path)
+    issues = builder.validate(graphs)
+
+    assert any("Dangling node" in issue.message for issue in issues)
+
+
+def test_validate_detects_missing_line_tag(tmp_path):
+    line_df = pd.DataFrame(
+        [{"domain": "steam", "from_tag": "S1", "to_tag": "V1"}]
+    )  # missing line_tag
+    valve_df = pd.DataFrame(
+        [{"domain": "steam", "tag": "V1", "fail_state": "CLOSED", "kind": "MV"}]
+    )
+    drain_df = pd.DataFrame(columns=["domain", "tag", "kind"])
+
+    line_path = tmp_path / "lines.csv"
+    valve_path = tmp_path / "valves.csv"
+    drain_path = tmp_path / "drains.csv"
+    line_df.to_csv(line_path, index=False)
+    valve_df.to_csv(valve_path, index=False)
+    drain_df.to_csv(drain_path, index=False)
+
+    builder = GraphBuilder()
+    graphs = builder.from_csvs(line_path, valve_path, drain_path)
+    issues = builder.validate(graphs)
+
+    assert any("missing line tag" in issue.message for issue in issues)
+
+
+def test_validate_detects_missing_domain(tmp_path):
+    line_df = pd.DataFrame(
+        [{"domain": None, "from_tag": "S1", "to_tag": "V1", "line_tag": "L1"}]
+    )
+    valve_df = pd.DataFrame(
+        [{"domain": None, "tag": "V1", "fail_state": "CLOSED", "kind": "MV"}]
+    )
+    drain_df = pd.DataFrame(columns=["domain", "tag", "kind"])
+
+    line_path = tmp_path / "lines.csv"
+    valve_path = tmp_path / "valves.csv"
+    drain_path = tmp_path / "drains.csv"
+    line_df.to_csv(line_path, index=False)
+    valve_df.to_csv(valve_path, index=False)
+    drain_df.to_csv(drain_path, index=False)
+
+    builder = GraphBuilder()
+    graphs = builder.from_csvs(line_path, valve_path, drain_path)
+    issues = builder.validate(graphs)
+
+    assert any("missing domain" in issue.message for issue in issues)


### PR DESCRIPTION
## Summary
- implement GraphBuilder.validate with checks for missing domains, line tags, dangling nodes, and cycles
- add tests covering happy path and failure scenarios for graph validation

## Testing
- `pre-commit run --files loto/graph_builder.py tests/test_graph_builder.py`
- `python -m pytest tests/test_graph_builder.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a2d9ff55c08322a9581bf5f18652ea