### PR TITLE
feat: add proposal endpoint and provenance

### DIFF
--- a/tests/test_service_blueprints.py
+++ b/tests/test_service_blueprints.py
@@ -1,27 +1,37 @@
 import io
+import hashlib
+import json
 import pandas as pd
 
 from loto.models import RulePack
-from loto.service.blueprints import plan_and_evaluate
+from loto.service.blueprints import plan_and_evaluate, Provenance
 
 
 def test_plan_and_evaluate_deterministic():
-    line_df = pd.DataFrame([
-        {"domain": "steam", "from_tag": "S", "to_tag": "V"},
-        {"domain": "steam", "from_tag": "V", "to_tag": "asset"},
-        {"domain": "steam", "from_tag": "asset", "to_tag": "D"},
-    ])
-    valve_df = pd.DataFrame([
-        {"domain": "steam", "tag": "V", "fail_state": "FC", "kind": "MV"},
-    ])
-    drain_df = pd.DataFrame([
-        {"domain": "steam", "tag": "D", "kind": "drain"},
-    ])
-    source_df = pd.DataFrame([
-        {"domain": "steam", "tag": "S", "kind": "source"},
-    ])
+    line_df = pd.DataFrame(
+        [
+            {"domain": "steam", "from_tag": "S", "to_tag": "V"},
+            {"domain": "steam", "from_tag": "V", "to_tag": "asset"},
+            {"domain": "steam", "from_tag": "asset", "to_tag": "D"},
+        ]
+    )
+    valve_df = pd.DataFrame(
+        [
+            {"domain": "steam", "tag": "V", "fail_state": "FC", "kind": "MV"},
+        ]
+    )
+    drain_df = pd.DataFrame(
+        [
+            {"domain": "steam", "tag": "D", "kind": "drain"},
+        ]
+    )
+    source_df = pd.DataFrame(
+        [
+            {"domain": "steam", "tag": "S", "kind": "source"},
+        ]
+    )
 
-    plan, report, impact = plan_and_evaluate(
+    plan, report, impact, prov = plan_and_evaluate(
         io.StringIO(line_df.to_csv(index=False)),
         io.StringIO(valve_df.to_csv(index=False)),
         io.StringIO(drain_df.to_csv(index=False)),
@@ -32,6 +42,7 @@ def test_plan_and_evaluate_deterministic():
         asset_units={"asset": "U1"},
         unit_data={"U1": {"rated": 5.0, "scheme": "SPOF"}},
         unit_areas={"U1": "Area1"},
+        seed=42,
     )
 
     assert [a.component_id for a in plan.actions] == ["steam:V->asset"]
@@ -39,3 +50,8 @@ def test_plan_and_evaluate_deterministic():
     assert impact.unavailable_assets == {"asset"}
     assert impact.unit_mw_delta == {"U1": 5.0}
     assert impact.area_mw_delta == {"Area1": 5.0}
+
+    expected_hash = hashlib.sha256(
+        json.dumps(RulePack().model_dump(), sort_keys=True).encode()
+    ).hexdigest()
+    assert prov == Provenance(seed=42, rule_hash=expected_hash)


### PR DESCRIPTION
## Summary
- add `/propose` endpoint that diffs proposed targets/assignments and returns an idempotency key
- record planning provenance with seed and rule pack hash
- test deterministic planning with provenance info

## Testing
- `ruff check apps/api/main.py loto/service/blueprints.py tests/test_service_blueprints.py`
- `black --check apps/api/main.py loto/service/blueprints.py tests/test_service_blueprints.py`
- `pytest tests/test_service_blueprints.py`
- ❌ `pytest` *(missing dependencies: networkx, requests, pandas, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68a2e87232508322a5cbb8e130154fe2