### PR TITLE
Enable structured JSON logging across API requests

### DIFF
--- a/loto/loggers.py
+++ b/loto/loggers.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "request_id", default=""
+)
+seed_var: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "seed", default=None
+)
+rule_hash_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "rule_hash", default=None
+)
+
+
+class ContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get()
+        record.seed = seed_var.get()
+        record.rule_hash = rule_hash_var.get()
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        data: dict[str, Any] = {
+            "time": datetime.fromtimestamp(record.created, timezone.utc).isoformat(),
+            "level": record.levelname.lower(),
+            "msg": record.getMessage(),
+            "request_id": getattr(record, "request_id", None),
+            "seed": getattr(record, "seed", None),
+            "rule_hash": getattr(record, "rule_hash", None),
+        }
+        return json.dumps(data)
+
+
+def configure_logging() -> None:
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    handler.addFilter(ContextFilter())
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)

--- a/tests/api/test_logging.py
+++ b/tests/api/test_logging.py
@@ -1,0 +1,27 @@
+import json
+import logging
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from loto.loggers import JsonFormatter
+
+
+def test_structured_logging(caplog):
+    client = TestClient(app)
+    payload = {
+        "tasks": {"a": {"duration": 1}},
+        "runs": 1,
+        "seed": 99,
+        "power_curve": [[0, 1], [1, 1]],
+        "price_curve": [[0, 1], [1, 1]],
+    }
+    with caplog.at_level(logging.INFO):
+        client.post("/schedule", json=payload)
+    record = next(r for r in caplog.records if r.getMessage() == "request complete")
+    data = json.loads(JsonFormatter().format(record))
+    assert data["msg"] == "request complete"
+    assert data["level"] == "info"
+    assert data["seed"] == 99
+    assert data["request_id"]
+    assert "rule_hash" in data


### PR DESCRIPTION
## Summary
- log requests as JSON including request ID, seed, and rule hash
- add shared logging utilities with context filter and JSON formatter
- test structured logging output from schedule endpoint

## Testing
- `pre-commit run --files apps/api/main.py loto/loggers.py tests/api/test_logging.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a3d7ef53c48322a0adc4fa8ab4ac21