### PR TITLE
feat: add export downloads

### DIFF
--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
@@ -7,3 +7,9 @@ test('renders 4 tabs', async () => {
   const tabs = await screen.findAllByRole('tab');
   expect(tabs).toHaveLength(4);
 });
+
+test('renders export buttons', () => {
+  render(<Page params={{ wo: 'WO-1' }} />);
+  expect(screen.getAllByText('Export PDF').length).toBeGreaterThan(0);
+  expect(screen.getAllByText('Export JSON').length).toBeGreaterThan(0);
+});

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useWorkOrder, useBlueprint } from '../../../lib/hooks';
+import Exports from '../../../components/Exports';
 
 const tabs = ['Plan', 'P&ID', 'Simulation', 'Impact'];
 
@@ -24,6 +25,7 @@ function PlannerContent({ wo }: { wo: string }) {
       <h1 className="mb-4 text-xl font-semibold">
         WO Planner: {workOrder.id}
       </h1>
+      <Exports wo={workOrder.id} />
       <div className="flex h-full">
         <div className="flex-1 pr-4">
           <div role="tablist" className="mb-4 border-b">

--- a/apps/maximo-extension-ui/src/components/Exports.test.tsx
+++ b/apps/maximo-extension-ui/src/components/Exports.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { test, expect, vi, afterEach } from 'vitest';
+import Exports from './Exports';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  global.fetch = originalFetch;
+});
+
+test('downloads PDF with hash and seed', async () => {
+  const hash = 'abc123';
+  const seed = '42';
+  const blob = new Blob(['pdf'], { type: 'application/pdf' });
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({ 'x-loto-hash': hash, 'x-loto-seed': seed }),
+    blob: () => Promise.resolve(blob)
+  });
+  global.fetch = fetchMock as any;
+
+  const click = vi.fn();
+  const origCreate = document.createElement.bind(document);
+  let anchor: HTMLAnchorElement;
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    if (tag === 'a') {
+      anchor = origCreate('a') as HTMLAnchorElement;
+      anchor.click = click;
+      return anchor;
+    }
+    return origCreate(tag);
+  });
+  (global as any).URL.createObjectURL = vi.fn(() => 'blob:mock');
+  (global as any).URL.revokeObjectURL = vi.fn();
+
+  render(<Exports wo="1" />);
+  fireEvent.click(screen.getByText('Export PDF'));
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+  expect(anchor.download).toBe('WO-1_abc123.pdf');
+  expect(click).toHaveBeenCalled();
+  await screen.findByText('Hash: abc123');
+  await screen.findByText('Seed: 42');
+});
+
+test('downloads JSON with hash in filename', async () => {
+  const hash = 'def456';
+  const seed = '7';
+  const blob = new Blob(['{}'], { type: 'application/json' });
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({ 'x-loto-hash': hash, 'x-loto-seed': seed }),
+    blob: () => Promise.resolve(blob)
+  });
+  global.fetch = fetchMock as any;
+
+  const click = vi.fn();
+  const origCreate2 = document.createElement.bind(document);
+  let anchor2: HTMLAnchorElement;
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    if (tag === 'a') {
+      anchor2 = origCreate2('a') as HTMLAnchorElement;
+      anchor2.click = click;
+      return anchor2;
+    }
+    return origCreate2(tag);
+  });
+  (global as any).URL.createObjectURL = vi.fn(() => 'blob:mock');
+  (global as any).URL.revokeObjectURL = vi.fn();
+
+  render(<Exports wo="2" />);
+  fireEvent.click(screen.getByText('Export JSON'));
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+  expect(anchor2.download).toBe('WO-2_def456.json');
+  expect(click).toHaveBeenCalled();
+  await screen.findByText('Hash: def456');
+  await screen.findByText('Seed: 7');
+});


### PR DESCRIPTION
## Summary
- add Exports component with PDF and JSON download buttons
- show rule hash and seed from export responses
- wire export buttons into planner page

## Testing
- `pnpm --filter maximo-extension-ui test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a2e6883840832286b6b5f6b662f979