### PR TITLE
docs: add pilot runbook and safety gates

### DIFF
--- a/docs/INTERNAL_REVIEW_CHECKLIST.md
+++ b/docs/INTERNAL_REVIEW_CHECKLIST.md
@@ -1,0 +1,7 @@
+# Internal Review Checklist
+
+- [ ] Steps generate → review → export → attach completed
+- [ ] Safety gates satisfied: simulation green and policy chips
+- [ ] `npx markdownlint docs/*.md` executed
+- [ ] `make test` passes
+- [ ] Times captured in absolute New Zealand time

--- a/docs/PILOT_RUNBOOK.md
+++ b/docs/PILOT_RUNBOOK.md
@@ -1,0 +1,28 @@
+# Pilot Runbook
+
+This runbook describes the pilot workflow from generation through attachment.
+
+## Steps
+
+1. **Generate** – Produce the initial artifact using the pilot tools.
+2. **Review** – Peers validate the artifact and simulation results.
+3. **Export** – Convert the reviewed artifact into the approved format.
+4. **Attach** – Upload the exported bundle to the system of record.
+
+## Data flow
+
+Source data enters the pipeline, is processed by the pilot tools,
+reviewed, and exported for attachment.
+
+## Environments
+
+- **dev** – local smoke tests
+- **staging** – integration tests
+- **prod** – official pilot execution
+
+All deadlines are recorded in New Zealand time; for example
+`2024-08-15 09:00 NZST (UTC+12)`.
+
+## Support
+
+Contact the platform team via `#pilot-support` for assistance.

--- a/docs/SAFETY_GATES.md
+++ b/docs/SAFETY_GATES.md
@@ -1,0 +1,26 @@
+# Safety Gates
+
+Gating rules that must pass before artifacts are attached.
+
+## Gating rules
+
+- **Simulation green** – proceed only when the latest simulation run is green.
+- **Policy chips** – confirm all policy chips are satisfied prior to export.
+
+## Data flow
+
+Inputs enter the simulator, gates evaluate results,
+and only approved outputs move forward for attachment.
+
+## Environments
+
+- **dev** – gates are informational
+- **staging** – requires simulation green
+- **prod** – requires simulation green and policy chips
+
+Gate reviews log absolute New Zealand times such as
+`2024-08-15 09:00 NZST (UTC+12)`.
+
+## Support
+
+For assistance with failing gates, contact `#pilot-support`.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,8 @@
+# Security
+
+Security considerations for the pilot process.
+
+- Review generated artifacts for sensitive information before export and attachment.
+- Data flows only through approved environments (`dev`, `staging`, `prod`).
+- Apply least-privilege permissions when accessing pilot resources.
+- Report incidents immediately in `#pilot-support`.


### PR DESCRIPTION
## Summary
- add pilot runbook describing generate → review → export → attach workflow
- document safety gate rules and environments with NZ time example
- introduce basic security guide and internal review checklist

## Testing
- `npx markdownlint-cli docs/*.md`
- `pre-commit run --files docs/PILOT_RUNBOOK.md docs/SAFETY_GATES.md docs/SECURITY.md docs/INTERNAL_REVIEW_CHECKLIST.md`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a414b2ffb08322806d2187ae2b49c9