### PR TITLE
Add jobpack endpoint and builder

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -22,6 +22,7 @@ from loto.inventory import (
     check_wo_parts_required,
 )
 from loto.loggers import configure_logging, request_id_var, rule_hash_var, seed_var
+from loto.materials.jobpack import build_jobpack
 from loto.models import RulePack
 from loto.scheduling.des_engine import Task
 from loto.scheduling.objective import integrate_cost
@@ -308,3 +309,10 @@ async def post_schedule(payload: ScheduleRequest) -> ScheduleResponse:
 async def get_workorder(workorder_id: str) -> dict[str, str]:
     """Mock work order fetch."""
     return {"workorder_id": workorder_id, "status": "mocked"}
+
+
+@app.get("/workorders/{workorder_id}/jobpack")
+async def get_jobpack(workorder_id: str) -> dict[str, dict[str, object]]:
+    """Return a mock job pack for the given work order."""
+
+    return build_jobpack(workorder_id)

--- a/loto/materials/__init__.py
+++ b/loto/materials/__init__.py
@@ -1,0 +1,1 @@
+"""Materials utilities."""

--- a/loto/materials/jobpack.py
+++ b/loto/materials/jobpack.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Dict, List
+
+DEFAULT_LEAD_DAYS = 2
+
+
+def _default_items() -> List[Dict[str, object]]:
+    """Fixture reservation lines for demo job packs."""
+
+    return [
+        {"part_number": "P-100", "quantity": 1, "storeroom": "WH1", "bin": "A1"},
+        {"part_number": "P-200", "quantity": 1, "storeroom": "WH1", "bin": "B2"},
+    ]
+
+
+def build_jobpack(
+    workorder_id: str,
+    *,
+    permit_start: date | None = None,
+    lead_days: int = DEFAULT_LEAD_DAYS,
+) -> Dict[str, Dict[str, object]]:
+    """Construct a mock job pack for ``workorder_id``.
+
+    Parameters
+    ----------
+    workorder_id:
+        Identifier of the work order.
+    permit_start:
+        Optional start date for the permit. If omitted, a date five days in the
+        future is used.
+    lead_days:
+        Number of days prior to ``permit_start`` that materials should be picked.
+    """
+
+    permit_start = permit_start or (date.today() + timedelta(days=5))
+    pick_by = permit_start - timedelta(days=lead_days)
+    items = _default_items()
+    payload = {
+        "workorder": workorder_id,
+        "permit_start": permit_start.isoformat(),
+        "pick_by": pick_by.isoformat(),
+        "items": items,
+    }
+
+    out_dir = Path("out/jobpacks") / f"WO-{workorder_id}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    json_bytes = json.dumps(payload, sort_keys=True).encode()
+    json_hash = hashlib.sha256(json_bytes).hexdigest()
+    json_name = f"{json_hash}.json"
+    (out_dir / json_name).write_bytes(json_bytes)
+
+    csv_buffer = io.StringIO()
+    fieldnames = ["part_number", "quantity", "storeroom", "bin", "pick_by"]
+    writer = csv.DictWriter(csv_buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for line in items:
+        row = dict(line)
+        row["pick_by"] = pick_by.isoformat()
+        writer.writerow(row)
+    csv_content = csv_buffer.getvalue()
+    csv_hash = hashlib.sha256(csv_content.encode()).hexdigest()
+    csv_name = f"{csv_hash}.csv"
+    (out_dir / csv_name).write_text(csv_content)
+
+    return {
+        "json": {"filename": json_name, "content": payload},
+        "csv": {"filename": csv_name, "content": csv_content},
+    }

--- a/tests/api/test_jobpack.py
+++ b/tests/api/test_jobpack.py
@@ -1,0 +1,47 @@
+import csv
+import hashlib
+import io
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+
+
+def test_jobpack_endpoint():
+    client = TestClient(app)
+    wo_id = "123"
+    res = client.get(f"/workorders/{wo_id}/jobpack")
+    assert res.status_code == 200
+    data = res.json()
+    assert "csv" in data and "json" in data
+
+    csv_info = data["csv"]
+    json_info = data["json"]
+
+    # filenames derived from content hash
+    csv_content = csv_info["content"]
+    csv_hash = hashlib.sha256(csv_content.encode()).hexdigest()
+    assert csv_info["filename"].startswith(csv_hash)
+
+    json_content = json_info["content"]
+    json_hash = hashlib.sha256(
+        json.dumps(json_content, sort_keys=True).encode()
+    ).hexdigest()
+    assert json_info["filename"].startswith(json_hash)
+
+    # pick_by is permit_start minus two days
+    permit_start = date.fromisoformat(json_content["permit_start"])
+    pick_by = date.fromisoformat(json_content["pick_by"])
+    assert permit_start - pick_by == timedelta(days=2)
+
+    # CSV has storeroom and bin columns
+    reader = csv.DictReader(io.StringIO(csv_content))
+    row = next(reader)
+    assert "storeroom" in row and "bin" in row
+
+    out_dir = Path("out/jobpacks") / f"WO-{wo_id}"
+    assert (out_dir / csv_info["filename"]).exists()
+    assert (out_dir / json_info["filename"]).exists()


### PR DESCRIPTION
## Summary
- add materials jobpack builder generating hashed JSON/CSV pick lists
- expose GET /workorders/{id}/jobpack endpoint
- test jobpack endpoint for hashed file output and pick-by calculation

## Testing
- `pre-commit run --files loto/materials/__init__.py loto/materials/jobpack.py apps/api/main.py tests/api/test_jobpack.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a410bb70608322889864b2250b4b2d