### PR TITLE
feat: add PID warnings drawer

### DIFF
--- a/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
@@ -45,19 +45,24 @@ test('adds aria-labels from title elements', async () => {
   (fetch as any).mockRestore();
 });
 
-test('renders warning chips when provided', async () => {
+test('renders warning messages and copies on click', async () => {
   const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>';
   vi.spyOn(global, 'fetch').mockResolvedValue({
     text: () => Promise.resolve(svg)
   } as any);
 
-  const { getByRole, findByText } = render(
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+
+  const { getByRole, findByRole } = render(
     <PidViewer src="/test.svg" warnings={['missing tag']} />
   );
 
   const btn = await waitFor(() => getByRole('button', { name: /warnings/i }));
   fireEvent.click(btn);
-  await findByText('missing tag');
+  const warnBtn = await findByRole('button', { name: 'missing tag' });
+  fireEvent.click(warnBtn);
+  expect(writeText).toHaveBeenCalledWith('missing tag');
 
   (fetch as any).mockRestore();
 });

--- a/apps/maximo-extension-ui/src/components/PidViewer.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.tsx
@@ -19,6 +19,10 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
   const dragStart = useRef({ x: 0, y: 0 });
   const [showWarnings, setShowWarnings] = useState(false);
 
+  function copyWarning(w: string) {
+    navigator.clipboard?.writeText(w).catch(() => {});
+  }
+
   useEffect(() => {
     fetch(src)
       .then((r) => r.text())
@@ -201,6 +205,20 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
           />
           Missing tag
         </div>
+        <div className="flex items-center">
+          <span
+            aria-hidden="true"
+            className="pid-badge pid-badge-unknown-selector mr-1"
+          />
+          Unknown selector
+        </div>
+        <div className="flex items-center">
+          <span
+            aria-hidden="true"
+            className="pid-badge pid-badge-unmapped mr-1"
+          />
+          Unmapped
+        </div>
       </div>
       {warnings.length > 0 && showWarnings && (
         <aside
@@ -209,11 +227,19 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
           role="complementary"
           aria-label="Warnings"
         >
-          {warnings.map((w) => (
-            <span key={w} className="pid-warning-chip">
-              {w}
-            </span>
-          ))}
+          <ul className="m-0 list-none p-0">
+            {warnings.map((w) => (
+              <li key={w}>
+                <button
+                  type="button"
+                  className="pid-warning-chip"
+                  onClick={() => copyWarning(w)}
+                >
+                  {w}
+                </button>
+              </li>
+            ))}
+          </ul>
         </aside>
       )}
     </div>

--- a/apps/maximo-extension-ui/src/lib/pidOverlay.test.ts
+++ b/apps/maximo-extension-ui/src/lib/pidOverlay.test.ts
@@ -37,4 +37,17 @@ describe('applyPidOverlay', () => {
     expect(badges[1].textContent).toBe('source');
     expect(badges[1].classList.contains('pid-badge-source')).toBe(true);
   });
+
+  it('returns unique warnings', () => {
+    const svg = createSvg([]);
+    const overlay: Overlay = {
+      highlight: [],
+      badges: [],
+      paths: [],
+      warnings: ['missing tag', 'missing tag', 'unmapped'],
+    };
+
+    const warnings = applyPidOverlay(svg, overlay);
+    expect(warnings).toEqual(['missing tag', 'unmapped']);
+  });
 });

--- a/apps/maximo-extension-ui/src/lib/pidOverlay.ts
+++ b/apps/maximo-extension-ui/src/lib/pidOverlay.ts
@@ -26,12 +26,13 @@ function uniq(values: string[]): string[] {
  * Badges are rendered near their target elements using SVG `foreignObject`
  * elements so that HTML can be positioned relative to the graphic.
  */
-export function applyPidOverlay(svg: SVGSVGElement, overlay: Overlay): void {
+export function applyPidOverlay(svg: SVGSVGElement, overlay: Overlay): string[] {
   const highlight = uniq(overlay.highlight);
   overlay.paths = overlay.paths.map((p) => ({
     ...p,
     selectors: uniq(p.selectors),
   }));
+  const warnings = uniq(overlay.warnings ?? []);
 
   highlight.forEach((selector) => {
     svg.querySelectorAll<SVGElement>(selector).forEach((el) => {
@@ -69,4 +70,5 @@ export function applyPidOverlay(svg: SVGSVGElement, overlay: Overlay): void {
 
     badgeLayer.appendChild(fo);
   });
+  return warnings;
 }

--- a/apps/maximo-extension-ui/src/styles/pid.css
+++ b/apps/maximo-extension-ui/src/styles/pid.css
@@ -46,6 +46,14 @@
   background: #f87171;
 }
 
+.pid-badge-unknown-selector {
+  background: #f97316;
+}
+
+.pid-badge-unmapped {
+  background: #9ca3af;
+}
+
 .pid-warning-drawer {
   position: absolute;
   top: 0.5rem;
@@ -65,4 +73,6 @@
   border-radius: var(--mxc-radius-sm);
   margin: 0 4px 4px 0;
   font-size: 0.75rem;
+  border: none;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- show P&ID overlay warnings in a right-hand drawer with copyable messages
- expose overlay warnings via `applyPidOverlay`
- add legend badges for missing tag, unknown selector, and unmapped

## Testing
- `pnpm -F maximo-extension-ui test`
- `make test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68a405503f5483229bb8a3710e63f0ec