### PR TITLE
feat: add scheduler bands and price metadata

### DIFF
--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/__snapshots__/page.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/__snapshots__/page.test.tsx.snap
@@ -1,0 +1,54 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renders gantt, price curve and hats timeline 1`] = `
+<main
+  class="h-full flex flex-col"
+>
+  <h1
+    class="mb-4 text-xl font-semibold"
+  >
+    Scheduler: 
+    WO-1
+  </h1>
+  <div
+    class="w-full h-full"
+  >
+    <div
+      data-sync="schedule"
+      data-testid="gantt-chart"
+    >
+      <div
+        class="recharts-responsive-container"
+        style="width: 100%; height: 200px; min-width: 0;"
+      />
+    </div>
+    <div
+      data-sync="schedule"
+      data-testid="price-chart"
+    >
+      <div
+        class="recharts-responsive-container"
+        style="width: 100%; height: 100px; min-width: 0;"
+      />
+    </div>
+    <div
+      data-sync="schedule"
+      data-testid="hats-chart"
+    >
+      <div
+        class="recharts-responsive-container"
+        style="width: 100%; height: 100px; min-width: 0;"
+      />
+    </div>
+  </div>
+  <footer
+    class="mt-4 text-sm text-gray-500"
+    data-testid="schedule-meta"
+  >
+    Seed: 
+    abc
+     Objective: 
+    0.95
+  </footer>
+</main>
+`;

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -15,18 +15,23 @@ test('renders gantt, price curve and hats timeline', async () => {
     schedule: [
       { date: '2024-01-01', p10: 10, p50: 20, p90: 30, price: 40, hats: 1 },
       { date: '2024-01-02', p10: 12, p50: 22, p90: 32, price: 42, hats: 2 }
-    ]
+    ],
+    seed: 'abc',
+    objective: 0.95
   };
   const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
     ok: true,
     json: async () => sample
   } as Response);
 
-  render(<Page params={{ wo: 'WO-1' }} />);
+  const { container } = render(<Page params={{ wo: 'WO-1' }} />);
 
   await screen.findByTestId('gantt-chart');
   expect(screen.getByTestId('price-chart')).toBeInTheDocument();
   expect(screen.getByTestId('hats-chart')).toBeInTheDocument();
+  expect(screen.getByTestId('schedule-meta').textContent).toContain('Seed: abc');
+  expect(screen.getByTestId('schedule-meta').textContent).toContain('Objective: 0.95');
+  expect(container.firstChild).toMatchSnapshot();
   const synced = document.querySelectorAll('[data-sync="schedule"]');
   expect(synced.length).toBe(3);
   fetchMock.mockRestore();

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
@@ -9,10 +9,14 @@ const queryClient = new QueryClient();
 function SchedulerContent({ wo }: { wo: string }) {
   const { data } = useSchedule(wo);
   if (!data) return null;
+  const { schedule, seed, objective } = data;
   return (
-    <main className="h-full">
+    <main className="h-full flex flex-col">
       <h1 className="mb-4 text-xl font-semibold">Scheduler: {wo}</h1>
-      <Gantt data={data} />
+      <Gantt data={schedule} />
+      <footer className="mt-4 text-sm text-gray-500" data-testid="schedule-meta">
+        Seed: {seed} Objective: {objective}
+      </footer>
     </main>
   );
 }

--- a/apps/maximo-extension-ui/src/components/Gantt.test.tsx
+++ b/apps/maximo-extension-ui/src/components/Gantt.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import Gantt from './Gantt';
+
+const sample = [
+  { date: '2024-01-01', p10: 10, p50: 20, p90: 30, price: 40, hats: 1 },
+  { date: '2024-01-02', p10: 12, p50: 22, p90: 32, price: 42, hats: 2 }
+];
+
+describe('Gantt', () => {
+  test('maps sync id across charts', () => {
+    class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    // @ts-ignore
+    global.ResizeObserver = ResizeObserver;
+    const { getByTestId } = render(<Gantt data={sample} />);
+    expect(getByTestId('gantt-chart').getAttribute('data-sync')).toBe('schedule');
+    expect(getByTestId('price-chart').getAttribute('data-sync')).toBe('schedule');
+    expect(getByTestId('hats-chart').getAttribute('data-sync')).toBe('schedule');
+  });
+});

--- a/apps/maximo-extension-ui/src/components/Gantt.tsx
+++ b/apps/maximo-extension-ui/src/components/Gantt.tsx
@@ -18,24 +18,45 @@ const SYNC_ID = 'schedule';
  * Simple Gantt/price/hats visualization with synced cursor.
  */
 export default function Gantt({ data }: { data: SchedulePoint[] }) {
+  const chartData = data.map((d) => ({
+    ...d,
+    p10to50: d.p50 - d.p10,
+    p50to90: d.p90 - d.p50
+  }));
+
   return (
     <div className="w-full h-full">
       <div data-testid="gantt-chart" data-sync={SYNC_ID}>
         <ResponsiveContainer width="100%" height={200}>
-          <ComposedChart data={data} syncId={SYNC_ID}>
+          <ComposedChart data={chartData} syncId={SYNC_ID}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="date" />
             <YAxis />
             <Tooltip />
-            <Area type="monotone" dataKey="p90" stroke="none" fill="#8884d8" fillOpacity={0.3} />
-            <Area type="monotone" dataKey="p10" stroke="none" fill="#fff" />
+            <Area type="monotone" dataKey="p10" stackId="range" stroke="none" fill="#fff" />
+            <Area
+              type="monotone"
+              dataKey="p10to50"
+              stackId="range"
+              stroke="none"
+              fill="#8884d8"
+              fillOpacity={0.3}
+            />
+            <Area
+              type="monotone"
+              dataKey="p50to90"
+              stackId="range"
+              stroke="none"
+              fill="#8884d8"
+              fillOpacity={0.1}
+            />
             <Line type="monotone" dataKey="p50" stroke="#8884d8" dot={false} />
           </ComposedChart>
         </ResponsiveContainer>
       </div>
       <div data-testid="price-chart" data-sync={SYNC_ID}>
         <ResponsiveContainer width="100%" height={100}>
-          <ComposedChart data={data} syncId={SYNC_ID}>
+          <ComposedChart data={chartData} syncId={SYNC_ID}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="date" />
             <YAxis />
@@ -46,7 +67,7 @@ export default function Gantt({ data }: { data: SchedulePoint[] }) {
       </div>
       <div data-testid="hats-chart" data-sync={SYNC_ID}>
         <ResponsiveContainer width="100%" height={100}>
-          <ComposedChart data={data} syncId={SYNC_ID}>
+          <ComposedChart data={chartData} syncId={SYNC_ID}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="date" />
             <YAxis />

--- a/apps/maximo-extension-ui/src/lib/schedule.ts
+++ b/apps/maximo-extension-ui/src/lib/schedule.ts
@@ -9,10 +9,16 @@ export interface SchedulePoint {
   hats: number;
 }
 
+export interface ScheduleResponse {
+  schedule: SchedulePoint[];
+  seed: string;
+  objective: number;
+}
+
 /**
  * Fetch schedule for a work order.
  */
-export async function fetchSchedule(wo: string): Promise<SchedulePoint[]> {
+export async function fetchSchedule(wo: string): Promise<ScheduleResponse> {
   const res = await fetch('/schedule', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -20,13 +26,13 @@ export async function fetchSchedule(wo: string): Promise<SchedulePoint[]> {
   });
   if (!res.ok) throw new Error('Failed to fetch schedule');
   const data = await res.json();
-  return data.schedule as SchedulePoint[];
+  return data as ScheduleResponse;
 }
 
 /**
  * React Query hook for schedule data.
  */
-export function useSchedule(wo: string): UseQueryResult<SchedulePoint[]> {
+export function useSchedule(wo: string): UseQueryResult<ScheduleResponse> {
   return useQuery({ queryKey: ['schedule', wo], queryFn: () => fetchSchedule(wo) });
 }
 


### PR DESCRIPTION
## Summary
- draw P10/P50/P90 ribbons in scheduler gantt chart and sync price sparkline
- surface schedule seed and objective in page footer
- test mapping of schedule data and snapshot bands

## Testing
- `pnpm install`
- `pnpm -F maximo-extension-ui test -- -u`
- `pip install httpx networkx requests pyyaml pandas reportlab PyPDF2`
- `pip install python-dotenv`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a3d40464208322981bf550df15c52a