### PR TITLE
Add Monte Carlo bands simulation

### DIFF
--- a/loto/scheduling/__init__.py
+++ b/loto/scheduling/__init__.py
@@ -1,0 +1,7 @@
+"""Scheduling utilities package."""
+
+from .des_engine import RunResult, Task, run
+from .monte import BandResult, bands
+from .monte_carlo import simulate
+
+__all__ = ["Task", "RunResult", "run", "simulate", "bands", "BandResult"]

--- a/loto/scheduling/monte.py
+++ b/loto/scheduling/monte.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Sequence, Tuple
+
+from .des_engine import Task, run
+from .objective import integrate_cost
+
+Point = Tuple[float, float]
+
+
+@dataclass
+class BandResult:
+    """Summary statistics from Monte Carlo schedule sampling."""
+
+    finish_times: Dict[str, float]
+    expected_cost: float
+
+
+def _wrap_duration(duration: Any) -> Any:
+    """Return a duration callable for ``run`` from ``duration`` spec.
+
+    ``duration`` may be a constant, a callable already compatible with
+    :func:`~loto.scheduling.des_engine.run` or a ``(mean, sigma)`` tuple which
+    is interpreted as a normal distribution rounded to the nearest integer.
+    """
+
+    if isinstance(duration, tuple) and len(duration) == 2:
+        mean, sigma = duration
+
+        def sampler(rng: random.Random, mean=mean, sigma=sigma) -> float:
+            return max(0.0, rng.normalvariate(mean, sigma))
+
+        return sampler
+    return duration
+
+
+def _percentiles(samples: Sequence[float]) -> Dict[str, float]:
+    values = sorted(samples)
+    if not values:
+        return {"P10": 0.0, "P50": 0.0, "P90": 0.0}
+
+    def pct(p: float) -> float:
+        k = (len(values) - 1) * p
+        f = math.floor(k)
+        c = math.ceil(k)
+        if f == c:
+            return float(values[int(k)])
+        return float(values[f] + (values[c] - values[f]) * (k - f))
+
+    return {"P10": pct(0.10), "P50": pct(0.50), "P90": pct(0.90)}
+
+
+def bands(
+    tasks: Mapping[str, Task],
+    resource_caps: Mapping[str, int],
+    runs: int,
+    price_curve: Sequence[Point],
+    state: Mapping[str, object] | None = None,
+    seed: int = 0,
+) -> BandResult:
+    """Run Monte Carlo samples and return finish time bands and expected cost."""
+
+    wrapped: Dict[str, Task] = {
+        tid: Task(
+            duration=_wrap_duration(task.duration),
+            predecessors=task.predecessors,
+            resources=task.resources,
+            calendar=task.calendar,
+            gate=task.gate,
+        )
+        for tid, task in tasks.items()
+    }
+
+    makespans: list[float] = []
+    costs: list[float] = []
+    for i in range(runs):
+        result = run(wrapped, resource_caps, state=state, seed=seed + i)
+        makespan = max(result.ends.values()) if result.ends else 0
+        makespans.append(float(makespan))
+        curve = [(0.0, 1.0), (float(makespan), 1.0)]
+        costs.append(integrate_cost(curve, price_curve))
+
+    finish = _percentiles(makespans)
+    expected_cost = sum(costs) / len(costs) if costs else 0.0
+    return BandResult(finish, expected_cost)

--- a/tests/test_objective.py
+++ b/tests/test_objective.py
@@ -1,6 +1,8 @@
 import pytest
 
-from loto.scheduling.objective import integrate_mwh, integrate_cost, objective
+from loto.scheduling.des_engine import Task
+from loto.scheduling.monte import bands
+from loto.scheduling.objective import integrate_cost, integrate_mwh, objective
 
 
 def test_integrate_mwh_edge_cases():
@@ -47,9 +49,40 @@ def test_objective_weighted_and_penalty():
 
     cost = integrate_cost(curve, price)
     expected = makespan + lam * cost + rho  # late penalty triggered
-    assert objective(makespan, curve, lam, rho, deadline, price) == pytest.approx(expected)
+    assert objective(makespan, curve, lam, rho, deadline, price) == pytest.approx(
+        expected
+    )
 
     # when curve or price are empty the objective reduces to makespan + penalty
     assert objective(0.5, [], lam, rho, 1.0, price) == pytest.approx(0.5)
     assert objective(0.5, curve, lam, rho, 1.0, []) == pytest.approx(0.5 + lam * 0.0)
 
+
+def test_bands_deterministic_schedule():
+    tasks = {
+        "a": Task(duration=2),
+        "b": Task(duration=3, predecessors=["a"]),
+    }
+    price = [(0.0, 2.0), (10.0, 2.0)]
+    result = bands(tasks, {}, runs=10, price_curve=price, seed=1)
+    assert (
+        result.finish_times["P10"]
+        == result.finish_times["P50"]
+        == result.finish_times["P90"]
+        == 5.0
+    )
+    expected = integrate_cost([(0.0, 1.0), (5.0, 1.0)], price)
+    assert result.expected_cost == pytest.approx(expected)
+
+
+def test_bands_stable_with_seed():
+    tasks = {
+        "a": Task(duration=lambda rng: rng.randint(1, 3)),
+        "b": Task(duration=(4, 1), predecessors=["a"]),
+    }
+    price = [(0.0, 1.0), (10.0, 1.0)]
+    r1 = bands(tasks, {}, runs=50, price_curve=price, seed=42)
+    r2 = bands(tasks, {}, runs=50, price_curve=price, seed=42)
+    assert r1.finish_times == r2.finish_times
+    assert r1.expected_cost == pytest.approx(r2.expected_cost)
+    assert r1.finish_times["P10"] < r1.finish_times["P50"] < r1.finish_times["P90"]


### PR DESCRIPTION
## Summary
- add `loto.scheduling.monte` with Monte Carlo finish-time bands and cost estimation
- expose `bands` API from scheduling package
- cover deterministic and seeded scenarios with new tests

## Testing
- `pre-commit run --files loto/scheduling/monte.py loto/scheduling/__init__.py tests/test_objective.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a3a6d18ed083228fdac6bc51daf942