### PR TITLE
feat(api): add blueprint endpoint

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,15 @@
-from typing import Optional
+from __future__ import annotations
 
-from fastapi import FastAPI, File, UploadFile
+from pathlib import Path
+from typing import Any, Dict, List
+
+from fastapi import FastAPI
+
+from loto.impact_config import load_impact_config
+from loto.models import RulePack
+from loto.service import plan_and_evaluate
+
+from .schemas import BlueprintRequest, BlueprintResponse, Step
 
 app = FastAPI(title="loto API")
 
@@ -11,13 +20,64 @@ async def healthz() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@app.post("/blueprint")
-async def post_blueprint(
-    csv: Optional[UploadFile] = File(default=None),
-    workorder_id: Optional[str] = None,
-) -> dict[str, str]:
-    """Placeholder for blueprint upload or work order reference."""
-    return {"detail": "Not implemented"}
+class DemoMaximoAdapter:
+    """Tiny Maximo adapter serving demo data from the repository."""
+
+    def load_context(self, workorder_id: str) -> Dict[str, Any]:
+        """Return file paths and metadata for the given work order."""
+
+        base = Path(__file__).resolve().parents[2] / "demo"
+        impact_cfg = load_impact_config(
+            base / "unit_map.yaml", base / "redundancy_map.yaml"
+        )
+        return {
+            "line_csv": base / "line_list.csv",
+            "valve_csv": base / "valves.csv",
+            "drain_csv": base / "drains.csv",
+            "source_csv": base / "sources.csv",
+            "asset_tag": "A",  # arbitrary asset tag for demo data
+            "impact_cfg": impact_cfg,
+        }
+
+
+@app.post("/blueprint", response_model=BlueprintResponse)
+async def post_blueprint(payload: BlueprintRequest) -> BlueprintResponse:
+    """Plan isolations for a work order and return impact metrics."""
+
+    adapter = DemoMaximoAdapter()
+    ctx = adapter.load_context(payload.workorder_id)
+    impact_cfg = ctx["impact_cfg"]
+
+    with (
+        open(ctx["line_csv"]) as line,
+        open(ctx["valve_csv"]) as valve,
+        open(ctx["drain_csv"]) as drain,
+        open(ctx["source_csv"]) as source,
+    ):
+        plan, _, impact = plan_and_evaluate(
+            line,
+            valve,
+            drain,
+            source,
+            asset_tag=str(ctx["asset_tag"]),
+            rule_pack=RulePack(),
+            stimuli=[],
+            asset_units=impact_cfg.asset_units,
+            unit_data=impact_cfg.unit_data,
+            unit_areas=impact_cfg.unit_areas,
+            penalties=impact_cfg.penalties,
+            asset_areas=impact_cfg.asset_areas,
+        )
+
+    steps: List[Step] = [
+        Step(component_id=a.component_id, method=a.method) for a in plan.actions
+    ]
+
+    return BlueprintResponse(
+        steps=steps,
+        unavailable_assets=sorted(impact.unavailable_assets),
+        unit_mw_delta=impact.unit_mw_delta,
+    )
 
 
 @app.post("/schedule")

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class BlueprintRequest(BaseModel):
+    """Request body for the /blueprint endpoint."""
+
+    workorder_id: str = Field(..., description="Identifier of the work order")
+
+    class Config:
+        extra = "forbid"
+
+
+class Step(BaseModel):
+    """Single isolation step in the computed plan."""
+
+    component_id: str = Field(..., description="Component identifier")
+    method: str = Field(..., description="Isolation method")
+
+    class Config:
+        extra = "forbid"
+
+
+class BlueprintResponse(BaseModel):
+    """Response model for the /blueprint endpoint."""
+
+    steps: List[Step] = Field(
+        default_factory=list, description="Ordered isolation steps"
+    )
+    unavailable_assets: List[str] = Field(
+        default_factory=list, description="Assets that became unavailable"
+    )
+    unit_mw_delta: Dict[str, float] = Field(
+        default_factory=dict, description="Lost capacity per unit in MW"
+    )
+
+    class Config:
+        extra = "forbid"


### PR DESCRIPTION
## Summary
- add demo Maximo adapter and `/blueprint` handler returning plan and impact
- define pydantic models for blueprint requests and responses

## Testing
- `pre-commit run --files apps/api/main.py apps/api/schemas.py`
- `pytest`
- `python - <<'PY'\nfrom fastapi.testclient import TestClient\nfrom apps.api.main import app\n\nclient = TestClient(app)\nprint(client.post('/blueprint', json={'workorder_id': 'WO-1'}).json())\nPY`


------
https://chatgpt.com/codex/tasks/task_b_68a2df12f0908322ad62c04455b49c8e