### PR TITLE
Handle unknown PID tags and dedupe overlay selectors

### DIFF
--- a/apps/maximo-extension-ui/src/lib/pidOverlay.ts
+++ b/apps/maximo-extension-ui/src/lib/pidOverlay.ts
@@ -14,6 +14,10 @@ export interface Overlay {
   paths: OverlayPath[];
 }
 
+function uniq(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
 /**
  * Apply overlay information to an SVG diagram.
  *
@@ -22,7 +26,13 @@ export interface Overlay {
  * elements so that HTML can be positioned relative to the graphic.
  */
 export function applyPidOverlay(svg: SVGSVGElement, overlay: Overlay): void {
-  overlay.highlight.forEach((selector) => {
+  const highlight = uniq(overlay.highlight);
+  overlay.paths = overlay.paths.map((p) => ({
+    ...p,
+    selectors: uniq(p.selectors),
+  }));
+
+  highlight.forEach((selector) => {
     svg.querySelectorAll<SVGElement>(selector).forEach((el) => {
       el.classList.add('hl-primary');
     });

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -42,3 +42,39 @@ def test_overlay_highlights_isolations_and_sim_fail(tmp_path):
     assert path0["id"] == "path0"
     assert "#V201A" in path0["selectors"]
     assert "#V201A" in highlights
+
+
+def test_overlay_dedup_and_warnings(tmp_path):
+    pid_map = tmp_path / "pid_map.yaml"
+    pid_map.write_text(
+        "\n".join(
+            [
+                "V-201A: '#DUP'",
+                "V-201B: '#DUP'",
+                "A-201: '#A201'",
+                "src: '#SRC'",
+            ]
+        )
+    )
+
+    plan = IsolationPlan(
+        plan_id="p2",
+        actions=[
+            IsolationAction(component_id="process:src->V-201A", method="lock"),
+            IsolationAction(component_id="process:src->V-201B", method="lock"),
+            IsolationAction(component_id="process:src->MISSING", method="lock"),
+        ],
+    )
+
+    overlay = build_overlay(
+        sources=["src", "UNKNOWN_SRC"],
+        asset="A-201",
+        plan=plan,
+        sim_fail_paths=[["src", "V-201A", "V-201B", "A-201", "UNKNOWN"]],
+        map_path=pid_map,
+    )
+
+    assert overlay["highlight"].count("#DUP") == 1
+    path0 = overlay["paths"][0]
+    assert path0["selectors"].count("#DUP") == 1
+    assert {"selector": "#A201", "type": "warning"} in overlay["badges"]


### PR DESCRIPTION
## Summary
- Deduplicate PID overlay selectors and handle missing mappings
- Clean overlay selectors on the client before applying highlights
- Add regression tests for selector deduplication and warning badges

## Testing
- `pre-commit run --files loto/pid/overlay.py apps/maximo-extension-ui/src/lib/pidOverlay.ts tests/test_overlay.py`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a37be66500832280b04be86d8a02f3