### PR TITLE
Stamp deterministic metadata on P&ID exports

### DIFF
--- a/apps/maximo-extension-ui/src/components/Exports.test.tsx
+++ b/apps/maximo-extension-ui/src/components/Exports.test.tsx
@@ -80,10 +80,13 @@ test('downloads JSON with hash in filename', async () => {
   await screen.findByText('Seed: 7');
 });
 
-test('exports P&ID view as PDF via backend', async () => {
+test('exports P&ID view as PDF via backend with hash and seed', async () => {
+  const hash = 'ghi789';
+  const seed = '99';
   const blob = new Blob(['pdf'], { type: 'application/pdf' });
   const fetchMock = vi.fn().mockResolvedValue({
     ok: true,
+    headers: new Headers({ 'x-loto-hash': hash, 'x-loto-seed': seed }),
     blob: () => Promise.resolve(blob)
   });
   global.fetch = fetchMock as any;
@@ -106,6 +109,8 @@ test('exports P&ID view as PDF via backend', async () => {
   fireEvent.click(screen.getByText('Export P&ID'));
   await waitFor(() => expect(fetchMock).toHaveBeenCalled());
 
-  expect(anchor.download).toBe('WO-3_pid.pdf');
+  expect(anchor.download).toBe(`WO-3_${hash}_pid.pdf`);
   expect(click).toHaveBeenCalled();
+  await screen.findByText(`Hash: ${hash}`);
+  await screen.findByText(`Seed: ${seed}`);
 });

--- a/apps/maximo-extension-ui/src/components/Exports.tsx
+++ b/apps/maximo-extension-ui/src/components/Exports.tsx
@@ -40,7 +40,7 @@ export default function Exports({ wo }: ExportProps) {
     URL.revokeObjectURL(url);
   }
 
-  async function handlePid() {
+  async function downloadPid(a3 = false) {
     const res = await fetch('/pid/pdf', {
       method: 'POST',
       headers: {
@@ -50,32 +50,18 @@ export default function Exports({ wo }: ExportProps) {
       body: JSON.stringify({ workorder_id: wo })
     });
     if (!res.ok) return;
-    const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `WO-${wo}_pid.pdf`;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  }
 
-  async function handlePidA3() {
-    const res = await fetch('/pid/pdf', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/pdf'
-      },
-      body: JSON.stringify({ workorder_id: wo })
-    });
-    if (!res.ok) return;
+    const h = res.headers.get('x-loto-hash');
+    const s = res.headers.get('x-loto-seed');
+    if (h) setHash(h);
+    if (s) setSeed(s);
+
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `WO-${wo}_pid_a3.pdf`;
+    const suffix = a3 ? '_pid_a3' : '_pid';
+    a.download = `WO-${wo}_${h ?? 'unknown'}${suffix}.pdf`;
     document.body.appendChild(a);
     a.click();
     a.remove();
@@ -111,10 +97,10 @@ export default function Exports({ wo }: ExportProps) {
       <Button aria-label="Export JSON" onClick={() => handleExport('json')}>
         Export JSON
       </Button>
-      <Button aria-label="Export P&ID" onClick={handlePid}>
+      <Button aria-label="Export P&ID" onClick={() => downloadPid(false)}>
         Export P&ID
       </Button>
-      <Button aria-label="Export P&ID (A3)" onClick={handlePidA3}>
+      <Button aria-label="Export P&ID (A3)" onClick={() => downloadPid(true)}>
         Export P&ID (A3)
       </Button>
       {hash && <span>Hash: {hash}</span>}

--- a/loto/renderer.py
+++ b/loto/renderer.py
@@ -79,7 +79,7 @@ class Renderer:
 
         story = [Paragraph(f"Isolation Plan: {plan.plan_id}", styles["Title"])]
         story.append(Paragraph(f"Work Order ID: {plan.plan_id}", styles["Normal"]))
-        story.append(Paragraph(f"Rule Pack Hash: {rule_hash}", styles["Normal"]))
+        story.append(Paragraph(f"Rule Hash: {rule_hash}", styles["Normal"]))
         story.append(
             Paragraph(f"Seed: {seed if seed is not None else 'N/A'}", styles["Normal"])
         )
@@ -166,8 +166,8 @@ class Renderer:
         nz_timestamp = datetime.now(ZoneInfo("Pacific/Auckland"))
         footer_text = (
             f"WO: {plan.plan_id} | Seed: {seed if seed is not None else 'N/A'} | "
-            f"Rule Pack Hash: {rule_hash} | Generated: {nz_timestamp.strftime('%Y-%m-%d %H:%M %Z')} | "
-            f"{env_badge}"
+            f"Rule Hash: {rule_hash} | Generated: {nz_timestamp.strftime('%Y-%m-%d %H:%M %Z')} | "
+            f"ENV: {env_badge}"
         )
 
         def _footer(canvas, doc):

--- a/tests/test_renderer_pdf.py
+++ b/tests/test_renderer_pdf.py
@@ -55,7 +55,7 @@ def test_pdf_contains_stamps_and_is_deterministic():
     )
 
     assert "WO: plan-123" in text1
-    assert "Rule Pack Hash: abc123" in text1
+    assert "Rule Hash: abc123" in text1
     assert "Seed: 42" in text1
     assert re.search(r"Generated: \d{4}-\d{2}-\d{2} \d{2}:\d{2} (NZDT|NZST)", text1)
     assert "DRY-RUN" in text1


### PR DESCRIPTION
## Summary
- stamp work order, seed, rule hash, NZ timestamp and environment in PDF footer
- fetch P&ID PDFs from backend deterministically and display hash/seed

## Testing
- `pre-commit run --files loto/renderer.py apps/maximo-extension-ui/src/components/Exports.tsx apps/maximo-extension-ui/src/components/Exports.test.tsx tests/test_renderer_pdf.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a428036a1c8322a4e37cc837641587