### PR TITLE
Add Docker demo setup

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install application and API dependencies
+COPY pyproject.toml README.md ./
+COPY loto ./loto
+COPY apps/api ./apps/api
+COPY demo ./demo
+RUN pip install --no-cache-dir -r apps/api/requirements.txt && \
+    pip install --no-cache-dir .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "apps.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,0 +1,16 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install pnpm and workspace dependencies for the UI
+RUN npm install -g pnpm
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/maximo-extension-ui/package.json apps/maximo-extension-ui/
+RUN pnpm install --filter maximo-extension-ui... --frozen-lockfile
+
+COPY apps/maximo-extension-ui apps/maximo-extension-ui
+
+EXPOSE 3000
+
+CMD ["pnpm", "-F", "maximo-extension-ui", "dev"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint typecheck test run-demo
+.PHONY: fmt lint typecheck test run-demo demo-up
 
 fmt:
 	black loto tests
@@ -15,3 +15,13 @@ test:
 
 run-demo:
 	python -m loto.cli --demo
+
+demo-up:
+	@if docker compose version >/dev/null 2>&1; then \
+		docker compose up --build -d; \
+	elif command -v docker-compose >/dev/null 2>&1; then \
+		docker-compose up --build -d; \
+	else \
+		echo "Docker Compose is not installed. Install Docker and Docker Compose."; \
+		exit 1; \
+	fi

--- a/README.md
+++ b/README.md
@@ -48,7 +48,24 @@ NEXT_PUBLIC_USE_API=false
 
 ### Demo
 
+Run the API and UI with demo data using Docker. Ensure Docker and Docker Compose are installed and the Docker daemon is running:
+
 ```bash
-# Show the CLI help as a simple demo
+make demo-up
+```
+
+This reads `.env.example` and starts the API at <http://localhost:8000> and the
+UI at <http://localhost:3000>. Verify the API is running:
+
+```bash
+curl :8000/healthz
+```
+
+Open the UI in your browser to view the Portfolio page at
+<http://localhost:3000>.
+
+To run the CLI demo instead:
+
+```bash
 make run-demo
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    ports:
+      - "8000:8000"
+    env_file: .env.example
+  ui:
+    build:
+      context: .
+      dockerfile: Dockerfile.ui
+    ports:
+      - "3000:3000"
+    env_file: .env.example
+    depends_on:
+      - api


### PR DESCRIPTION
## Summary
- Add Dockerfiles and compose to run API and UI demo
- Provide make demo-up target with Docker Compose fallback
- Document demo usage in README

## Testing
- `pre-commit run --files Makefile README.md Dockerfile.api Dockerfile.ui docker-compose.yml`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `make demo-up` *(fails: unshare: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_b_68a3d7ca42808322bf12a564151053c7