### PR TITLE
feat: add PID overlay utilities

### DIFF
--- a/apps/maximo-extension-ui/src/lib/pidOverlay.test.ts
+++ b/apps/maximo-extension-ui/src/lib/pidOverlay.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { applyPidOverlay, type Overlay } from './pidOverlay';
+
+function createSvg(ids: string[]): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  ids.forEach((id) => {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    el.setAttribute('id', id);
+    svg.appendChild(el);
+  });
+  return svg;
+}
+
+describe('applyPidOverlay', () => {
+  it('highlights elements and adds badges', () => {
+    const svg = createSvg(['a', 'b']);
+    const overlay: Overlay = {
+      highlight: ['#a', '#b'],
+      badges: [
+        { selector: '#a', type: 'asset' },
+        { selector: '#b', type: 'source' }
+      ],
+      paths: []
+    };
+
+    applyPidOverlay(svg, overlay);
+
+    const a = svg.querySelector('#a')!;
+    const b = svg.querySelector('#b')!;
+    expect(a.classList.contains('hl-primary')).toBe(true);
+    expect(b.classList.contains('hl-primary')).toBe(true);
+
+    const badges = Array.from(svg.querySelectorAll('.pid-badge'));
+    expect(badges).toHaveLength(2);
+    expect(badges[0].textContent).toBe('asset');
+    expect(badges[1].textContent).toBe('source');
+  });
+});

--- a/apps/maximo-extension-ui/src/lib/pidOverlay.ts
+++ b/apps/maximo-extension-ui/src/lib/pidOverlay.ts
@@ -1,0 +1,59 @@
+export interface Badge {
+  selector: string;
+  type: string;
+}
+
+export interface OverlayPath {
+  id: string;
+  selectors: string[];
+}
+
+export interface Overlay {
+  highlight: string[];
+  badges: Badge[];
+  paths: OverlayPath[];
+}
+
+/**
+ * Apply overlay information to an SVG diagram.
+ *
+ * Elements matching selectors in `highlight` receive the `hl-primary` class.
+ * Badges are rendered near their target elements using SVG `foreignObject`
+ * elements so that HTML can be positioned relative to the graphic.
+ */
+export function applyPidOverlay(svg: SVGSVGElement, overlay: Overlay): void {
+  overlay.highlight.forEach((selector) => {
+    svg.querySelectorAll<SVGElement>(selector).forEach((el) => {
+      el.classList.add('hl-primary');
+    });
+  });
+
+  const badgeLayer = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  badgeLayer.setAttribute('data-badge-layer', '');
+  svg.appendChild(badgeLayer);
+
+  overlay.badges.forEach((badge) => {
+    const target = svg.querySelector<SVGGraphicsElement>(badge.selector);
+    if (!target) return;
+
+    let bbox: DOMRect | { x: number; y: number; width: number; height: number };
+    try {
+      bbox = target.getBBox();
+    } catch {
+      bbox = { x: 0, y: 0, width: 0, height: 0 };
+    }
+
+    const fo = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject');
+    fo.setAttribute('x', String(bbox.x));
+    fo.setAttribute('y', String(bbox.y));
+    fo.setAttribute('width', String(bbox.width));
+    fo.setAttribute('height', String(bbox.height));
+
+    const div = document.createElement('div');
+    div.className = 'pid-badge';
+    div.textContent = badge.type;
+    fo.appendChild(div);
+
+    badgeLayer.appendChild(fo);
+  });
+}


### PR DESCRIPTION
## Summary
- implement PID overlay adapter that applies highlight classes and renders SVG badge markers
- cover overlay behavior with unit tests

## Testing
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `pre-commit run --files apps/maximo-extension-ui/src/lib/pidOverlay.ts apps/maximo-extension-ui/src/lib/pidOverlay.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a2f98b9e808322a037b0938fb63e6a