### PR TITLE
feat: add maximo adapter

### DIFF
--- a/loto/integrations/__init__.py
+++ b/loto/integrations/__init__.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, List
 
 from .coupa_adapter import CoupaAdapter, DemoCoupaAdapter
-from .stores_adapter import StoresAdapter, DemoStoresAdapter
-from .wapr_adapter import WaprAdapter, DemoWaprAdapter
+from .maximo_adapter import MaximoAdapter
+from .stores_adapter import DemoStoresAdapter, StoresAdapter
+from .wapr_adapter import DemoWaprAdapter, WaprAdapter
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from ..isolation_planner import IsolationPlan
@@ -110,4 +111,5 @@ __all__ = [
     "DemoStoresAdapter",
     "WaprAdapter",
     "DemoWaprAdapter",
+    "MaximoAdapter",
 ]

--- a/loto/integrations/maximo_adapter.py
+++ b/loto/integrations/maximo_adapter.py
@@ -1,0 +1,82 @@
+"""Read-only Maximo CMMS adapter."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, TypedDict
+
+import requests  # type: ignore[import-untyped]
+
+
+class WorkOrder(TypedDict):
+    """Shape of a work order returned by the adapter."""
+
+    id: str
+    description: str
+    asset_id: str
+
+
+class Asset(TypedDict):
+    """Shape of an asset returned by the adapter."""
+
+    id: str
+    description: str
+    location: str
+
+
+class MaximoAdapter:
+    """HTTP-based adapter for retrieving data from Maximo.
+
+    The adapter uses environment variables for configuration:
+    - ``MAXIMO_BASE_URL``: base URL of the Maximo REST API.
+    - ``MAXIMO_APIKEY``: API key for authentication (optional).
+    - ``MAXIMO_OS_WORKORDER``: object structure name for work orders.
+    - ``MAXIMO_OS_ASSET``: object structure name for assets.
+    """
+
+    def __init__(self, *, session: requests.Session | None = None) -> None:
+        self.base_url = os.environ.get("MAXIMO_BASE_URL", "")
+        self.apikey = os.environ.get("MAXIMO_APIKEY")
+        self.os_workorder = os.environ.get("MAXIMO_OS_WORKORDER", "WORKORDER")
+        self.os_asset = os.environ.get("MAXIMO_OS_ASSET", "ASSET")
+        self._session = session or requests.Session()
+
+    # internal helper
+    def _get(self, path: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        url = f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
+        headers = {"apikey": self.apikey} if self.apikey else {}
+        resp = self._session.get(url, headers=headers, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_work_order(self, work_order_id: str) -> WorkOrder:
+        """Retrieve a single work order by identifier."""
+        data = self._get(f"os/{self.os_workorder}/{work_order_id}")
+        return {
+            "id": data["id"],
+            "description": data.get("description", ""),
+            "asset_id": data.get("asset_id", ""),
+        }
+
+    def list_open_work_orders(self, window: int) -> List[WorkOrder]:
+        """List open work orders within the specified window."""
+        data = self._get(
+            f"os/{self.os_workorder}", params={"status": "OPEN", "window": window}
+        )
+        return [
+            {
+                "id": item["id"],
+                "description": item.get("description", ""),
+                "asset_id": item.get("asset_id", ""),
+            }
+            for item in data.get("members", [])
+        ]
+
+    def get_asset(self, asset_id: str) -> Asset:
+        """Retrieve asset details by identifier."""
+        data = self._get(f"os/{self.os_asset}/{asset_id}")
+        return {
+            "id": data["id"],
+            "description": data.get("description", ""),
+            "location": data.get("location", ""),
+        }

--- a/tests/integrations/test_maximo_adapter.py
+++ b/tests/integrations/test_maximo_adapter.py
@@ -1,0 +1,73 @@
+from typing import Any, Dict
+
+from loto.integrations.maximo_adapter import MaximoAdapter
+
+
+class DummyResponse:
+    def __init__(self, data: Dict[str, Any]):
+        self._data = data
+
+    def raise_for_status(self) -> None:  # pragma: no cover - does nothing
+        return None
+
+    def json(self) -> Dict[str, Any]:
+        return self._data
+
+
+def _set_env(monkeypatch) -> None:
+    monkeypatch.setenv("MAXIMO_BASE_URL", "http://maximo.local")
+    monkeypatch.setenv("MAXIMO_APIKEY", "secret")
+    monkeypatch.setenv("MAXIMO_OS_WORKORDER", "WORKORDER")
+    monkeypatch.setenv("MAXIMO_OS_ASSET", "ASSET")
+
+
+def test_get_work_order(monkeypatch) -> None:
+    _set_env(monkeypatch)
+
+    def fake_get(url, headers=None, params=None):
+        assert url == "http://maximo.local/os/WORKORDER/WO-1"
+        assert headers == {"apikey": "secret"}
+        return DummyResponse(
+            {"id": "WO-1", "description": "Fix pump", "asset_id": "A-1"}
+        )
+
+    adapter = MaximoAdapter()
+    monkeypatch.setattr(adapter._session, "get", fake_get)
+    work_order = adapter.get_work_order("WO-1")
+    assert work_order == {"id": "WO-1", "description": "Fix pump", "asset_id": "A-1"}
+
+
+def test_list_open_work_orders(monkeypatch) -> None:
+    _set_env(monkeypatch)
+
+    def fake_get(url, headers=None, params=None):
+        assert url == "http://maximo.local/os/WORKORDER"
+        assert params == {"status": "OPEN", "window": 7}
+        data = {
+            "members": [
+                {"id": "WO-1", "description": "A", "asset_id": "A-1"},
+                {"id": "WO-2", "description": "B", "asset_id": "A-2"},
+            ]
+        }
+        return DummyResponse(data)
+
+    adapter = MaximoAdapter()
+    monkeypatch.setattr(adapter._session, "get", fake_get)
+    work_orders = adapter.list_open_work_orders(7)
+    assert work_orders == [
+        {"id": "WO-1", "description": "A", "asset_id": "A-1"},
+        {"id": "WO-2", "description": "B", "asset_id": "A-2"},
+    ]
+
+
+def test_get_asset(monkeypatch) -> None:
+    _set_env(monkeypatch)
+
+    def fake_get(url, headers=None, params=None):
+        assert url == "http://maximo.local/os/ASSET/A-1"
+        return DummyResponse({"id": "A-1", "description": "Pump", "location": "LOC-1"})
+
+    adapter = MaximoAdapter()
+    monkeypatch.setattr(adapter._session, "get", fake_get)
+    asset = adapter.get_asset("A-1")
+    assert asset == {"id": "A-1", "description": "Pump", "location": "LOC-1"}


### PR DESCRIPTION
## Summary
- add read-only Maximo adapter with work order and asset helpers
- export Maximo adapter via integrations package
- cover adapter with unit tests

## Testing
- `pre-commit run --files loto/integrations/maximo_adapter.py loto/integrations/__init__.py tests/integrations/test_maximo_adapter.py`
- `pytest tests/integrations/test_maximo_adapter.py tests/test_integrations_adapters.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2dedfae1c8322936841ed0c13b213