### PR TITLE
Add per-resource calendars and hard caps to DES engine

### DIFF
--- a/loto/integrations/wapr_adapter.py
+++ b/loto/integrations/wapr_adapter.py
@@ -61,7 +61,12 @@ class DemoWaprAdapter(WaprAdapter):
         "WO-200": {"applied_isolations": ["ISO-3"]},
     }
     _FIXTURE_CURVES: Dict[str, List[Tuple[int, float]]] = {
-        "ASSET-1": [(0, 100.0), (1, 110.0)],
+        "ASSET-1": [
+            (0, 100.0),
+            (1, 110.0),
+            (2, 120.0),
+            (3, 130.0),
+        ],
     }
 
     def fetch_permit(self, work_order_id: str) -> Dict[str, Any]:

--- a/tests/scheduling/test_des_engine.py
+++ b/tests/scheduling/test_des_engine.py
@@ -1,3 +1,4 @@
+from loto.scheduling import roster_input
 from loto.scheduling.des_engine import Task, run
 
 
@@ -34,3 +35,25 @@ def test_calendar_blocks_outside_work_windows():
     result = run(tasks, {})
     assert result.starts == {"a": 5}
     assert result.ends == {"a": 7}
+
+
+def test_resource_calendar_violation(tmp_path):
+    csv_path = tmp_path / "hats.csv"
+    csv_path.write_text("hat,start,stop,breaks,ot\ncrew,0,2,,false\ncrew,3,4,,false\n")
+
+    roster = roster_input.read_hat_roster(csv_path)
+    cal = roster_input.calendar_adapter(roster["crew"])
+
+    tasks = {
+        "a": Task(duration=2, resources={"crew": 1}),
+        "b": Task(duration=2, predecessors=["a"], resources={"crew": 1}),
+    }
+    result = run(
+        tasks,
+        {"crew": 1},
+        resource_calendars={"crew": cal},
+        max_time=10,
+    )
+    assert result.starts == {"a": 0}
+    assert result.ends == {"a": 2}
+    assert result.violations == ["b"]


### PR DESCRIPTION
## Summary
- support per-resource calendars and hard-cap violations in the DES engine
- extend demo WAPR adapter price curve
- test resource calendar blockage and violations

## Testing
- `pre-commit run --files loto/integrations/wapr_adapter.py loto/scheduling/des_engine.py tests/scheduling/test_des_engine.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a3a6ff94a883228096a5d1ac6a958c