### PR TITLE
Validate PID map selectors and expose warnings

### DIFF
--- a/apps/api/pid_endpoints.py
+++ b/apps/api/pid_endpoints.py
@@ -121,7 +121,7 @@ async def post_overlay(payload: OverlayRequest) -> OverlayResponse:
                 base = Path(__file__).resolve().parents[2]
                 svg_path = base / svg_path
             report = validate_svg_map(svg_path, map_path)
-            warnings = report.missing_selectors
+            warnings.extend(report.warnings)
     finally:
         map_path.unlink(missing_ok=True)
 

--- a/apps/maximo-extension-ui/src/components/PidViewer.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.tsx
@@ -18,6 +18,13 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
   const dragging = useRef(false);
   const dragStart = useRef({ x: 0, y: 0 });
   const [showWarnings, setShowWarnings] = useState(false);
+  const uniqueWarnings = Array.from(new Set(warnings));
+
+  useEffect(() => {
+    if (uniqueWarnings.length === 0) {
+      setShowWarnings(false);
+    }
+  }, [uniqueWarnings.length]);
 
   function copyWarning(w: string) {
     navigator.clipboard?.writeText(w).catch(() => {});
@@ -159,7 +166,7 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
         <button className="badge" onClick={resetView} type="button">
           Reset
         </button>
-        {warnings.length > 0 && (
+        {uniqueWarnings.length > 0 && (
           <button
             className="badge"
             onClick={() => setShowWarnings((s) => !s)}
@@ -167,7 +174,7 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
             aria-controls="pid-warnings"
             type="button"
           >
-            Warnings ({warnings.length})
+            Warnings ({uniqueWarnings.length})
           </button>
         )}
       </div>
@@ -220,7 +227,7 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
           Unmapped
         </div>
       </div>
-      {warnings.length > 0 && showWarnings && (
+      {uniqueWarnings.length > 0 && showWarnings && (
         <aside
           id="pid-warnings"
           className="pid-warning-drawer"
@@ -228,7 +235,7 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
           aria-label="Warnings"
         >
           <ul className="m-0 list-none p-0">
-            {warnings.map((w) => (
+            {uniqueWarnings.map((w) => (
               <li key={w}>
                 <button
                   type="button"

--- a/apps/maximo-extension-ui/src/lib/pidOverlay.ts
+++ b/apps/maximo-extension-ui/src/lib/pidOverlay.ts
@@ -70,5 +70,6 @@ export function applyPidOverlay(svg: SVGSVGElement, overlay: Overlay): string[] 
 
     badgeLayer.appendChild(fo);
   });
-  return warnings;
+  // Return a copy so callers can freely modify the list.
+  return [...warnings];
 }

--- a/loto/pid/validator.py
+++ b/loto/pid/validator.py
@@ -1,59 +1,79 @@
+"""Utilities for validating PID tag maps against SVG diagrams."""
+
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Mapping, Set
+from typing import Dict, Iterable, List, Mapping, Set
 
 from .schema import load_tag_map
 
 
 @dataclass
 class ValidationReport:
-    """Report from validating selectors against an SVG document."""
+    """Result of validating a PID map against an SVG."""
 
-    missing_selectors: List[str]
+    warnings: List[str]
 
 
-def _flatten_selectors(mapping: Mapping[str, Iterable[str]]) -> Set[str]:
+def _flatten_selectors(mapping: Mapping[str, Iterable[str]]) -> Dict[str, List[str]]:
+    """Return mapping of selector to tags using it."""
+
+    selector_map: Dict[str, List[str]] = {}
+    for tag, values in mapping.items():
+        for sel in values:
+            selector_map.setdefault(sel, []).append(tag)
+    return selector_map
+
+
+def _svg_selectors(root: ET.Element) -> Set[str]:
     selectors: Set[str] = set()
-    for values in mapping.values():
-        selectors.update(values)
+    for elem in root.iter():
+        elem_id = elem.get("id")
+        if elem_id:
+            selectors.add(f"#{elem_id}")
+        class_attr = elem.get("class")
+        if class_attr:
+            selectors.update(f".{c}" for c in class_attr.split())
     return selectors
 
 
 def validate_svg_map(svg_path: str | Path, map_path: str | Path) -> ValidationReport:
-    """Validate selectors in ``map_path`` exist in the SVG at ``svg_path``."""
+    """Validate selectors in ``map_path`` against the SVG at ``svg_path``."""
 
     svg_path = Path(svg_path)
     map_path = Path(map_path)
 
     raw_map = load_tag_map(map_path).root
     tag_map: dict[str, List[str]] = {k: list(v.root) for k, v in raw_map.items()}
-    selectors = _flatten_selectors(tag_map)
+    selector_map = _flatten_selectors(tag_map)
+
+    warnings: List[str] = []
+
+    # Warn on selectors mapped to multiple tags
+    for sel, tags in selector_map.items():
+        if len(tags) > 1:
+            joined = ", ".join(sorted(tags))
+            warnings.append(f"duplicate tag '{sel}' mapped from: {joined}")
 
     try:
         root = ET.parse(svg_path).getroot()
     except FileNotFoundError:
-        return ValidationReport(sorted(selectors))
+        # If SVG missing, all selectors are effectively missing
+        for sel in selector_map:
+            warnings.append(f"missing selector '{sel}'")
+        return ValidationReport(sorted(warnings))
 
-    missing: List[str] = []
-    for sel in selectors:
-        if sel.startswith("#"):
-            if root.find(f".//*[@id='{sel[1:]}']") is None:
-                missing.append(sel)
-        elif sel.startswith("."):
-            class_name = sel[1:]
-            found = False
-            for elem in root.findall(".//*[@class]"):
-                classes = elem.get("class", "").split()
-                if class_name in classes:
-                    found = True
-                    break
-            if not found:
-                missing.append(sel)
-        else:
-            if not root.findall(f".//{sel}"):
-                missing.append(sel)
+    svg_selectors = _svg_selectors(root)
+    map_selectors = set(selector_map)
 
-    return ValidationReport(sorted(missing))
+    missing = sorted(map_selectors - svg_selectors)
+    for sel in missing:
+        warnings.append(f"missing selector '{sel}'")
+
+    unmapped = sorted(svg_selectors - map_selectors)
+    for sel in unmapped:
+        warnings.append(f"unmapped tag '{sel}'")
+
+    return ValidationReport(sorted(warnings))

--- a/tests/pid/test_svg_validator.py
+++ b/tests/pid/test_svg_validator.py
@@ -1,0 +1,33 @@
+from loto.pid.validator import validate_svg_map
+
+
+def test_validator_reports_warnings(tmp_path):
+    svg = tmp_path / "d.svg"
+    svg.write_text(
+        "<svg xmlns='http://www.w3.org/2000/svg'>"
+        "<g id='a'/>"
+        "<g id='b'/>"
+        "<g class='foo bar'/>"
+        "</svg>"
+    )
+    pid_map = tmp_path / "pid_map.yaml"
+    pid_map.write_text(
+        "\n".join(
+            [
+                "tag1: '#a'",
+                "tag2: '#missing'",
+                "tag3: '.foo'",
+                "dup1: '#dup'",
+                "dup2: '#dup'",
+            ]
+        )
+    )
+
+    report = validate_svg_map(svg, pid_map)
+    warnings = report.warnings
+
+    assert "missing selector '#missing'" in warnings
+    assert "missing selector '#dup'" in warnings
+    assert any("duplicate tag '#dup'" in w for w in warnings)
+    assert "unmapped tag '#b'" in warnings
+    assert "unmapped tag '.bar'" in warnings

--- a/tests/pid/test_validator.py
+++ b/tests/pid/test_validator.py
@@ -33,4 +33,5 @@ def test_validate_svg_map_reports_missing(tmp_path: Path) -> None:
     svg = _write_svg(tmp_path)
     mapping = _write_map(tmp_path)
     report = validate_svg_map(svg, mapping)
-    assert report.missing_selectors == ["#missing", ".missing"]
+    assert "missing selector '#missing'" in report.warnings
+    assert "missing selector '.missing'" in report.warnings


### PR DESCRIPTION
## Summary
- add PID validator that flags missing selectors, unmapped tags, and duplicate mappings
- surface validator warnings through /pid/overlay endpoint
- render warning drawer in PID viewer

## Testing
- `pre-commit run --files loto/pid/validator.py apps/api/pid_endpoints.py apps/maximo-extension-ui/src/components/PidViewer.tsx apps/maximo-extension-ui/src/lib/pidOverlay.ts tests/pid/test_svg_validator.py tests/pid/test_validator.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a427e50970832282c704511af4cecb