### PR TITLE
Feed inventory readiness into parts gate

### DIFF
--- a/loto/scheduling/gates.py
+++ b/loto/scheduling/gates.py
@@ -105,3 +105,22 @@ def compose_gates(*preds: Callable[[State], bool]) -> Callable[[State], bool]:
         return all(pred(state) for pred in preds)
 
     return combined
+
+
+def feed_parts_state(state: State, wo_id: str, ready: bool) -> State:
+    """Return new state reflecting parts readiness for ``wo_id``.
+
+    The returned mapping contains a ``"parts"`` set updated based on the
+    ``ready`` flag.  When ``ready`` is ``True`` the work order ID is added to
+    the set; otherwise it is removed.  The original ``state`` mapping is not
+    mutated.
+    """
+
+    parts = set(state.get("parts", set()))
+    if ready:
+        parts.add(wo_id)
+    else:
+        parts.discard(wo_id)
+    new_state: dict[str, Any] = dict(state)
+    new_state["parts"] = parts
+    return new_state

--- a/tests/scheduling/test_gates_inventory_flow.py
+++ b/tests/scheduling/test_gates_inventory_flow.py
@@ -1,0 +1,33 @@
+from loto.inventory import InventoryStatus
+from loto.models import IsolationAction, IsolationPlan
+from loto.service import scheduling
+from loto.service.blueprints import inventory_state
+
+
+class _WO:
+    def __init__(self, wo_id: str) -> None:
+        self.id = wo_id
+        self.reservations: list[object] = []
+
+
+def test_inventory_gate_flow() -> None:
+    wo = _WO("wo-1")
+    plan = IsolationPlan(
+        plan_id="p1",
+        actions=[IsolationAction(component_id="c", method="lock", duration_s=1)],
+    )
+
+    status = InventoryStatus(blocked=True)
+
+    def check_parts(_: object) -> InventoryStatus:
+        return status
+
+    tasks = scheduling.assemble_tasks(wo, plan, check_parts)
+    state = inventory_state(wo, check_parts)
+    result = scheduling.run_schedule(tasks, {}, state=state)
+    assert "p1-0" not in result.starts
+
+    status.blocked = False
+    state = inventory_state(wo, check_parts, state)
+    result = scheduling.run_schedule(tasks, {}, state=state)
+    assert result.starts == {"p1-0": 0}


### PR DESCRIPTION
## Summary
- add `feed_parts_state` helper for propagating parts readiness
- expose `inventory_state` blueprint to wire Stores inventory into scheduler state
- test inventory-driven gating flow

## Testing
- `pre-commit run --files loto/scheduling/gates.py loto/service/blueprints.py tests/scheduling/test_gates_inventory_flow.py`
- `pytest tests/scheduling/test_gates_inventory_flow.py tests/scheduling/test_assemble_parts_gate.py tests/scheduling/test_des_engine_parts_gate.py tests/test_service_scheduling.py tests/test_service_blueprints.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2defddb948322b55e85adbfdde96e