### PR TITLE
feat: add optional bearer token auth

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -55,6 +55,19 @@ if origins:
 app.include_router(pid_router)
 
 
+AUTH_REQUIRED = os.getenv("AUTH_REQUIRED", "").lower() == "true"
+AUTH_TOKEN = os.getenv("AUTH_TOKEN", "")
+
+
+@app.middleware("http")
+async def auth_guard(request: Request, call_next):
+    if AUTH_REQUIRED:
+        auth_header = request.headers.get("Authorization")
+        if auth_header != f"Bearer {AUTH_TOKEN}":
+            return Response(status_code=401)
+    return await call_next(request)
+
+
 @app.middleware("http")
 async def log_context(request: Request, call_next):
     req_id = str(uuid4())

--- a/apps/maximo-extension-ui/src/app/layout.tsx
+++ b/apps/maximo-extension-ui/src/app/layout.tsx
@@ -3,6 +3,21 @@ import '../styles/globals.css';
 import ThemeToggle from '../components/ThemeToggle';
 import DensityToggle from '../components/DensityToggle';
 
+if (
+  process.env.NODE_ENV === 'development' &&
+  process.env.NEXT_PUBLIC_API_TOKEN
+) {
+  const token = process.env.NEXT_PUBLIC_API_TOKEN;
+  const originalFetch = global.fetch;
+  global.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers || {});
+    if (!headers.has('Authorization')) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+    return originalFetch(input, { ...init, headers });
+  };
+}
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="h-full">

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,19 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+import apps.api.main as main
+
+
+def test_bearer_token(monkeypatch):
+    monkeypatch.setenv("AUTH_REQUIRED", "true")
+    monkeypatch.setenv("AUTH_TOKEN", "secret")
+    importlib.reload(main)
+    client = TestClient(main.app)
+    resp_ok = client.get("/healthz", headers={"Authorization": "Bearer secret"})
+    assert resp_ok.status_code == 200
+    resp_fail = client.get("/healthz")
+    assert resp_fail.status_code == 401
+    monkeypatch.delenv("AUTH_REQUIRED", raising=False)
+    monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    importlib.reload(main)


### PR DESCRIPTION
## Summary
- gate API endpoints behind optional bearer token when `AUTH_REQUIRED` is true
- send dev Authorization header from `NEXT_PUBLIC_API_TOKEN`
- test auth gating

## Testing
- `pnpm -F maximo-extension-ui test`
- `make fmt`
- `make lint`
- `make typecheck`
- `pre-commit run --files apps/api/main.py apps/maximo-extension-ui/src/app/layout.tsx tests/api/test_auth.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a41d1367588322b564847acb7a87c7