### PR TITLE
Add PID registry schema and demo tag map

### DIFF
--- a/demo/pids/pid_map.yaml
+++ b/demo/pids/pid_map.yaml
@@ -1,0 +1,7 @@
+# Mapping of P&ID tags to CSS selectors used by overlay utilities.
+V-101: '#V101'
+V-102:
+  - '#V102A'
+  - '#V102B'
+A-100: '#A100'
+src: '#SRC'

--- a/loto/pid/registry.py
+++ b/loto/pid/registry.py
@@ -1,0 +1,48 @@
+"""Schema for P&ID registry definitions.
+
+This module defines light-weight Pydantic models describing available process
+and instrumentation diagrams (P&IDs).  A registry associates a unique
+identifier with the SVG document and corresponding tag map used by
+:func:`loto.pid.overlay.build_overlay`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class PidEntry(BaseModel):
+    """Metadata for a single P&ID document."""
+
+    svg: Path = Field(..., description="Path to the SVG document")
+    tag_map: Path = Field(..., description="Path to YAML map of tags to CSS selectors")
+    description: str | None = Field(
+        None, description="Optional human readable description"
+    )
+
+    class Config:
+        extra = "forbid"
+
+
+class PidRegistry(BaseModel):
+    """Registry of available P&ID documents."""
+
+    pids: Dict[str, PidEntry] = Field(
+        default_factory=dict,
+        description="Mapping of PID identifier to registry entry",
+    )
+
+    class Config:
+        extra = "forbid"
+
+
+def load_registry(path: str | Path) -> PidRegistry:
+    """Load a :class:`PidRegistry` from a YAML file."""
+
+    with Path(path).open("r") as fh:
+        data = yaml.safe_load(fh) or {}
+    return PidRegistry(**data)


### PR DESCRIPTION
## Summary
- define PidEntry and PidRegistry models with loader for P&ID metadata
- include demo tag map YAML for overlay examples

## Testing
- `pre-commit run --files loto/pid/registry.py demo/pids/pid_map.yaml`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a2f73ea39c8322b9cc42416db65afa