### PR TITLE
feat: post demo P&ID overlay

### DIFF
--- a/apps/maximo-extension-ui/package.json
+++ b/apps/maximo-extension-ui/package.json
@@ -15,6 +15,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "html2canvas": "^1.4.1",
+    "js-yaml": "^4.1.0",
     "jspdf": "^3.0.1",
     "next": "^14.0.0",
     "react": "^18.2.0",

--- a/apps/maximo-extension-ui/package.json
+++ b/apps/maximo-extension-ui/package.json
@@ -33,6 +33,7 @@
     "@testing-library/jest-dom": "^6.1.0",
     "@testing-library/react": "^14.0.0",
     "@types/node": "^20.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       html2canvas:
         specifier: ^1.4.1
         version: 1.4.1
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       jspdf:
         specifier: ^3.0.1
         version: 3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.3.1(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.11
@@ -1986,6 +1989,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/lodash@4.17.20':
     resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
@@ -7429,6 +7435,8 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/lodash@4.17.20': {}
 


### PR DESCRIPTION
## Summary
- post to /pid/overlay with mock plan and pid_map for demo work orders
- add js-yaml dependency for pid_map parsing

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx apps/maximo-extension-ui/package.json pnpm-lock.yaml`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a4227947c88322abcb0e8fe03ab677