### PR TITLE
feat: add accessible theme toggle and aria improvements

### DIFF
--- a/apps/maximo-extension-ui/src/app/layout.tsx
+++ b/apps/maximo-extension-ui/src/app/layout.tsx
@@ -1,13 +1,15 @@
 import type { ReactNode } from 'react';
 import '../styles/globals.css';
+import ThemeToggle from '../components/ThemeToggle';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="h-full">
       <body className="min-h-screen">
         <div className="flex min-h-screen flex-col">
-          <header className="flex h-12 items-center bg-[var(--mxc-topbar-bg)] px-4 text-[var(--mxc-topbar-fg)]">
+          <header className="flex h-12 items-center justify-between bg-[var(--mxc-topbar-bg)] px-4 text-[var(--mxc-topbar-fg)]">
             <span className="font-semibold">Maximo Extension</span>
+            <ThemeToggle />
           </header>
           <div className="flex flex-1 overflow-hidden">
             <nav className="w-56 shrink-0 border-r border-[var(--mxc-border)] bg-[var(--mxc-nav-bg)] p-4 text-[var(--mxc-nav-fg)]">

--- a/apps/maximo-extension-ui/src/components/Button.tsx
+++ b/apps/maximo-extension-ui/src/components/Button.tsx
@@ -8,8 +8,9 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 export default function Button({ className, ...props }: ButtonProps) {
   return (
     <button
+      type="button"
       className={clsx(
-        'rounded-[var(--mxc-radius-sm)] bg-[var(--mxc-topbar-bg)] px-4 py-2 text-[var(--mxc-topbar-fg)] shadow-[var(--mxc-shadow-sm)]',
+        'rounded-[var(--mxc-radius-sm)] bg-[var(--mxc-topbar-bg)] px-4 py-2 text-[var(--mxc-topbar-fg)] shadow-[var(--mxc-shadow-sm)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--mxc-topbar-bg)]',
         className
       )}
       {...props}

--- a/apps/maximo-extension-ui/src/components/ConflictsList.tsx
+++ b/apps/maximo-extension-ui/src/components/ConflictsList.tsx
@@ -43,7 +43,9 @@ export default function ConflictsList({ candidates }: ConflictsListProps) {
           </li>
         ))}
       </ul>
-      <button onClick={handleRecommend}>Select recommended set</button>
+      <button type="button" aria-label="Select recommended set" onClick={handleRecommend}>
+        Select recommended set
+      </button>
     </div>
   );
 }

--- a/apps/maximo-extension-ui/src/components/Exports.tsx
+++ b/apps/maximo-extension-ui/src/components/Exports.tsx
@@ -41,8 +41,12 @@ export default function Exports({ wo }: ExportProps) {
 
   return (
     <div className="mb-4 flex items-center space-x-2">
-      <Button onClick={() => handleExport('pdf')}>Export PDF</Button>
-      <Button onClick={() => handleExport('json')}>Export JSON</Button>
+      <Button aria-label="Export PDF" onClick={() => handleExport('pdf')}>
+        Export PDF
+      </Button>
+      <Button aria-label="Export JSON" onClick={() => handleExport('json')}>
+        Export JSON
+      </Button>
       {hash && <span>Hash: {hash}</span>}
       {seed && <span>Seed: {seed}</span>}
     </div>

--- a/apps/maximo-extension-ui/src/components/MaterialsPanel.tsx
+++ b/apps/maximo-extension-ui/src/components/MaterialsPanel.tsx
@@ -16,7 +16,11 @@ export default function MaterialsPanel({ items }: MaterialsPanelProps) {
   return (
     <div className="flex flex-col gap-4">
       <div className="overflow-hidden rounded-[var(--mxc-radius-md)] border border-[var(--mxc-border)]">
-        <table className="min-w-full divide-y divide-[var(--mxc-border)] text-sm">
+        <table
+          aria-label="Materials"
+          tabIndex={0}
+          className="min-w-full divide-y divide-[var(--mxc-border)] text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--mxc-border)]"
+        >
           <thead className="bg-[var(--mxc-bg)]">
             <tr>
               <th scope="col" className="px-4 py-2 text-left font-medium">

--- a/apps/maximo-extension-ui/src/components/ThemeToggle.tsx
+++ b/apps/maximo-extension-ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Button from './Button';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme');
+      if (stored === 'light' || stored === 'dark') return stored;
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <Button aria-label="Toggle dark mode" onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+      {theme === 'dark' ? 'Light mode' : 'Dark mode'}
+    </Button>
+  );
+}

--- a/apps/maximo-extension-ui/src/components/__snapshots__/Button.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/components/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`matches snapshot 1`] = `
 <button
-  class="rounded-[var(--mxc-radius-sm)] bg-[var(--mxc-topbar-bg)] px-4 py-2 text-[var(--mxc-topbar-fg)] shadow-[var(--mxc-shadow-sm)]"
+  class="rounded-[var(--mxc-radius-sm)] bg-[var(--mxc-topbar-bg)] px-4 py-2 text-[var(--mxc-topbar-fg)] shadow-[var(--mxc-shadow-sm)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--mxc-topbar-bg)]"
+  type="button"
 >
   Click
 </button>

--- a/apps/maximo-extension-ui/src/components/__snapshots__/ConflictsList.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/components/__snapshots__/ConflictsList.test.tsx.snap
@@ -64,7 +64,10 @@ exports[`click sets recommended items 1`] = `
       </p>
     </li>
   </ul>
-  <button>
+  <button
+    aria-label="Select recommended set"
+    type="button"
+  >
     Select recommended set
   </button>
 </div>

--- a/apps/maximo-extension-ui/src/styles/theme-maximo.css
+++ b/apps/maximo-extension-ui/src/styles/theme-maximo.css
@@ -1,4 +1,7 @@
-:root {
+/* Light theme (default) */
+:root,
+[data-theme="light"] {
+  color-scheme: light;
   /* Palette */
   --mxc-bg: #f4f4f4;
   --mxc-fg: #161616;
@@ -16,9 +19,9 @@
   --mxc-radius-lg: 8px;
 
   /* Shadows */
-  --mxc-shadow-sm: 0 1px 2px rgba(0,0,0,0.1);
-  --mxc-shadow-md: 0 2px 4px rgba(0,0,0,0.1);
-  --mxc-shadow-lg: 0 4px 8px rgba(0,0,0,0.1);
+  --mxc-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.1);
+  --mxc-shadow-md: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --mxc-shadow-lg: 0 4px 8px rgba(0, 0, 0, 0.1);
 
   /* Chips */
   --mxc-chip-bg: #e0e0e0;
@@ -26,7 +29,10 @@
   --mxc-chip-radius: 16px;
 }
 
+/* Dark theme */
+[data-theme="dark"],
 .dark {
+  color-scheme: dark;
   --mxc-bg: #161616;
   --mxc-fg: #f4f4f4;
   --mxc-topbar-bg: #393939;
@@ -38,4 +44,22 @@
   --mxc-border: #525252;
   --mxc-chip-bg: #393939;
   --mxc-chip-fg: #f4f4f4;
+}
+
+/* Respect system preference unless explicitly set */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    color-scheme: dark;
+    --mxc-bg: #161616;
+    --mxc-fg: #f4f4f4;
+    --mxc-topbar-bg: #393939;
+    --mxc-topbar-fg: #f4f4f4;
+    --mxc-nav-bg: #262626;
+    --mxc-nav-fg: #f4f4f4;
+    --mxc-drawer-bg: #393939;
+    --mxc-drawer-fg: #f4f4f4;
+    --mxc-border: #525252;
+    --mxc-chip-bg: #393939;
+    --mxc-chip-fg: #f4f4f4;
+  }
 }


### PR DESCRIPTION
## Summary
- add dark/light theme toggle honoring prefers-color-scheme
- improve keyboard navigation and focus outlines
- add missing ARIA labels to buttons and tables

## Testing
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a2e880953c8322b085311898322009