### PR TITLE
Expose inventory gating in blueprint

### DIFF
--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -36,6 +36,9 @@ class BlueprintResponse(BaseModel):
     unit_mw_delta: Dict[str, float] = Field(
         default_factory=dict, description="Lost capacity per unit in MW"
     )
+    blocked_by_parts: bool = Field(
+        False, description="Whether execution is blocked due to missing parts"
+    )
 
     class Config:
         extra = "forbid"


### PR DESCRIPTION
## Summary
- simulate inventory check in `/blueprint` using demo stores and work order reservations
- track parts availability in API state and surface `blocked_by_parts` flag
- cover inventory gating via API tests

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a3b1e7f4b48322b96201eb762b90ba