### PR TITLE
Wrap API errors in envelope

### DIFF
--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for API tests.

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -1,0 +1,22 @@
+import logging
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+
+
+@app.get("/force_error")
+def force_error() -> None:
+    raise RuntimeError("boom")
+
+
+def test_error_envelope_and_logging(caplog) -> None:
+    client = TestClient(app)
+    with caplog.at_level(logging.ERROR):
+        response = client.get("/force_error")
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["error"]["code"] == 500
+    assert payload["error"]["message"] == "Internal Server Error"
+    assert "boom" in payload["error"]["details"]
+    assert any("request_id=" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- add middleware to log request IDs and return consistent error envelopes
- test error responses include envelope and log request ID

## Testing
- `pre-commit run --files apps/api/main.py tests/api/test_errors.py tests/api/__init__.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a3c706d66c83228c65ffa49145077b