### PR TITLE
feat(api): add propose endpoint and provenance

### DIFF
--- a/tests/test_service_blueprints.py
+++ b/tests/test_service_blueprints.py
@@ -1,4 +1,5 @@
 import io
+
 import pandas as pd
 
 from loto.models import RulePack
@@ -6,22 +7,30 @@ from loto.service.blueprints import plan_and_evaluate
 
 
 def test_plan_and_evaluate_deterministic():
-    line_df = pd.DataFrame([
-        {"domain": "steam", "from_tag": "S", "to_tag": "V"},
-        {"domain": "steam", "from_tag": "V", "to_tag": "asset"},
-        {"domain": "steam", "from_tag": "asset", "to_tag": "D"},
-    ])
-    valve_df = pd.DataFrame([
-        {"domain": "steam", "tag": "V", "fail_state": "FC", "kind": "MV"},
-    ])
-    drain_df = pd.DataFrame([
-        {"domain": "steam", "tag": "D", "kind": "drain"},
-    ])
-    source_df = pd.DataFrame([
-        {"domain": "steam", "tag": "S", "kind": "source"},
-    ])
+    line_df = pd.DataFrame(
+        [
+            {"domain": "steam", "from_tag": "S", "to_tag": "V"},
+            {"domain": "steam", "from_tag": "V", "to_tag": "asset"},
+            {"domain": "steam", "from_tag": "asset", "to_tag": "D"},
+        ]
+    )
+    valve_df = pd.DataFrame(
+        [
+            {"domain": "steam", "tag": "V", "fail_state": "FC", "kind": "MV"},
+        ]
+    )
+    drain_df = pd.DataFrame(
+        [
+            {"domain": "steam", "tag": "D", "kind": "drain"},
+        ]
+    )
+    source_df = pd.DataFrame(
+        [
+            {"domain": "steam", "tag": "S", "kind": "source"},
+        ]
+    )
 
-    plan, report, impact = plan_and_evaluate(
+    plan, report, impact, prov = plan_and_evaluate(
         io.StringIO(line_df.to_csv(index=False)),
         io.StringIO(valve_df.to_csv(index=False)),
         io.StringIO(drain_df.to_csv(index=False)),
@@ -39,3 +48,5 @@ def test_plan_and_evaluate_deterministic():
     assert impact.unavailable_assets == {"asset"}
     assert impact.unit_mw_delta == {"U1": 5.0}
     assert impact.area_mw_delta == {"Area1": 5.0}
+    assert prov.seed is None
+    assert len(prov.rule_hash) == 64


### PR DESCRIPTION
## Summary
- add /propose API endpoint to diff proposed plans/schedules against current targets and assignments
- return deterministic provenance (seed and rule hash) from blueprint service
- cover provenance in existing blueprint service tests

## Testing
- `pre-commit run --files apps/api/main.py loto/service/blueprints.py tests/test_service_blueprints.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a2ebf78d388322874e0db82bb636fb