### PR TITLE
feat: expose material status in blueprint

### DIFF
--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -39,6 +39,9 @@ class BlueprintResponse(BaseModel):
     blocked_by_parts: bool = Field(
         False, description="Whether execution is blocked due to missing parts"
     )
+    parts_status: Dict[str, str] = Field(
+        default_factory=dict, description="Inventory status per material line"
+    )
 
     class Config:
         extra = "forbid"

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
@@ -1,15 +1,41 @@
-import { render, screen } from '@testing-library/react';
-import { test, expect } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { test, expect, vi, afterEach } from 'vitest';
 import Page from './page';
 
-test('renders 5 tabs', async () => {
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+test('renders 6 tabs', async () => {
   render(<Page params={{ wo: 'WO-1' }} />);
   const tabs = await screen.findAllByRole('tab');
-  expect(tabs).toHaveLength(5);
+  expect(tabs).toHaveLength(6);
 });
 
 test('renders export buttons', () => {
   render(<Page params={{ wo: 'WO-1' }} />);
   expect(screen.getAllByText('Export PDF').length).toBeGreaterThan(0);
   expect(screen.getAllByText('Export JSON').length).toBeGreaterThan(0);
+});
+
+test('renders material status chips', async () => {
+  const shortage = {
+    steps: [],
+    unavailable_assets: [],
+    unit_mw_delta: {},
+    blocked_by_parts: true,
+    parts_status: { 'P-100': 'ok', 'P-200': 'short' }
+  };
+  vi.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => shortage
+  } as Response);
+
+  render(<Page params={{ wo: 'WO-1' }} />);
+  const tab = await screen.findByRole('tab', { name: 'Materials' });
+  fireEvent.click(tab);
+  await screen.findByText('P-200');
+  expect(screen.getByText('OK')).toBeInTheDocument();
+  expect(screen.getByText('Short')).toBeInTheDocument();
 });

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -6,8 +6,9 @@ import { useWorkOrder, useBlueprint } from '../../../lib/hooks';
 import Exports from '../../../components/Exports';
 import CommitPanel from './CommitPanel';
 import PidTab from './PidTab';
+import type { MaterialStatus } from '../../../types/api';
 
-const tabs = ['Plan', 'P&ID', 'Simulation', 'Impact', 'Commit'];
+const tabs = ['Plan', 'Materials', 'P&ID', 'Simulation', 'Impact', 'Commit'];
 
 const queryClient = new QueryClient();
 
@@ -21,6 +22,23 @@ function PlannerContent({ wo }: { wo: string }) {
   const plan = blueprint?.steps ?? [];
   const unavailable = blueprint?.unavailable_assets ?? [];
   const impact = blueprint?.unit_mw_delta ?? {};
+  const materials = blueprint?.parts_status ?? {};
+
+  const statusStyles: Record<MaterialStatus, string> = {
+    ok: 'bg-green-100 text-green-800',
+    low: 'bg-yellow-100 text-yellow-800',
+    short: 'bg-red-100 text-red-800',
+    rfq: 'bg-blue-100 text-blue-800',
+    parked: 'bg-gray-100 text-gray-800'
+  };
+
+  const statusLabels: Record<MaterialStatus, string> = {
+    ok: 'OK',
+    low: 'Low',
+    short: 'Short',
+    rfq: 'RFQ',
+    parked: 'Parked'
+  };
 
   return (
     <main className="h-full">
@@ -58,6 +76,30 @@ function PlannerContent({ wo }: { wo: string }) {
                     <td className="px-4 py-2">{idx + 1}</td>
                     <td className="px-4 py-2">{p.component_id}</td>
                     <td className="px-4 py-2">{p.method}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+          {activeTab === 'Materials' && (
+            <table className="min-w-full border border-[var(--mxc-border)]">
+              <thead className="bg-[var(--mxc-nav-bg)] text-left">
+                <tr>
+                  <th className="px-4 py-2">Item</th>
+                  <th className="px-4 py-2">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(materials).map(([item, status]) => (
+                  <tr key={item}>
+                    <td className="px-4 py-2">{item}</td>
+                    <td className="px-4 py-2">
+                      <span
+                        className={`inline-block rounded-full px-2 py-1 text-xs font-medium ${statusStyles[status as MaterialStatus]}`}
+                      >
+                        {statusLabels[status as MaterialStatus]}
+                      </span>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/maximo-extension-ui/src/types/api.ts
+++ b/apps/maximo-extension-ui/src/types/api.ts
@@ -16,6 +16,8 @@ export interface BlueprintData {
   steps: BlueprintStep[];
   unavailable_assets: string[];
   unit_mw_delta: Record<string, number>;
+  blocked_by_parts?: boolean;
+  parts_status?: Record<string, MaterialStatus>;
   diff?: string;
   audit_metadata?: Record<string, unknown>;
 }
@@ -42,6 +44,8 @@ export interface ImpactRecord {
 }
 
 export type InventoryStatus = 'ready' | 'short' | 'ordered';
+
+export type MaterialStatus = 'ok' | 'low' | 'short' | 'rfq' | 'parked';
 
 export interface InventoryItem {
   item: string;


### PR DESCRIPTION
## Summary
- add per-material status and blocked flag to blueprint API
- show Materials tab with status chips in planner
- test rendering of shortage chips

## Testing
- `pre-commit run --files apps/api/schemas.py apps/api/main.py apps/maximo-extension-ui/src/types/api.ts apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a410c326f4832287f1bbcd24b6c51c