### PR TITLE
feat: add scheduler gantt and price charts

### DIFF
--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { vi, test, expect } from 'vitest';
+import Page from './page';
+
+test('renders gantt, price curve and hats timeline', async () => {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserver;
+
+  const sample = {
+    schedule: [
+      { date: '2024-01-01', p10: 10, p50: 20, p90: 30, price: 40, hats: 1 },
+      { date: '2024-01-02', p10: 12, p50: 22, p90: 32, price: 42, hats: 2 }
+    ]
+  };
+  const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => sample
+  } as Response);
+
+  render(<Page params={{ wo: 'WO-1' }} />);
+
+  await screen.findByTestId('gantt-chart');
+  expect(screen.getByTestId('price-chart')).toBeInTheDocument();
+  expect(screen.getByTestId('hats-chart')).toBeInTheDocument();
+  const synced = document.querySelectorAll('[data-sync="schedule"]');
+  expect(synced.length).toBe(3);
+  fetchMock.mockRestore();
+});
+

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Gantt from '../../../components/Gantt';
+import { useSchedule } from '../../../lib/schedule';
+
+const queryClient = new QueryClient();
+
+function SchedulerContent({ wo }: { wo: string }) {
+  const { data } = useSchedule(wo);
+  if (!data) return null;
+  return (
+    <main className="h-full">
+      <h1 className="mb-4 text-xl font-semibold">Scheduler: {wo}</h1>
+      <Gantt data={data} />
+    </main>
+  );
+}
+
+export default function SchedulerPage({ params }: { params: { wo: string } }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <SchedulerContent wo={params.wo} />
+    </QueryClientProvider>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/components/Gantt.tsx
+++ b/apps/maximo-extension-ui/src/components/Gantt.tsx
@@ -1,0 +1,61 @@
+import {
+  Area,
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import React from 'react';
+import type { SchedulePoint } from '../lib/schedule';
+
+const SYNC_ID = 'schedule';
+
+/**
+ * Simple Gantt/price/hats visualization with synced cursor.
+ */
+export default function Gantt({ data }: { data: SchedulePoint[] }) {
+  return (
+    <div className="w-full h-full">
+      <div data-testid="gantt-chart" data-sync={SYNC_ID}>
+        <ResponsiveContainer width="100%" height={200}>
+          <ComposedChart data={data} syncId={SYNC_ID}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Area type="monotone" dataKey="p90" stroke="none" fill="#8884d8" fillOpacity={0.3} />
+            <Area type="monotone" dataKey="p10" stroke="none" fill="#fff" />
+            <Line type="monotone" dataKey="p50" stroke="#8884d8" dot={false} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+      <div data-testid="price-chart" data-sync={SYNC_ID}>
+        <ResponsiveContainer width="100%" height={100}>
+          <ComposedChart data={data} syncId={SYNC_ID}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="price" stroke="#ff7300" dot={false} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+      <div data-testid="hats-chart" data-sync={SYNC_ID}>
+        <ResponsiveContainer width="100%" height={100}>
+          <ComposedChart data={data} syncId={SYNC_ID}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="hats" fill="#82ca9d" />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/lib/schedule.ts
+++ b/apps/maximo-extension-ui/src/lib/schedule.ts
@@ -1,0 +1,32 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+
+export interface SchedulePoint {
+  date: string;
+  p10: number;
+  p50: number;
+  p90: number;
+  price: number;
+  hats: number;
+}
+
+/**
+ * Fetch schedule for a work order.
+ */
+export async function fetchSchedule(wo: string): Promise<SchedulePoint[]> {
+  const res = await fetch('/schedule', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ workorder: wo })
+  });
+  if (!res.ok) throw new Error('Failed to fetch schedule');
+  const data = await res.json();
+  return data.schedule as SchedulePoint[];
+}
+
+/**
+ * React Query hook for schedule data.
+ */
+export function useSchedule(wo: string): UseQueryResult<SchedulePoint[]> {
+  return useQuery({ queryKey: ['schedule', wo], queryFn: () => fetchSchedule(wo) });
+}
+


### PR DESCRIPTION
## Summary
- add schedule hook to call /schedule
- add Gantt component with synced price and hats charts
- add scheduler page and test for rendering

## Testing
- `pnpm --filter maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a2e2da20a083229fd8b177ea17462c