### PR TITLE
Fix CI trigger for master branch and tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     tags:
       - 'v*'
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   tests:


### PR DESCRIPTION
## Summary
- run GitHub Actions CI when pushing to the master branch
- keep CI running on version tags matching `v*`

## Testing
- `/root/.pyenv/versions/3.12.10/bin/pre-commit run --files .github/workflows/ci.yml`
- `make test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68a42d2f19448322b2f1875a6f88bd5e