### PR TITLE
Stamp PDF metadata and support A3 P&ID export

### DIFF
--- a/apps/maximo-extension-ui/src/components/Exports.tsx
+++ b/apps/maximo-extension-ui/src/components/Exports.tsx
@@ -40,6 +40,27 @@ export default function Exports({ wo }: ExportProps) {
     URL.revokeObjectURL(url);
   }
 
+  async function handlePidA3() {
+    const res = await fetch('/pid/pdf', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/pdf'
+      },
+      body: JSON.stringify({ workorder_id: wo })
+    });
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `WO-${wo}_pid_a3.pdf`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <div className="mb-4 flex items-center space-x-2">
       <Button aria-label="Export PDF" onClick={() => handleExport('pdf')}>
@@ -53,6 +74,9 @@ export default function Exports({ wo }: ExportProps) {
         onClick={() => exportPid(`WO-${wo}_pid.pdf`)}
       >
         Export P&ID
+      </Button>
+      <Button aria-label="Export P&ID (A3)" onClick={handlePidA3}>
+        Export P&ID (A3)
       </Button>
       {hash && <span>Hash: {hash}</span>}
       {seed && <span>Seed: {seed}</span>}

--- a/loto/renderer.py
+++ b/loto/renderer.py
@@ -13,8 +13,10 @@ serialize plan data to JSON.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import datetime
 from io import BytesIO
 from typing import Any, Dict
+from zoneinfo import ZoneInfo
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
@@ -81,11 +83,18 @@ class Renderer:
             Paragraph(f"Seed: {seed if seed is not None else 'N/A'}", styles["Normal"])
         )
         story.append(Paragraph(f"Timezone: {timezone}", styles["Normal"]))
+        timestamp = datetime.now(ZoneInfo(timezone))
+        story.append(
+            Paragraph(
+                f"Generated: {timestamp.strftime('%Y-%m-%d %H:%M %Z')}",
+                styles["Normal"],
+            )
+        )
         story.append(Spacer(1, 12))
         story.append(Paragraph("Legend", styles["Heading2"]))
         story.append(
             Paragraph(
-                "Because footnotes explain why each isolation is required."
+                "Because… footnotes explain why each isolation is required."
                 " 'DDBB' denotes double block and bleed.",
                 styles["Normal"],
             )

--- a/tests/test_renderer_pdf.py
+++ b/tests/test_renderer_pdf.py
@@ -23,13 +23,16 @@ def test_pdf_contains_plan_id():
         total_time_s=1.0,
     )
 
-    pdf_bytes = Renderer().pdf(plan, sim, rule_hash="abc123", seed=42, timezone="UTC")
+    pdf_bytes = Renderer().pdf(
+        plan, sim, rule_hash="abc123", seed=42, timezone="Pacific/Auckland"
+    )
 
     assert pdf_bytes, "pdf() should return non-empty bytes"
 
     reader = PdfReader(io.BytesIO(pdf_bytes))
     text = "".join(page.extract_text() for page in reader.pages)
-    assert plan.plan_id in text
-    assert "abc123" in text
+    assert "Work Order ID: plan-123" in text
+    assert "Rule Pack Hash: abc123" in text
     assert "Seed: 42" in text
-    assert "Legend" in text
+    assert "Timezone: Pacific/Auckland" in text
+    assert "Because" in text


### PR DESCRIPTION
## Summary
- stamp work order, rule hash, seed, timezone and generation time onto PDFs and include a "Because…" legend
- allow frontend to request deterministic A3 P&ID PDF from backend
- verify PDF metadata via PyPDF2 tests

## Testing
- `pre-commit run --files loto/renderer.py apps/maximo-extension-ui/src/components/Exports.tsx tests/test_renderer_pdf.py`
- `pnpm -F maximo-extension-ui test`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a37c1d986c8322b97584f23a049c8e