### PR TITLE
feat(portfolio): add planner scheduler links

### DIFF
--- a/apps/maximo-extension-ui/src/app/portfolio/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.test.tsx
@@ -4,8 +4,28 @@ import Page from './page';
 
 test('renders work orders from mock fetch', async () => {
   render(<Page />);
-  await screen.findByText('Pump replacement');
-  const [, tbody] = screen.getAllByRole('rowgroup');
+  await screen.findAllByText('Pump replacement');
+  const rowgroups = screen.getAllByRole('rowgroup');
+  const tbody = rowgroups[rowgroups.length - 1];
   const rows = within(tbody).getAllByRole('row');
   expect(rows).toHaveLength(3);
+});
+
+test('row actions preserve seed/objective in links', async () => {
+  window.history.pushState({}, '', '/portfolio?seed=abc&objective=0.5');
+  render(<Page />);
+  await screen.findAllByText('Pump replacement');
+  const rowgroups = screen.getAllByRole('rowgroup');
+  const tbody = rowgroups[rowgroups.length - 1];
+  const [first] = within(tbody).getAllByRole('row');
+  const planner = within(first).getByRole('link', { name: 'Planner' });
+  const scheduler = within(first).getByRole('link', { name: 'Scheduler' });
+  expect(planner).toHaveAttribute(
+    'href',
+    '/planner/WO-1?seed=abc&objective=0.5'
+  );
+  expect(scheduler).toHaveAttribute(
+    'href',
+    '/scheduler/WO-1?seed=abc&objective=0.5'
+  );
 });

--- a/apps/maximo-extension-ui/src/app/portfolio/page.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.tsx
@@ -10,6 +10,8 @@ const queryClient = new QueryClient();
 function PortfolioContent() {
   const [dense, setDense] = useState(false);
   const { data } = usePortfolio();
+  const search =
+    typeof window !== 'undefined' ? window.location.search : '';
 
   if (!data) return null;
 
@@ -33,6 +35,7 @@ function PortfolioContent() {
             <th className="px-4 py-2">Description</th>
             <th className="px-4 py-2">Status</th>
             <th className="px-4 py-2">Owner</th>
+            <th className="px-4 py-2">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -41,6 +44,10 @@ function PortfolioContent() {
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.description}</td>
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.status}</td>
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.owner}</td>
+              <td className={`px-4 ${dense ? 'py-1' : 'py-2'} space-x-2`}>
+                <a href={`/planner/${wo.id}${search}`}>Planner</a>
+                <a href={`/scheduler/${wo.id}${search}`}>Scheduler</a>
+              </td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- add row actions to open Planner and Scheduler from Portfolio
- preserve seed/objective query parameters when navigating

## Testing
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `pre-commit run --files apps/maximo-extension-ui/src/app/portfolio/page.tsx apps/maximo-extension-ui/src/app/portfolio/page.test.tsx`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a405c571b8832295ad8e46f12b1570