### PR TITLE
ci: trigger on default branch and tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- run CI on default branch and v* tags

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `make fmt` *(failed: produced unrelated reformatting; reverted)*
- `make lint`
- `make typecheck` *(failed: Makefile:11 error 1)*
- `make test` *(failed: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68a414bcfae883229c0e37e299b13f41