### PR TITLE
feat(pid): add warnings drawer and legend badges

### DIFF
--- a/apps/maximo-extension-ui/src/components/Exports.tsx
+++ b/apps/maximo-extension-ui/src/components/Exports.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Button from './Button';
 import { exportPid } from '../lib/exportPid';
 
@@ -11,6 +11,7 @@ interface ExportProps {
 export default function Exports({ wo }: ExportProps) {
   const [hash, setHash] = useState<string | null>(null);
   const [seed, setSeed] = useState<string | null>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
 
   async function handleExport(format: 'pdf' | 'json') {
     const res = await fetch('/blueprint', {
@@ -61,8 +62,29 @@ export default function Exports({ wo }: ExportProps) {
     URL.revokeObjectURL(url);
   }
 
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (!toolbarRef.current) return;
+    const buttons = toolbarRef.current.querySelectorAll<HTMLButtonElement>('button');
+    const currentIndex = Array.from(buttons).indexOf(document.activeElement as HTMLButtonElement);
+    if (e.key === 'ArrowRight') {
+      const next = buttons[(currentIndex + 1) % buttons.length];
+      next.focus();
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft') {
+      const prev = buttons[(currentIndex - 1 + buttons.length) % buttons.length];
+      prev.focus();
+      e.preventDefault();
+    }
+  }
+
   return (
-    <div className="mb-4 flex items-center space-x-2">
+    <div
+      ref={toolbarRef}
+      role="toolbar"
+      aria-label="Export options"
+      onKeyDown={handleKeyDown}
+      className="mb-4 flex items-center space-x-2"
+    >
       <Button aria-label="Export PDF" onClick={() => handleExport('pdf')}>
         Export PDF
       </Button>

--- a/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import { vi, test, expect } from 'vitest';
 import PidViewer from './PidViewer';
 
@@ -41,6 +41,23 @@ test('adds aria-labels from title elements', async () => {
     expect(rect?.getAttribute('aria-label')).toBe('Valve 1');
     expect(rect?.getAttribute('tabindex')).toBe('0');
   });
+
+  (fetch as any).mockRestore();
+});
+
+test('renders warning chips when provided', async () => {
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>';
+  vi.spyOn(global, 'fetch').mockResolvedValue({
+    text: () => Promise.resolve(svg)
+  } as any);
+
+  const { getByRole, findByText } = render(
+    <PidViewer src="/test.svg" warnings={['missing tag']} />
+  );
+
+  const btn = await waitFor(() => getByRole('button', { name: /warnings/i }));
+  fireEvent.click(btn);
+  await findByText('missing tag');
 
   (fetch as any).mockRestore();
 });

--- a/apps/maximo-extension-ui/src/components/PidViewer.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.tsx
@@ -6,9 +6,10 @@ type Highlight = 'primary' | 'warning' | null;
 interface PidViewerProps {
   src: string;
   highlight?: Highlight;
+  warnings?: string[];
 }
 
-export default function PidViewer({ src, highlight = null }: PidViewerProps) {
+export default function PidViewer({ src, highlight = null, warnings = [] }: PidViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgContainerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
@@ -16,6 +17,7 @@ export default function PidViewer({ src, highlight = null }: PidViewerProps) {
   const [translate, setTranslate] = useState({ x: 0, y: 0 });
   const dragging = useRef(false);
   const dragStart = useRef({ x: 0, y: 0 });
+  const [showWarnings, setShowWarnings] = useState(false);
 
   useEffect(() => {
     fetch(src)
@@ -122,6 +124,14 @@ export default function PidViewer({ src, highlight = null }: PidViewerProps) {
       setScale((s) => Math.min(s * 1.1, 10));
     } else if (e.key === '-') {
       setScale((s) => Math.max(s * 0.9, 0.1));
+    } else if (e.key === 'ArrowLeft') {
+      setTranslate((t) => ({ ...t, x: t.x + 10 }));
+    } else if (e.key === 'ArrowRight') {
+      setTranslate((t) => ({ ...t, x: t.x - 10 }));
+    } else if (e.key === 'ArrowUp') {
+      setTranslate((t) => ({ ...t, y: t.y + 10 }));
+    } else if (e.key === 'ArrowDown') {
+      setTranslate((t) => ({ ...t, y: t.y - 10 }));
     }
   }
 
@@ -145,6 +155,17 @@ export default function PidViewer({ src, highlight = null }: PidViewerProps) {
         <button className="badge" onClick={resetView} type="button">
           Reset
         </button>
+        {warnings.length > 0 && (
+          <button
+            className="badge"
+            onClick={() => setShowWarnings((s) => !s)}
+            aria-expanded={showWarnings}
+            aria-controls="pid-warnings"
+            type="button"
+          >
+            Warnings ({warnings.length})
+          </button>
+        )}
       </div>
       <div
         className="legend absolute bottom-2 left-2 text-xs bg-white bg-opacity-80 p-2 rounded shadow"
@@ -167,7 +188,34 @@ export default function PidViewer({ src, highlight = null }: PidViewerProps) {
           />
           Warning
         </div>
+        <div className="flex items-center">
+          <span aria-hidden="true" className="pid-badge pid-badge-asset mr-1" /> Asset
+        </div>
+        <div className="flex items-center">
+          <span aria-hidden="true" className="pid-badge pid-badge-source mr-1" /> Source
+        </div>
+        <div className="flex items-center">
+          <span
+            aria-hidden="true"
+            className="pid-badge pid-badge-missing-tag mr-1"
+          />
+          Missing tag
+        </div>
       </div>
+      {warnings.length > 0 && showWarnings && (
+        <aside
+          id="pid-warnings"
+          className="pid-warning-drawer"
+          role="complementary"
+          aria-label="Warnings"
+        >
+          {warnings.map((w) => (
+            <span key={w} className="pid-warning-chip">
+              {w}
+            </span>
+          ))}
+        </aside>
+      )}
     </div>
   );
 }

--- a/apps/maximo-extension-ui/src/lib/pidOverlay.test.ts
+++ b/apps/maximo-extension-ui/src/lib/pidOverlay.test.ts
@@ -33,6 +33,8 @@ describe('applyPidOverlay', () => {
     const badges = Array.from(svg.querySelectorAll('.pid-badge'));
     expect(badges).toHaveLength(2);
     expect(badges[0].textContent).toBe('asset');
+    expect(badges[0].classList.contains('pid-badge-asset')).toBe(true);
     expect(badges[1].textContent).toBe('source');
+    expect(badges[1].classList.contains('pid-badge-source')).toBe(true);
   });
 });

--- a/apps/maximo-extension-ui/src/lib/pidOverlay.ts
+++ b/apps/maximo-extension-ui/src/lib/pidOverlay.ts
@@ -12,6 +12,7 @@ export interface Overlay {
   highlight: string[];
   badges: Badge[];
   paths: OverlayPath[];
+  warnings?: string[];
 }
 
 function uniq(values: string[]): string[] {
@@ -60,8 +61,10 @@ export function applyPidOverlay(svg: SVGSVGElement, overlay: Overlay): void {
     fo.setAttribute('height', String(bbox.height));
 
     const div = document.createElement('div');
-    div.className = 'pid-badge';
+    const typeClass = badge.type.replace(/\s+/g, '-');
+    div.className = `pid-badge pid-badge-${typeClass}`;
     div.textContent = badge.type;
+    div.setAttribute('tabindex', '0');
     fo.appendChild(div);
 
     badgeLayer.appendChild(fo);

--- a/apps/maximo-extension-ui/src/styles/pid.css
+++ b/apps/maximo-extension-ui/src/styles/pid.css
@@ -25,3 +25,44 @@
   padding: 2px 6px;
   border-radius: var(--mxc-radius-sm);
 }
+
+.pid-badge {
+  display: inline-block;
+  padding: 2px 4px;
+  border-radius: var(--mxc-radius-sm);
+  font-size: 0.7rem;
+  color: #fff;
+}
+
+.pid-badge-asset {
+  background: var(--mxc-topbar-bg);
+}
+
+.pid-badge-source {
+  background: #3b82f6;
+}
+
+.pid-badge-missing-tag {
+  background: #f87171;
+}
+
+.pid-warning-drawer {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  max-width: 12rem;
+  background: white;
+  padding: 0.5rem;
+  border-radius: var(--mxc-radius-sm);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.pid-warning-chip {
+  display: inline-block;
+  background: #fbbf24;
+  color: #000;
+  padding: 2px 4px;
+  border-radius: var(--mxc-radius-sm);
+  margin: 0 4px 4px 0;
+  font-size: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- show P&ID overlay badges by type and include warning drawer
- support keyboard navigation and toolbar semantics in export buttons
- expose overlay warnings to PidViewer with legend badges for asset, source and missing tags

## Testing
- `pnpm -F maximo-extension-ui test`
- `pre-commit run --files apps/maximo-extension-ui/src/components/Exports.tsx apps/maximo-extension-ui/src/components/PidViewer.test.tsx apps/maximo-extension-ui/src/components/PidViewer.tsx apps/maximo-extension-ui/src/lib/pidOverlay.test.ts apps/maximo-extension-ui/src/lib/pidOverlay.ts apps/maximo-extension-ui/src/styles/pid.css`


------
https://chatgpt.com/codex/tasks/task_b_68a3d3ddb3f48322ab6f33a04b29aa45