### PR TITLE
Validate PID tag maps

### DIFF
--- a/loto/pid/schema.py
+++ b/loto/pid/schema.py
@@ -96,8 +96,7 @@ def load_tag_map(path: str | Path) -> PidTagMap:
         err = exc.errors()[0]
         loc = err.get("loc", ())
         if loc:
-            tag = loc[0]
-            line = line_map.get(str(tag), 1)
-        else:
-            line = 1
-        raise ValueError(f"{path}:{line}: {err['msg']}") from None
+            tag = str(loc[0])
+            line = line_map.get(tag, 1)
+            raise ValueError(f"{path}:{line}: tag '{tag}': {err['msg']}") from None
+        raise ValueError(f"{path}:1: {err['msg']}") from None


### PR DESCRIPTION
## Summary
- enforce strict tag map validation with path-aware errors
- load tag maps through schema for regex and empty selector checks
- test invalid selectors, duplicate tags, and empty mappings

## Testing
- `pre-commit run --files loto/pid/overlay.py loto/pid/registry.py loto/pid/schema.py tests/test_overlay.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a427f171288322ac9ac2d4a6848f18