### PR TITLE
Stamp metadata on PID PDFs and fetch backend export

### DIFF
--- a/apps/maximo-extension-ui/src/components/Exports.tsx
+++ b/apps/maximo-extension-ui/src/components/Exports.tsx
@@ -2,7 +2,6 @@
 
 import React, { useRef, useState } from 'react';
 import Button from './Button';
-import { exportPid } from '../lib/exportPid';
 
 interface ExportProps {
   wo: string;
@@ -35,6 +34,27 @@ export default function Exports({ wo }: ExportProps) {
     const a = document.createElement('a');
     a.href = url;
     a.download = `WO-${wo}_${h ?? 'unknown'}.${ext}`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  async function handlePid() {
+    const res = await fetch('/pid/pdf', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/pdf'
+      },
+      body: JSON.stringify({ workorder_id: wo })
+    });
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `WO-${wo}_pid.pdf`;
     document.body.appendChild(a);
     a.click();
     a.remove();
@@ -91,10 +111,7 @@ export default function Exports({ wo }: ExportProps) {
       <Button aria-label="Export JSON" onClick={() => handleExport('json')}>
         Export JSON
       </Button>
-      <Button
-        aria-label="Export P&ID"
-        onClick={() => exportPid(`WO-${wo}_pid.pdf`)}
-      >
+      <Button aria-label="Export P&ID" onClick={handlePid}>
         Export P&ID
       </Button>
       <Button aria-label="Export P&ID (A3)" onClick={handlePidA3}>

--- a/tests/test_renderer_pdf.py
+++ b/tests/test_renderer_pdf.py
@@ -1,4 +1,8 @@
+import hashlib
 import io
+import re
+from datetime import datetime
+from unittest.mock import patch
 
 from PyPDF2 import PdfReader
 
@@ -12,7 +16,13 @@ from loto.models import (
 from loto.renderer import Renderer
 
 
-def test_pdf_contains_plan_id():
+class _FixedDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        return datetime(2024, 1, 1, 0, 0, tzinfo=tz)
+
+
+def test_pdf_contains_stamps_and_is_deterministic():
     plan = IsolationPlan(
         plan_id="plan-123",
         actions=[IsolationAction(component_id="A", method="lock", duration_s=1.0)],
@@ -23,16 +33,30 @@ def test_pdf_contains_plan_id():
         total_time_s=1.0,
     )
 
-    pdf_bytes = Renderer().pdf(
-        plan, sim, rule_hash="abc123", seed=42, timezone="Pacific/Auckland"
+    renderer = Renderer()
+    with patch("loto.renderer.datetime", _FixedDatetime):
+        pdf_bytes1 = renderer.pdf(
+            plan, sim, rule_hash="abc123", seed=42, timezone="Pacific/Auckland"
+        )
+        pdf_bytes2 = renderer.pdf(
+            plan, sim, rule_hash="abc123", seed=42, timezone="Pacific/Auckland"
+        )
+
+    assert pdf_bytes1 and pdf_bytes2, "pdf() should return non-empty bytes"
+
+    reader1 = PdfReader(io.BytesIO(pdf_bytes1))
+    reader2 = PdfReader(io.BytesIO(pdf_bytes2))
+    text1 = "".join(page.extract_text() for page in reader1.pages)
+    text2 = "".join(page.extract_text() for page in reader2.pages)
+    assert text1 == text2
+    assert (
+        hashlib.sha256(text1.encode()).hexdigest()
+        == hashlib.sha256(text2.encode()).hexdigest()
     )
 
-    assert pdf_bytes, "pdf() should return non-empty bytes"
-
-    reader = PdfReader(io.BytesIO(pdf_bytes))
-    text = "".join(page.extract_text() for page in reader.pages)
-    assert "Work Order ID: plan-123" in text
-    assert "Rule Pack Hash: abc123" in text
-    assert "Seed: 42" in text
-    assert "Timezone: Pacific/Auckland" in text
-    assert "Because" in text
+    assert "WO: plan-123" in text1
+    assert "Rule Pack Hash: abc123" in text1
+    assert "Seed: 42" in text1
+    assert re.search(r"Generated: \d{4}-\d{2}-\d{2} \d{2}:\d{2} (NZDT|NZST)", text1)
+    assert "DRY-RUN" in text1
+    assert "Because" in text1


### PR DESCRIPTION
## Summary
- stamp work order, seed, rule hash, NZ timestamp and environment badge in PDF footer
- fetch P&ID PDFs from backend for deterministic exports
- cover PDF stamps and backend P&ID download in tests

## Testing
- `pre-commit run --files loto/renderer.py apps/maximo-extension-ui/src/components/Exports.tsx apps/maximo-extension-ui/src/components/Exports.test.tsx tests/test_renderer_pdf.py`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a405b07e488322950ad171460be262