### PR TITLE
feat: add jobpack endpoint

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -23,7 +23,7 @@ from loto.inventory import (
     check_wo_parts_required,
 )
 from loto.loggers import configure_logging, request_id_var, rule_hash_var, seed_var
-from loto.materials.jobpack import build_jobpack
+from loto.materials.jobpack import DEFAULT_LEAD_DAYS, build_jobpack
 from loto.models import RulePack
 from loto.scheduling.des_engine import Task
 from loto.scheduling.monte_carlo import simulate
@@ -353,7 +353,11 @@ async def get_workorder(workorder_id: str) -> dict[str, str]:
 
 
 @app.get("/workorders/{workorder_id}/jobpack")
-async def get_jobpack(workorder_id: str) -> dict[str, dict[str, object]]:
+async def get_jobpack(
+    workorder_id: str,
+    permit_start: date | None = None,
+    lead_days: int = DEFAULT_LEAD_DAYS,
+) -> dict[str, dict[str, object]]:
     """Return a mock job pack for the given work order."""
 
-    return build_jobpack(workorder_id)
+    return build_jobpack(workorder_id, permit_start=permit_start, lead_days=lead_days)

--- a/loto/materials/jobpack.py
+++ b/loto/materials/jobpack.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Dict, List
 
 DEFAULT_LEAD_DAYS = 2
+__all__ = ["build_jobpack", "DEFAULT_LEAD_DAYS"]
 
 
 def _default_items() -> List[Dict[str, object]]:


### PR DESCRIPTION
## Summary
- allow jobpack retrieval endpoint to accept configurable permit start and lead days
- expose jobpack builder default lead days constant

## Testing
- `pre-commit run --files apps/api/main.py loto/materials/jobpack.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a42aec8ce08322b3a419621440b2a7