### PR TITLE
ci: build and test frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,21 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack enable
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
           pre-commit install
+      - name: Frontend build and test
+        run: |
+          pnpm -C apps/maximo-extension-ui i
+          pnpm -C apps/maximo-extension-ui build
+          pnpm -C apps/maximo-extension-ui test
       - name: Lint
         run: make lint
       - name: Type check


### PR DESCRIPTION
## Summary
- add Node setup and run pnpm install, build, and test for maximo-extension-ui in CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pnpm -C apps/maximo-extension-ui build`
- `pnpm -C apps/maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a3e5c7a5d0832296b0d21f1e7d8735