### PR TITLE
feat(pid): validate pid tag maps

### DIFF
--- a/loto/pid/schema.py
+++ b/loto/pid/schema.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+from pydantic import RootModel, ValidationError, field_validator, model_validator
+
+SELECTOR_RE = re.compile(r"^#?[A-Za-z0-9_.:-]+$")
+
+
+class TagSelectors(RootModel[List[str]]):
+    """List of CSS selectors for a single tag."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce(cls, value: object) -> List[str]:
+        if isinstance(value, str):
+            value = [value]
+        elif isinstance(value, list):
+            value = list(value)
+        else:
+            raise ValueError("selector must be string or list of strings")
+        if not value:
+            raise ValueError("selector must not be empty")
+        return value
+
+    @field_validator("root")
+    @classmethod
+    def _validate_selector(cls, selectors: List[str]) -> List[str]:
+        for selector in selectors:
+            if not SELECTOR_RE.fullmatch(selector):
+                raise ValueError("invalid selector")
+        return selectors
+
+
+class PidTagMap(RootModel[Dict[str, TagSelectors]]):
+    """Mapping of tag identifiers to CSS selectors."""
+
+
+class _TagMapLoader(yaml.SafeLoader):
+    """YAML loader that records line numbers and rejects duplicate keys."""
+
+    def __init__(self, stream) -> None:
+        super().__init__(stream)
+        self.tag_lines: Dict[str, int] = {}
+
+
+def _construct_mapping(loader: _TagMapLoader, node, deep=False):  # type: ignore[override]
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if not isinstance(key, str):
+            raise ValueError(
+                f"{loader.name}:{key_node.start_mark.line + 1}: tag must be a string"
+            )
+        if key in mapping:
+            raise ValueError(
+                f"{loader.name}:{key_node.start_mark.line + 1}: duplicate tag '{key}'"
+            )
+        loader.tag_lines[key] = value_node.start_mark.line + 1
+        value = loader.construct_object(value_node, deep=deep)
+        if not isinstance(value, (str, list)):
+            raise ValueError(
+                f"{loader.name}:{value_node.start_mark.line + 1}: selector must be string or list of strings"
+            )
+        mapping[key] = value
+    return mapping
+
+
+_TagMapLoader.add_constructor(  # type: ignore[attr-defined]
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping
+)
+
+
+def load_tag_map(path: str | Path) -> PidTagMap:
+    """Load and validate a tag map from ``path``."""
+
+    path = Path(path)
+    with path.open("r") as fh:
+        loader = _TagMapLoader(fh)
+        loader.name = str(path)
+        try:
+            data = loader.get_single_data() or {}
+        finally:
+            loader.dispose()
+        line_map = loader.tag_lines
+
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}:1: expected mapping of tags to selectors")
+
+    try:
+        return PidTagMap.model_validate(data)
+    except ValidationError as exc:  # pragma: no cover - re-raise with line info
+        err = exc.errors()[0]
+        loc = err.get("loc", ())
+        if loc:
+            tag = loc[0]
+            line = line_map.get(str(tag), 1)
+        else:
+            line = 1
+        raise ValueError(f"{path}:{line}: {err['msg']}") from None

--- a/tests/pid/test_schema.py
+++ b/tests/pid/test_schema.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import pytest
+
+from loto.pid.registry import load_registry
+from loto.pid.schema import load_tag_map
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    path = tmp_path / name
+    path.write_text(content)
+    return path
+
+
+def test_load_tag_map_valid(tmp_path: Path) -> None:
+    path = _write(tmp_path, "map.yaml", "T1: '#a'\nT2:\n  - '#b'\n")
+    tag_map = load_tag_map(path)
+    assert tag_map.model_dump() == {"T1": ["#a"], "T2": ["#b"]}
+
+
+def test_load_tag_map_duplicate_tag(tmp_path: Path) -> None:
+    path = _write(tmp_path, "map.yaml", "T1: '#a'\nT1: '#b'\n")
+    with pytest.raises(ValueError) as exc:
+        load_tag_map(path)
+    assert f"{path}:2" in str(exc.value)
+    assert "duplicate tag" in str(exc.value)
+
+
+def test_load_tag_map_empty_selector(tmp_path: Path) -> None:
+    path = _write(tmp_path, "map.yaml", "T1: ''\n")
+    with pytest.raises(ValueError) as exc:
+        load_tag_map(path)
+    assert f"{path}:1" in str(exc.value)
+    assert "selector" in str(exc.value)
+
+
+def test_load_tag_map_wrong_type(tmp_path: Path) -> None:
+    path = _write(tmp_path, "map.yaml", "T1: [1, 2]\n")
+    with pytest.raises(ValueError) as exc:
+        load_tag_map(path)
+    assert f"{path}:1" in str(exc.value)
+
+
+def test_load_registry_validates_tag_map(tmp_path: Path) -> None:
+    tag_map = _write(tmp_path, "map.yaml", "T1: '#a'\n")
+    registry = _write(
+        tmp_path,
+        "registry.yaml",
+        """
+        pids:
+          test:
+            svg: doc.svg
+            tag_map: map.yaml
+        """.strip(),
+    )
+    loaded = load_registry(registry)
+    assert loaded.pids["test"].tag_map == tag_map
+
+
+def test_load_registry_invalid_tag_map(tmp_path: Path) -> None:
+    tag_map = _write(tmp_path, "map.yaml", "T1: 123\n")
+    registry = _write(
+        tmp_path,
+        "registry.yaml",
+        """
+        pids:
+          test:
+            svg: doc.svg
+            tag_map: map.yaml
+        """.strip(),
+    )
+    with pytest.raises(ValueError) as exc:
+        load_registry(registry)
+    assert str(tag_map) in str(exc.value)


### PR DESCRIPTION
## Summary
- add schema and loader for PID tag maps, enforcing unique tags and selector patterns
- validate tag_map files when loading PID registry
- test registry and tag map validation for good and bad inputs

## Testing
- `pre-commit run --files loto/pid/schema.py loto/pid/registry.py tests/pid/test_schema.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a3766ddbc88322bf2d3e4d954e05dc