### PR TITLE
Add PidViewer component with pan and zoom

### DIFF
--- a/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
@@ -1,0 +1,28 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi, test, expect } from 'vitest';
+import PidViewer from './PidViewer';
+
+test('toggles highlight classes', async () => {
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>';
+  vi.spyOn(global, 'fetch').mockResolvedValue({
+    text: () => Promise.resolve(svg)
+  } as any);
+
+  const { container, rerender } = render(
+    <PidViewer src="/test.svg" highlight="primary" />
+  );
+
+  await waitFor(() => {
+    const svgEl = container.querySelector('svg');
+    expect(svgEl).toBeTruthy();
+    expect(svgEl!.classList.contains('hl-primary')).toBe(true);
+  });
+
+  rerender(<PidViewer src="/test.svg" highlight="warning" />);
+  await waitFor(() => {
+    const svgEl = container.querySelector('svg');
+    expect(svgEl!.classList.contains('hl-warning')).toBe(true);
+  });
+
+  (fetch as any).mockRestore();
+});

--- a/apps/maximo-extension-ui/src/components/PidViewer.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useRef, useState } from 'react';
+import '../styles/pid.css';
+
+type Highlight = 'primary' | 'warning' | null;
+
+interface PidViewerProps {
+  src: string;
+  highlight?: Highlight;
+}
+
+export default function PidViewer({ src, highlight = null }: PidViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const svgContainerRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const [scale, setScale] = useState(1);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const dragging = useRef(false);
+  const dragStart = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    fetch(src)
+      .then((r) => r.text())
+      .then((txt) => {
+        if (svgContainerRef.current) {
+          svgContainerRef.current.innerHTML = txt;
+          svgRef.current = svgContainerRef.current.querySelector('svg');
+          applyHighlight();
+          fitToScreen();
+        }
+      });
+  }, [src]);
+
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    svg.style.transform = `translate(${translate.x}px, ${translate.y}px) scale(${scale})`;
+    svg.style.transformOrigin = '0 0';
+  }, [scale, translate]);
+
+  useEffect(() => {
+    applyHighlight();
+  }, [highlight]);
+
+  function applyHighlight() {
+    const svg = svgRef.current;
+    if (!svg) return;
+    svg.classList.remove('hl-primary', 'hl-warning');
+    if (highlight === 'primary') svg.classList.add('hl-primary');
+    if (highlight === 'warning') svg.classList.add('hl-warning');
+  }
+
+  function fitToScreen() {
+    const container = containerRef.current;
+    const svg = svgRef.current;
+    if (!container || !svg) return;
+    const vb = svg.getAttribute('viewBox');
+    if (!vb) return;
+    const [x, y, w, h] = vb.split(' ').map(Number);
+    const scaleX = container.clientWidth / w;
+    const scaleY = container.clientHeight / h;
+    const s = Math.min(scaleX, scaleY);
+    setScale(s);
+    setTranslate({
+      x: -x * s + (container.clientWidth - w * s) / 2,
+      y: -y * s + (container.clientHeight - h * s) / 2
+    });
+  }
+
+  function resetView() {
+    setScale(1);
+    setTranslate({ x: 0, y: 0 });
+  }
+
+  function handleWheel(e: React.WheelEvent) {
+    e.preventDefault();
+    const container = containerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    const delta = -e.deltaY;
+    const zoomFactor = delta > 0 ? 1.1 : 0.9;
+    const newScale = Math.min(Math.max(scale * zoomFactor, 0.1), 10);
+    const scaleRatio = newScale / scale;
+    setScale(newScale);
+    setTranslate({
+      x: offsetX - scaleRatio * (offsetX - translate.x),
+      y: offsetY - scaleRatio * (offsetY - translate.y)
+    });
+  }
+
+  function startDrag(e: React.MouseEvent) {
+    dragging.current = true;
+    dragStart.current = { x: e.clientX - translate.x, y: e.clientY - translate.y };
+  }
+
+  function onDrag(e: React.MouseEvent) {
+    if (!dragging.current) return;
+    setTranslate({ x: e.clientX - dragStart.current.x, y: e.clientY - dragStart.current.y });
+  }
+
+  function endDrag() {
+    dragging.current = false;
+  }
+
+  function handleKey(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === '+' || e.key === '=') {
+      setScale((s) => Math.min(s * 1.1, 10));
+    } else if (e.key === '-') {
+      setScale((s) => Math.max(s * 0.9, 0.1));
+    }
+  }
+
+  return (
+    <div
+      className="pid-container relative w-full h-full"
+      tabIndex={0}
+      ref={containerRef}
+      onWheel={handleWheel}
+      onKeyDown={handleKey}
+      onMouseDown={startDrag}
+      onMouseMove={onDrag}
+      onMouseUp={endDrag}
+      onMouseLeave={endDrag}
+    >
+      <div ref={svgContainerRef} className="w-full h-full" />
+      <div className="controls absolute top-2 left-2 flex gap-2">
+        <button className="badge" onClick={fitToScreen} type="button">
+          Fit
+        </button>
+        <button className="badge" onClick={resetView} type="button">
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/stories/PidViewer.stories.tsx
+++ b/apps/maximo-extension-ui/src/stories/PidViewer.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import PidViewer from '../components/PidViewer';
+
+const meta: Meta<typeof PidViewer> = {
+  title: 'PidViewer',
+  component: PidViewer
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PidViewer>;
+
+export const Demo: Story = {
+  render: () => (
+    <div style={{ width: '400px', height: '300px' }}>
+      <PidViewer src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect x='10' y='10' width='80' height='80' fill='none' stroke='black'/%3E%3C/svg%3E" />
+    </div>
+  )
+};

--- a/apps/maximo-extension-ui/src/styles/pid.css
+++ b/apps/maximo-extension-ui/src/styles/pid.css
@@ -1,0 +1,27 @@
+.pid-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.pid-container:focus-visible {
+  outline: 2px solid var(--mxc-topbar-bg);
+  outline-offset: 2px;
+}
+
+.hl-primary {
+  stroke: var(--mxc-topbar-bg);
+  stroke-width: 2;
+}
+
+.hl-warning {
+  stroke: #fbbf24;
+  stroke-width: 2;
+}
+
+.badge {
+  background: var(--mxc-topbar-bg);
+  color: var(--mxc-topbar-fg);
+  padding: 2px 6px;
+  border-radius: var(--mxc-radius-sm);
+}


### PR DESCRIPTION
## Summary
- add PidViewer component to inline SVGs with pan, zoom, fit, and reset controls
- style SVG highlights with pid.css and expose storybook demo
- cover highlight class toggling with unit test

## Testing
- `pnpm install`
- `pre-commit run --files apps/maximo-extension-ui/src/components/PidViewer.tsx apps/maximo-extension-ui/src/styles/pid.css apps/maximo-extension-ui/src/stories/PidViewer.stories.tsx apps/maximo-extension-ui/src/components/PidViewer.test.tsx`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a2f97ad7bc8322941b74caf21cd25a