### PR TITLE
feat(ui): add portfolio API hook

### DIFF
--- a/apps/maximo-extension-ui/src/lib/hooks.ts
+++ b/apps/maximo-extension-ui/src/lib/hooks.ts
@@ -4,11 +4,32 @@ import { fetchWorkOrder } from '../mocks/workorder';
 import type { WorkOrderSummary } from '../types/api';
 
 /**
- * Query hook for portfolio data.
+ * Fetch portfolio data from the API.
  */
-export function usePortfolio(): UseQueryResult<PortfolioData> {
-  return useQuery({ queryKey: ['portfolio'], queryFn: fetchPortfolio });
+async function fetchPortfolioApi(): Promise<PortfolioData> {
+  const res = await fetch('/portfolio');
+  if (!res.ok) {
+    throw new Error('Failed to fetch portfolio');
+  }
+  return res.json();
 }
+
+/**
+ * Query hook for portfolio data.
+ *
+ * When `NEXT_PUBLIC_USE_API` is set to `true`, data is retrieved from the
+ * `/portfolio` API endpoint. Otherwise, mocked data is used.
+ */
+export function usePortfolioApi(): UseQueryResult<PortfolioData> {
+  const useApi = process.env.NEXT_PUBLIC_USE_API === 'true';
+  return useQuery({
+    queryKey: ['portfolio'],
+    queryFn: useApi ? fetchPortfolioApi : fetchPortfolio
+  });
+}
+
+// Preserve existing hook name for consumers expecting mocks.
+export const usePortfolio = usePortfolioApi;
 
 /**
  * Query hook for an individual work order.


### PR DESCRIPTION
## Summary
- add `usePortfolioApi` hook that optionally fetches data from `/portfolio`
- keep mocked portfolio data when `NEXT_PUBLIC_USE_API` is not set

## Testing
- `pnpm --filter maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a2e2c54aa483229f8083c3c085eedc