### PR TITLE
feat(pid): cache maps and svg existence

### DIFF
--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,5 +1,6 @@
 from loto.models import IsolationAction, IsolationPlan
 from loto.pid import build_overlay
+from loto.pid import overlay as overlay_mod
 
 
 def test_overlay_highlights_isolations_and_sim_fail(tmp_path):
@@ -42,3 +43,30 @@ def test_overlay_highlights_isolations_and_sim_fail(tmp_path):
     assert path0["id"] == "path0"
     assert "#V201A" in path0["selectors"]
     assert "#V201A" in highlights
+
+
+def test_overlay_map_cached(tmp_path):
+    pid_map = tmp_path / "pid_map.yaml"
+    pid_map.write_text("A-201: '#A201'\n")
+
+    plan = IsolationPlan(plan_id="p1", actions=[])
+
+    overlay_mod._load_map_cached.cache_clear()
+    overlay_mod._MAP_PARSES = 0
+
+    build_overlay(
+        sources=[],
+        asset="A-201",
+        plan=plan,
+        sim_fail_paths=[],
+        map_path=pid_map,
+    )
+    build_overlay(
+        sources=[],
+        asset="A-201",
+        plan=plan,
+        sim_fail_paths=[],
+        map_path=pid_map,
+    )
+
+    assert overlay_mod._MAP_PARSES == 1


### PR DESCRIPTION
## Summary
- cache P&ID registry files keyed by path mtime
- cache overlay tag map parsing and track parse count
- cache SVG existence checks in PID endpoints
- test overlay map caching

## Testing
- `pre-commit run --files apps/api/pid_endpoints.py loto/pid/overlay.py loto/pid/registry.py tests/test_overlay.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68a37c0076cc8322b92fd8a1211070d9