### PR TITLE
Add PDF provenance and PID accessibility

### DIFF
--- a/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
@@ -26,3 +26,21 @@ test('toggles highlight classes', async () => {
 
   (fetch as any).mockRestore();
 });
+
+test('adds aria-labels from title elements', async () => {
+  const svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="5" height="5"><title>Valve 1</title></rect></svg>';
+  vi.spyOn(global, 'fetch').mockResolvedValue({
+    text: () => Promise.resolve(svg)
+  } as any);
+
+  const { container } = render(<PidViewer src="/test.svg" />);
+
+  await waitFor(() => {
+    const rect = container.querySelector('rect');
+    expect(rect?.getAttribute('aria-label')).toBe('Valve 1');
+    expect(rect?.getAttribute('tabindex')).toBe('0');
+  });
+
+  (fetch as any).mockRestore();
+});

--- a/apps/maximo-extension-ui/src/components/PidViewer.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.tsx
@@ -24,6 +24,7 @@ export default function PidViewer({ src, highlight = null }: PidViewerProps) {
         if (svgContainerRef.current) {
           svgContainerRef.current.innerHTML = txt;
           svgRef.current = svgContainerRef.current.querySelector('svg');
+          enhanceAccessibility();
           applyHighlight();
           fitToScreen();
         }
@@ -47,6 +48,19 @@ export default function PidViewer({ src, highlight = null }: PidViewerProps) {
     svg.classList.remove('hl-primary', 'hl-warning');
     if (highlight === 'primary') svg.classList.add('hl-primary');
     if (highlight === 'warning') svg.classList.add('hl-warning');
+  }
+
+  function enhanceAccessibility() {
+    const svg = svgRef.current;
+    if (!svg) return;
+    svg.setAttribute('role', 'img');
+    svg.querySelectorAll('title').forEach((t) => {
+      const parent = t.parentElement;
+      if (parent && t.textContent) {
+        parent.setAttribute('aria-label', t.textContent);
+        parent.setAttribute('tabindex', '0');
+      }
+    });
   }
 
   function fitToScreen() {
@@ -131,6 +145,28 @@ export default function PidViewer({ src, highlight = null }: PidViewerProps) {
         <button className="badge" onClick={resetView} type="button">
           Reset
         </button>
+      </div>
+      <div
+        className="legend absolute bottom-2 left-2 text-xs bg-white bg-opacity-80 p-2 rounded shadow"
+        role="note"
+        aria-label="Legend"
+      >
+        <div className="flex items-center">
+          <span
+            aria-hidden="true"
+            className="mr-1 inline-block h-1 w-4"
+            style={{ background: 'var(--mxc-topbar-bg)' }}
+          />
+          Primary
+        </div>
+        <div className="flex items-center">
+          <span
+            aria-hidden="true"
+            className="mr-1 inline-block h-1 w-4"
+            style={{ background: '#fbbf24' }}
+          />
+          Warning
+        </div>
       </div>
     </div>
   );

--- a/loto/cli.py
+++ b/loto/cli.py
@@ -142,7 +142,7 @@ def main(argv: Optional[list[str]] = None) -> None:
     # Render outputs
     json_output = renderer.to_json(plan, sim_report)
     rule_hash = rule_engine.hash(rule_pack)
-    pdf_bytes = renderer.pdf(plan, sim_report, rule_hash)
+    pdf_bytes = renderer.pdf(plan, sim_report, rule_hash, seed=None, timezone="UTC")
 
     out_dir = Path(args.output)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_renderer_pdf.py
+++ b/tests/test_renderer_pdf.py
@@ -23,10 +23,13 @@ def test_pdf_contains_plan_id():
         total_time_s=1.0,
     )
 
-    pdf_bytes = Renderer().pdf(plan, sim, rule_hash="abc123")
+    pdf_bytes = Renderer().pdf(plan, sim, rule_hash="abc123", seed=42, timezone="UTC")
 
     assert pdf_bytes, "pdf() should return non-empty bytes"
 
     reader = PdfReader(io.BytesIO(pdf_bytes))
     text = "".join(page.extract_text() for page in reader.pages)
     assert plan.plan_id in text
+    assert "abc123" in text
+    assert "Seed: 42" in text
+    assert "Legend" in text


### PR DESCRIPTION
## Summary
- add legend and screen-reader labels to P&ID viewer
- stamp exported PDFs with seed, work order and timezone, plus legend and footnotes

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/components/PidViewer.tsx apps/maximo-extension-ui/src/components/PidViewer.test.tsx loto/renderer.py loto/cli.py tests/test_renderer_pdf.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a3018b3c908322b226fe82559c85bd