### PR TITLE
Expand demo integration adapters with additional stubs

### DIFF
--- a/loto/integrations/coupa_adapter.py
+++ b/loto/integrations/coupa_adapter.py
@@ -31,10 +31,26 @@ class CoupaAdapter(abc.ABC):
             Identifier of the raised RFQ.
         """
 
+    @abc.abstractmethod
+    def get_po_status(self, po_number: str) -> str:
+        """Return the status of a purchase order."""
+
 
 class DemoCoupaAdapter(CoupaAdapter):
     """Dry-run Coupa adapter that fabricates RFQ identifiers."""
 
+    _PO_STATUSES = {
+        "PO-1": "OPEN",
+        "PO-2": "CLOSED",
+    }
+
     def raise_urgent_enquiry(self, part_number: str, quantity: int) -> str:
         """Simulate raising an RFQ and return its identifier."""
         return f"RFQ-{uuid.uuid4().hex[:8]}"
+
+    def get_po_status(self, po_number: str) -> str:
+        """Return a fixture status for the given purchase order."""
+        try:
+            return self._PO_STATUSES[po_number]
+        except KeyError as exc:  # pragma: no cover - simple error path
+            raise KeyError(f"Unknown purchase order {po_number}") from exc

--- a/loto/integrations/stores_adapter.py
+++ b/loto/integrations/stores_adapter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import abc
 import uuid
+from typing import Dict
 
 
 class StoresAdapter(abc.ABC):
@@ -30,10 +31,26 @@ class StoresAdapter(abc.ABC):
             Identifier of the generated pick list.
         """
 
+    @abc.abstractmethod
+    def inventory_status(self, asset: str) -> Dict[str, int]:
+        """Return current inventory levels for ``asset``."""
+
 
 class DemoStoresAdapter(StoresAdapter):
     """Dry-run stores adapter that fabricates pick list identifiers."""
 
+    _INVENTORY = {
+        "P-100": {"available": 5},
+        "P-200": {"available": 0},
+    }
+
     def create_pick_list(self, part_number: str, quantity: int) -> str:
         """Simulate creating a pick list and return its identifier."""
         return f"PL-{uuid.uuid4().hex[:8]}"
+
+    def inventory_status(self, asset: str) -> Dict[str, int]:
+        """Return fixture inventory levels for ``asset``."""
+        try:
+            return self._INVENTORY[asset]
+        except KeyError as exc:  # pragma: no cover - simple error path
+            raise KeyError(f"Unknown asset {asset}") from exc

--- a/tests/integrations/test_demo_adapters.py
+++ b/tests/integrations/test_demo_adapters.py
@@ -1,0 +1,87 @@
+"""Smoke tests for demo integration adapters.
+
+These tests validate the default return shapes and basic error handling of
+
+the demo adapters.  The adapters perform no external calls and only return
+fixture data.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from loto.integrations.coupa_adapter import DemoCoupaAdapter
+from loto.integrations.stores_adapter import DemoStoresAdapter
+from loto.integrations.wapr_adapter import DemoWaprAdapter
+
+
+def test_wapr_reserve_window_returns_identifier() -> None:
+    """A reservation identifier is produced for a valid window."""
+    adapter = DemoWaprAdapter()
+    start = datetime(2024, 1, 1, 8)
+    end = datetime(2024, 1, 1, 9)
+    reservation = adapter.reserve_window(start, end)
+    assert reservation.startswith("RES-")
+
+
+def test_wapr_reserve_window_invalid() -> None:
+    """Invalid windows raise a ValueError."""
+    adapter = DemoWaprAdapter()
+    start = datetime(2024, 1, 1, 9)
+    end = datetime(2024, 1, 1, 8)
+    with pytest.raises(ValueError):
+        adapter.reserve_window(start, end)
+
+
+def test_wapr_list_conflicts_returns_list() -> None:
+    """Conflicts are returned as a list of work order identifiers."""
+    adapter = DemoWaprAdapter()
+    start = datetime(2024, 1, 1, 8)
+    end = datetime(2024, 1, 1, 9)
+    conflicts = adapter.list_conflicts(start, end)
+    assert conflicts and all(isinstance(c, str) for c in conflicts)
+
+
+def test_wapr_get_price_curve_shape() -> None:
+    """Price curves are lists of ``(hour, price)`` pairs."""
+    adapter = DemoWaprAdapter()
+    curve = adapter.get_price_curve("ASSET-1")
+    assert isinstance(curve, list)
+    assert curve and isinstance(curve[0], tuple)
+
+
+def test_wapr_get_price_curve_unknown() -> None:
+    """Unknown assets raise a ``KeyError``."""
+    adapter = DemoWaprAdapter()
+    with pytest.raises(KeyError):
+        adapter.get_price_curve("UNKNOWN")
+
+
+def test_coupa_po_status_fixture() -> None:
+    """Fixture purchase order statuses are returned."""
+    adapter = DemoCoupaAdapter()
+    status = adapter.get_po_status("PO-1")
+    assert status in {"OPEN", "CLOSED"}
+
+
+def test_coupa_po_status_unknown() -> None:
+    """Unknown purchase orders raise ``KeyError``."""
+    adapter = DemoCoupaAdapter()
+    with pytest.raises(KeyError):
+        adapter.get_po_status("PO-999")
+
+
+def test_stores_inventory_status_fixture() -> None:
+    """Inventory status includes an ``available`` quantity."""
+    adapter = DemoStoresAdapter()
+    status = adapter.inventory_status("P-100")
+    assert "available" in status
+
+
+def test_stores_inventory_status_unknown() -> None:
+    """Unknown assets raise ``KeyError``."""
+    adapter = DemoStoresAdapter()
+    with pytest.raises(KeyError):
+        adapter.inventory_status("P-999")


### PR DESCRIPTION
## Summary
- flesh out WAPR demo adapter with reservation, conflict and price curve helpers
- add purchase order status lookup to Coupa demo adapter
- expose simple inventory status via Stores demo adapter
- cover demo adapter behaviour with targeted tests

## Testing
- `pytest tests/test_integrations_adapters.py tests/integrations/test_demo_adapters.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a2deef9bec8322bc9439e6e8f200fe