### PR TITLE
Add Maximo palette, density toggle, and commit confirmation

### DIFF
--- a/apps/maximo-extension-ui/src/app/layout.tsx
+++ b/apps/maximo-extension-ui/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import '../styles/globals.css';
 import ThemeToggle from '../components/ThemeToggle';
+import DensityToggle from '../components/DensityToggle';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -9,7 +10,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <div className="flex min-h-screen flex-col">
           <header className="flex h-12 items-center justify-between bg-[var(--mxc-topbar-bg)] px-4 text-[var(--mxc-topbar-fg)]">
             <span className="font-semibold">Maximo Extension</span>
-            <ThemeToggle />
+            <div className="flex gap-2">
+              <ThemeToggle />
+              <DensityToggle />
+            </div>
           </header>
           <div className="flex flex-1 overflow-hidden">
             <nav className="w-56 shrink-0 border-r border-[var(--mxc-border)] bg-[var(--mxc-nav-bg)] p-4 text-[var(--mxc-nav-fg)]">

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx
@@ -1,7 +1,13 @@
-import { render, screen } from '@testing-library/react';
-import { test, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { test, expect, vi, afterEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import CommitPanel from './CommitPanel';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
 
 test('renders audit metadata and disables commit in TEST role', async () => {
   vi.stubEnv('NEXT_PUBLIC_ROLE', 'TEST');
@@ -16,6 +22,29 @@ test('renders audit metadata and disables commit in TEST role', async () => {
   await screen.findByTestId('diff');
   expect(screen.getByText(/Audit Metadata/)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Commit' })).toBeDisabled();
-  vi.unstubAllGlobals();
-  vi.unstubAllEnvs();
+});
+
+test('requires typing COMMIT to confirm', async () => {
+  vi.stubEnv('NEXT_PUBLIC_ROLE', 'DEV');
+  const blueprint = { diff: 'diff text' };
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(blueprint) })
+    .mockResolvedValue({ ok: true });
+  vi.stubGlobal('fetch', fetchMock);
+  const prompt = vi.spyOn(window, 'prompt').mockReturnValue('nope');
+  const queryClient = new QueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CommitPanel wo="WO-1" />
+    </QueryClientProvider>
+  );
+  await screen.findByTestId('diff');
+  const button = screen.getByRole('button', { name: 'Commit' });
+  fireEvent.click(button);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  prompt.mockReturnValue('COMMIT');
+  fireEvent.click(button);
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  prompt.mockRestore();
 });

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx
@@ -14,6 +14,12 @@ export default function CommitPanel({ wo }: CommitPanelProps) {
   const diff = data?.diff;
   const audit = data?.audit_metadata as Record<string, unknown> | undefined;
 
+  const handleCommit = async () => {
+    const input = window.prompt('Type COMMIT to confirm');
+    if (input !== 'COMMIT') return;
+    await fetch(`/api/commit/${wo}`, { method: 'POST' });
+  };
+
   return (
     <section>
       {diff && (
@@ -29,7 +35,9 @@ export default function CommitPanel({ wo }: CommitPanelProps) {
           </pre>
         </div>
       )}
-      <Button disabled={!canCommit}>Commit</Button>
+      <Button disabled={!canCommit} onClick={handleCommit}>
+        Commit
+      </Button>
     </section>
   );
 }

--- a/apps/maximo-extension-ui/src/components/DensityToggle.test.tsx
+++ b/apps/maximo-extension-ui/src/components/DensityToggle.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import DensityToggle from './DensityToggle';
+
+test('toggles between comfortable and compact densities', async () => {
+  render(<DensityToggle />);
+  const button = screen.getByRole('button', { name: /density/i });
+  expect(document.documentElement.dataset.density).toBe('comfortable');
+  fireEvent.click(button);
+  expect(document.documentElement.dataset.density).toBe('compact');
+  fireEvent.click(button);
+  expect(document.documentElement.dataset.density).toBe('comfortable');
+});

--- a/apps/maximo-extension-ui/src/components/DensityToggle.tsx
+++ b/apps/maximo-extension-ui/src/components/DensityToggle.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Button from './Button';
+
+export default function DensityToggle() {
+  const [density, setDensity] = useState<'comfortable' | 'compact'>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('density');
+      if (stored === 'comfortable' || stored === 'compact') return stored;
+    }
+    return 'comfortable';
+  });
+
+  useEffect(() => {
+    document.documentElement.dataset.density = density;
+    localStorage.setItem('density', density);
+  }, [density]);
+
+  return (
+    <Button
+      aria-label="Toggle density"
+      onClick={() => setDensity(density === 'compact' ? 'comfortable' : 'compact')}
+    >
+      {density === 'compact' ? 'Comfortable density' : 'Compact density'}
+    </Button>
+  );
+}

--- a/apps/maximo-extension-ui/src/styles/theme-maximo.css
+++ b/apps/maximo-extension-ui/src/styles/theme-maximo.css
@@ -12,6 +12,10 @@
   --mxc-drawer-bg: #e0e0e0;
   --mxc-drawer-fg: #161616;
   --mxc-border: #e0e0e0;
+  --mxc-status-success: #24a148;
+  --mxc-status-info: #0f62fe;
+  --mxc-status-warning: #f1c21b;
+  --mxc-status-critical: #da1e28;
 
   /* Radii */
   --mxc-radius-sm: 2px;
@@ -42,8 +46,21 @@
   --mxc-drawer-bg: #393939;
   --mxc-drawer-fg: #f4f4f4;
   --mxc-border: #525252;
+  --mxc-status-success: #42be65;
+  --mxc-status-info: #4589ff;
+  --mxc-status-warning: #f1c21b;
+  --mxc-status-critical: #fa4d56;
   --mxc-chip-bg: #393939;
   --mxc-chip-fg: #f4f4f4;
+}
+
+:root,
+[data-density='comfortable'] {
+  --mxc-density: 1;
+}
+
+[data-density='compact'] {
+  --mxc-density: 0.75;
 }
 
 /* Respect system preference unless explicitly set */

--- a/apps/maximo-extension-ui/tailwind.config.ts
+++ b/apps/maximo-extension-ui/tailwind.config.ts
@@ -1,10 +1,19 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
-  darkMode: ['class'],
+  darkMode: ['class', '[data-theme="dark"]'],
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        background: 'var(--mxc-bg)',
+        foreground: 'var(--mxc-fg)',
+        'status-success': 'var(--mxc-status-success)',
+        'status-info': 'var(--mxc-status-info)',
+        'status-warning': 'var(--mxc-status-warning)',
+        'status-critical': 'var(--mxc-status-critical)'
+      }
+    }
   },
   plugins: [require('tailwindcss-animate')]
 };


### PR DESCRIPTION
## Summary
- extend Tailwind with dark/light palettes and status accents
- add compact/comfortable density toggle
- require destructive commits to type CONFIRM

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/app/layout.tsx apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx apps/maximo-extension-ui/src/styles/theme-maximo.css apps/maximo-extension-ui/tailwind.config.ts apps/maximo-extension-ui/src/components/DensityToggle.tsx apps/maximo-extension-ui/src/components/DensityToggle.test.tsx`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a3d429ad548322bbf16771ff483d87