### PR TITLE
Add SVG selector validation for P&ID overlays

### DIFF
--- a/apps/api/pid_endpoints.py
+++ b/apps/api/pid_endpoints.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 
 from loto.models import IsolationPlan
 from loto.pid import build_overlay
+from loto.pid.validator import validate_svg_map
 
 router = APIRouter(prefix="/pid", tags=["pid"])
 
@@ -54,6 +55,7 @@ class OverlayResponse(BaseModel):
     highlight: List[str] = Field(default_factory=list)
     badges: List[OverlayBadge] = Field(default_factory=list)
     paths: List[OverlayPath] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
 
     class Config:
         extra = "forbid"
@@ -74,8 +76,16 @@ async def get_pid_svg(drawing_id: str) -> StreamingResponse:
 async def post_overlay(payload: OverlayRequest) -> OverlayResponse:
     """Return overlay JSON for a work order, plan, and simulation results."""
 
+    pid_map = dict(payload.pid_map)
+    svg_obj = pid_map.pop("__svg__", None)
+    svg_path_raw: str | None
+    if isinstance(svg_obj, str):
+        svg_path_raw = svg_obj
+    else:
+        svg_path_raw = None
+
     with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as fh:
-        yaml.safe_dump(payload.pid_map, fh)
+        yaml.safe_dump(pid_map, fh)
         map_path = Path(fh.name)
     try:
         data = build_overlay(
@@ -85,7 +95,15 @@ async def post_overlay(payload: OverlayRequest) -> OverlayResponse:
             sim_fail_paths=cast(List[Iterable[str]], payload.sim_fail_paths),
             map_path=map_path,
         )
+        warnings: List[str] = []
+        if svg_path_raw:
+            svg_path = Path(svg_path_raw)
+            if not svg_path.is_absolute():
+                base = Path(__file__).resolve().parents[2]
+                svg_path = base / svg_path
+            report = validate_svg_map(svg_path, map_path)
+            warnings = report.missing_selectors
     finally:
         map_path.unlink(missing_ok=True)
 
-    return OverlayResponse(**data)
+    return OverlayResponse(**data, warnings=warnings)

--- a/loto/pid/validator.py
+++ b/loto/pid/validator.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Mapping, Set
+
+from .schema import load_tag_map
+
+
+@dataclass
+class ValidationReport:
+    """Report from validating selectors against an SVG document."""
+
+    missing_selectors: List[str]
+
+
+def _flatten_selectors(mapping: Mapping[str, Iterable[str]]) -> Set[str]:
+    selectors: Set[str] = set()
+    for values in mapping.values():
+        selectors.update(values)
+    return selectors
+
+
+def validate_svg_map(svg_path: str | Path, map_path: str | Path) -> ValidationReport:
+    """Validate selectors in ``map_path`` exist in the SVG at ``svg_path``."""
+
+    svg_path = Path(svg_path)
+    map_path = Path(map_path)
+
+    raw_map = load_tag_map(map_path).root
+    tag_map: dict[str, List[str]] = {k: list(v.root) for k, v in raw_map.items()}
+    selectors = _flatten_selectors(tag_map)
+
+    try:
+        root = ET.parse(svg_path).getroot()
+    except FileNotFoundError:
+        return ValidationReport(sorted(selectors))
+
+    missing: List[str] = []
+    for sel in selectors:
+        if sel.startswith("#"):
+            if root.find(f".//*[@id='{sel[1:]}']") is None:
+                missing.append(sel)
+        elif sel.startswith("."):
+            class_name = sel[1:]
+            found = False
+            for elem in root.findall(".//*[@class]"):
+                classes = elem.get("class", "").split()
+                if class_name in classes:
+                    found = True
+                    break
+            if not found:
+                missing.append(sel)
+        else:
+            if not root.findall(f".//{sel}"):
+                missing.append(sel)
+
+    return ValidationReport(sorted(missing))

--- a/tests/pid/test_validator.py
+++ b/tests/pid/test_validator.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from loto.pid.validator import validate_svg_map
+
+
+def _write_svg(path: Path) -> Path:
+    svg_path = path / "doc.svg"
+    svg_path.write_text(
+        "<svg xmlns='http://www.w3.org/2000/svg'>\n"
+        "        <rect id='a'/>\n"
+        "        <circle class='foo bar'/>\n"
+        "        </svg>"
+    )
+    return svg_path
+
+
+def _write_map(path: Path) -> Path:
+    map_path = path / "map.yaml"
+    map_path.write_text(
+        "\n".join(
+            [
+                "T1: '#a'",
+                "T2: '.foo'",
+                "T3: '#missing'",
+                "T4: '.missing'",
+            ]
+        )
+    )
+    return map_path
+
+
+def test_validate_svg_map_reports_missing(tmp_path: Path) -> None:
+    svg = _write_svg(tmp_path)
+    mapping = _write_map(tmp_path)
+    report = validate_svg_map(svg, mapping)
+    assert report.missing_selectors == ["#missing", ".missing"]


### PR DESCRIPTION
## Summary
- validate PID map selectors against an SVG document
- expose selector warnings from `/pid/overlay`
- test selector validation logic

## Testing
- `pre-commit run --files loto/pid/validator.py apps/api/pid_endpoints.py tests/pid/test_validator.py`
- `make lint`
- `make typecheck`
- `make test` *(fails: 23 errors during collection)*
- `pytest tests/pid/test_validator.py`


------
https://chatgpt.com/codex/tasks/task_b_68a37ba931948322bd3097d94f1f13f7