### PR TITLE
feat(api): configure CORS and rate limit via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,9 @@ MAXIMO_APIKEY=changeme
 MAXIMO_OS_WORKORDER=WORKORDER
 MAXIMO_OS_ASSET=ASSET
 NEXT_PUBLIC_USE_API=false
+## API configuration
+# Comma-separated list of origins allowed to access the API
+CORS_ORIGINS=
+# Rate limiting settings
+RATE_LIMIT_CAPACITY=10
+RATE_LIMIT_INTERVAL=60

--- a/tests/api/test_healthz.py
+++ b/tests/api/test_healthz.py
@@ -1,0 +1,25 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def test_healthz_reports_rate_limit(monkeypatch):
+    monkeypatch.setenv("RATE_LIMIT_CAPACITY", "5")
+    monkeypatch.setenv("RATE_LIMIT_INTERVAL", "30")
+    import apps.api.main as main
+
+    importlib.reload(main)
+
+    client = TestClient(main.app)
+    res = client.get("/healthz")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["rate_limit"]["capacity"] == 5
+    assert data["rate_limit"]["interval"] == 30.0
+    for path in main.RATE_LIMIT_PATHS:
+        assert path in data["rate_limit"]["counters"]
+    assert res.headers["X-Env"] == main.ENV_BADGE
+
+    monkeypatch.delenv("RATE_LIMIT_CAPACITY", raising=False)
+    monkeypatch.delenv("RATE_LIMIT_INTERVAL", raising=False)
+    importlib.reload(main)


### PR DESCRIPTION
## Summary
- read rate limit capacity and interval from env
- include rate limit counters and caps on `/healthz`
- document CORS and rate limit env vars

## Testing
- `pre-commit run --files apps/api/main.py .env.example tests/api/test_healthz.py`
- `make lint`
- `make typecheck`
- `make test` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68a41d0b60b083228349f6206b94802f