### PR TITLE
Add commit panel with role-gated commit button

### DIFF
--- a/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { test, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import CommitPanel from './CommitPanel';
+
+test('renders audit metadata and disables commit in TEST role', async () => {
+  vi.stubEnv('NEXT_PUBLIC_ROLE', 'TEST');
+  const blueprint = { diff: 'diff text', audit_metadata: { user: 'alice' } };
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(blueprint) }));
+  const queryClient = new QueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CommitPanel wo="WO-1" />
+    </QueryClientProvider>
+  );
+  await screen.findByTestId('diff');
+  expect(screen.getByText(/Audit Metadata/)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Commit' })).toBeDisabled();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useBlueprint } from '../../../lib/hooks';
+import Button from '../../../components/Button';
+
+interface CommitPanelProps {
+  wo: string;
+}
+
+export default function CommitPanel({ wo }: CommitPanelProps) {
+  const { data } = useBlueprint(wo);
+  const role = (process.env.NEXT_PUBLIC_ROLE || 'TEST').toUpperCase();
+  const canCommit = role !== 'TEST';
+  const diff = data?.diff;
+  const audit = data?.audit_metadata as Record<string, unknown> | undefined;
+
+  return (
+    <section>
+      {diff && (
+        <pre className="mb-4 overflow-x-auto border p-2 text-sm" data-testid="diff">
+          {diff}
+        </pre>
+      )}
+      {audit && (
+        <div className="mb-4">
+          <h2 className="mb-1 font-semibold">Audit Metadata</h2>
+          <pre className="overflow-x-auto border p-2 text-sm">
+            {JSON.stringify(audit, null, 2)}
+          </pre>
+        </div>
+      )}
+      <Button disabled={!canCommit}>Commit</Button>
+    </section>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
@@ -2,10 +2,10 @@ import { render, screen } from '@testing-library/react';
 import { test, expect } from 'vitest';
 import Page from './page';
 
-test('renders 4 tabs', async () => {
+test('renders 5 tabs', async () => {
   render(<Page params={{ wo: 'WO-1' }} />);
   const tabs = await screen.findAllByRole('tab');
-  expect(tabs).toHaveLength(4);
+  expect(tabs).toHaveLength(5);
 });
 
 test('renders export buttons', () => {

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -4,8 +4,9 @@ import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useWorkOrder, useBlueprint } from '../../../lib/hooks';
 import Exports from '../../../components/Exports';
+import CommitPanel from './CommitPanel';
 
-const tabs = ['Plan', 'P&ID', 'Simulation', 'Impact'];
+const tabs = ['Plan', 'P&ID', 'Simulation', 'Impact', 'Commit'];
 
 const queryClient = new QueryClient();
 
@@ -115,6 +116,7 @@ function PlannerContent({ wo }: { wo: string }) {
               </tbody>
             </table>
           )}
+          {activeTab === 'Commit' && <CommitPanel wo={wo} />}
         </div>
         <aside className="w-64 shrink-0 border-l border-[var(--mxc-border)] bg-[var(--mxc-drawer-bg)] p-4 text-[var(--mxc-drawer-fg)]">
           Warnings placeholder

--- a/apps/maximo-extension-ui/src/types/api.ts
+++ b/apps/maximo-extension-ui/src/types/api.ts
@@ -16,6 +16,8 @@ export interface BlueprintData {
   steps: BlueprintStep[];
   unavailable_assets: string[];
   unit_mw_delta: Record<string, number>;
+  diff?: string;
+  audit_metadata?: Record<string, unknown>;
 }
 
 export interface PlanStep {


### PR DESCRIPTION
## Summary
- add CommitPanel component showing diff and audit metadata
- add Commit tab to planner page
- extend BlueprintData type with diff and audit metadata fields

## Testing
- `pnpm --filter maximo-extension-ui test`

------
https://chatgpt.com/codex/tasks/task_b_68a2e8798a2c832282debad86e5150b9