### PR TITLE
feat: add PID tab with overlay viewer

### DIFF
--- a/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import PidViewer from '../../../components/PidViewer';
+import { applyPidOverlay, type Overlay } from '../../../lib/pidOverlay';
+
+interface OverlayResponse extends Overlay {
+  drawingId: string;
+}
+
+async function fetchOverlay(wo: string): Promise<OverlayResponse> {
+  const res = await fetch(`/pid/overlay?wo=${wo}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch overlay');
+  }
+  return res.json();
+}
+
+export default function PidTab({ wo }: { wo: string }) {
+  const { data } = useQuery({ queryKey: ['pid', wo], queryFn: () => fetchOverlay(wo) });
+  const [showSimFails, setShowSimFails] = useState(false);
+  const [showSourcePath, setShowSourcePath] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!data || !containerRef.current) return;
+    const svg = containerRef.current.querySelector('svg');
+    if (!svg) return;
+
+    svg.querySelectorAll('.hl-primary').forEach((el) => el.classList.remove('hl-primary'));
+    svg.querySelectorAll('[data-badge-layer]').forEach((el) => el.remove());
+
+    const highlight = [...data.highlight];
+    const sourcePath = data.paths[0]?.selectors ?? [];
+    const simFailSelectors = data.paths.slice(1).flatMap((p) => p.selectors);
+    if (showSourcePath) highlight.push(...sourcePath);
+    if (showSimFails) highlight.push(...simFailSelectors);
+
+    applyPidOverlay(svg as unknown as SVGSVGElement, {
+      highlight,
+      badges: data.badges,
+      paths: []
+    });
+  }, [data, showSimFails, showSourcePath]);
+
+  if (!data) return null;
+
+  const src = `/pid/${data.drawingId}/svg`;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mb-2 flex gap-4">
+        <label>
+          <input
+            type="checkbox"
+            checked={showSimFails}
+            onChange={(e) => setShowSimFails(e.target.checked)}
+          />
+          {' '}Show sim fails
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showSourcePath}
+            onChange={(e) => setShowSourcePath(e.target.checked)}
+          />
+          {' '}Show sources→asset path
+        </label>
+      </div>
+      <div ref={containerRef} className="flex-1">
+        <PidViewer src={src} />
+      </div>
+    </div>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useWorkOrder, useBlueprint } from '../../../lib/hooks';
 import Exports from '../../../components/Exports';
 import CommitPanel from './CommitPanel';
+import PidTab from './PidTab';
 
 const tabs = ['Plan', 'P&ID', 'Simulation', 'Impact', 'Commit'];
 
@@ -62,26 +63,7 @@ function PlannerContent({ wo }: { wo: string }) {
               </tbody>
             </table>
           )}
-          {activeTab === 'P&ID' && (
-            <table className="min-w-full border border-[var(--mxc-border)]">
-              <thead className="bg-[var(--mxc-nav-bg)] text-left">
-                <tr>
-                  <th className="px-4 py-2">Step</th>
-                  <th className="px-4 py-2">Component</th>
-                  <th className="px-4 py-2">Method</th>
-                </tr>
-              </thead>
-              <tbody>
-                {plan.map((p, idx) => (
-                  <tr key={idx}>
-                    <td className="px-4 py-2">{idx + 1}</td>
-                    <td className="px-4 py-2">{p.component_id}</td>
-                    <td className="px-4 py-2">{p.method}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
+          {activeTab === 'P&ID' && <PidTab wo={wo} />}
           {activeTab === 'Simulation' && (
             <table className="min-w-full border border-[var(--mxc-border)]">
               <thead className="bg-[var(--mxc-nav-bg)] text-left">


### PR DESCRIPTION
## Summary
- add PidTab component to fetch PID SVG and overlay for a work order
- integrate PidTab into planner page with toggles for simulation fails and source→asset path

## Testing
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `pre-commit run --files apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68a2fdf2244c8322a6f21aabb01e775b