### PR TITLE
Add PID overlay service

### DIFF
--- a/loto/pid/__init__.py
+++ b/loto/pid/__init__.py
@@ -1,0 +1,5 @@
+"""PID overlay utilities."""
+
+from .overlay import build_overlay
+
+__all__ = ["build_overlay"]

--- a/loto/pid/overlay.py
+++ b/loto/pid/overlay.py
@@ -1,0 +1,107 @@
+"""Generate overlay payloads for process diagrams.
+
+This module translates isolation planner and simulation outputs into a
+structure understood by the front-end overlay system.  It maps graph node
+identifiers to CSS selectors using a ``pid_map.yaml`` file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List, Set
+
+import yaml
+
+from ..models import IsolationPlan
+
+
+def _load_map(map_path: Path) -> Dict[str, List[str]]:
+    """Return mapping from component tags to CSS selectors."""
+
+    with map_path.open("r") as fh:
+        raw = yaml.safe_load(fh) or {}
+
+    mapping: Dict[str, List[str]] = {}
+    for tag, selector in raw.items():
+        if isinstance(selector, str):
+            mapping[tag] = [selector]
+        elif isinstance(selector, Iterable):
+            mapping[tag] = [s for s in selector if isinstance(s, str)]
+    return mapping
+
+
+def _selectors(tag: str, mapping: Dict[str, List[str]]) -> List[str]:
+    return list(mapping.get(tag, []))
+
+
+def _selectors_from_path(
+    path: Iterable[str], mapping: Dict[str, List[str]]
+) -> List[str]:
+    selectors: List[str] = []
+    for node in path:
+        selectors.extend(_selectors(node, mapping))
+    return selectors
+
+
+def build_overlay(
+    sources: Iterable[str],
+    asset: str,
+    plan: IsolationPlan,
+    sim_fail_paths: List[Iterable[str]],
+    map_path: str | Path = "pid_map.yaml",
+) -> Dict[str, object]:
+    """Build overlay payload.
+
+    Parameters
+    ----------
+    sources:
+        Iterable of energy source tags.
+    asset:
+        Tag of the asset under isolation.
+    plan:
+        Isolation plan produced by the planner.
+    sim_fail_paths:
+        Paths that still allow energy flow after simulation.
+    map_path:
+        Location of ``pid_map.yaml`` mapping tags to CSS selectors.
+    """
+
+    mapping = _load_map(Path(map_path))
+
+    highlight: Set[str] = set()
+    badges: List[Dict[str, str]] = []
+    paths: List[Dict[str, object]] = []
+
+    # Asset badge
+    for sel in _selectors(asset, mapping):
+        highlight.add(sel)
+        badges.append({"selector": sel, "type": "asset"})
+
+    # Source badges
+    for src in sources:
+        for sel in _selectors(src, mapping):
+            highlight.add(sel)
+            badges.append({"selector": sel, "type": "source"})
+
+    # Isolation actions highlight
+    for action in plan.actions:
+        try:
+            edge = action.component_id.split(":", 1)[1]
+            u, v = edge.split("->")
+        except ValueError:
+            continue
+        for tag in (u, v):
+            highlight.update(_selectors(tag, mapping))
+
+    # Simulation failing paths
+    for idx, path_nodes in enumerate(sim_fail_paths):
+        selectors = _selectors_from_path(path_nodes, mapping)
+        if selectors:
+            paths.append({"id": f"path{idx}", "selectors": selectors})
+            highlight.update(selectors)
+
+    return {
+        "highlight": sorted(highlight),
+        "badges": badges,
+        "paths": paths,
+    }

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,0 +1,44 @@
+from loto.models import IsolationAction, IsolationPlan
+from loto.pid import build_overlay
+
+
+def test_overlay_highlights_isolations_and_sim_fail(tmp_path):
+    pid_map = tmp_path / "pid_map.yaml"
+    pid_map.write_text(
+        "\n".join(
+            [
+                "V-201A: '#V201A'",
+                "V-201B: '#V201B'",
+                "BL-201: '#BL201'",
+                "A-201: '#A201'",
+                "src: '#SRC'",
+            ]
+        )
+    )
+
+    plan = IsolationPlan(
+        plan_id="p1",
+        actions=[
+            IsolationAction(component_id="process:src->V-201A", method="lock"),
+            IsolationAction(component_id="process:src->V-201B", method="lock"),
+            IsolationAction(component_id="process:src->BL-201", method="lock"),
+        ],
+    )
+
+    overlay = build_overlay(
+        sources=["src"],
+        asset="A-201",
+        plan=plan,
+        sim_fail_paths=[["src", "V-201A", "A-201"]],
+        map_path=pid_map,
+    )
+
+    highlights = overlay["highlight"]
+    assert "#V201A" in highlights
+    assert "#V201B" in highlights
+    assert "#BL201" in highlights
+
+    path0 = overlay["paths"][0]
+    assert path0["id"] == "path0"
+    assert "#V201A" in path0["selectors"]
+    assert "#V201A" in highlights


### PR DESCRIPTION
## Summary
- map engine output to P&ID overlay payload
- include path highlighting for simulation failures

## Testing
- `pre-commit run --files loto/pid/__init__.py loto/pid/overlay.py tests/test_overlay.py`
- `pytest tests/test_overlay.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2ef85432c832299293db3ae58f686