### PR TITLE
Implement roster ranking algorithm with EWMA and bands

### DIFF
--- a/loto/roster/__init__.py
+++ b/loto/roster/__init__.py
@@ -1,0 +1,5 @@
+"""Roster ranking utilities."""
+
+from .ranking import update_ranking
+
+__all__ = ["update_ranking"]

--- a/loto/roster/ranking.py
+++ b/loto/roster/ranking.py
@@ -1,0 +1,129 @@
+"""Ranking algorithms for roster metrics.
+
+This module exposes :func:`update_ranking` which consumes a *ledger* – a
+mapping of entity identifiers to an ordered sequence of metric tuples – and
+returns a snapshot containing the rank and coefficient for each entity.
+
+The calculation demonstrates a few statistical techniques:
+
+* **Composite** – multiple metrics for a single observation are combined into
+  a single score by averaging them.
+* **EWMA** – the sequence of composite scores is reduced to a single value via
+  an exponential weighted moving average.
+* **Shrinkage** – each EWMA value is pulled slightly towards the global mean to
+  temper extreme outliers.
+* **Bands** – the final coefficient is categorised into a band (``S`` through
+  ``C``) based on simple thresholds.
+* **Caps** – coefficients are clipped into a fixed range to keep them
+  well‑behaved.
+
+The function is intentionally small and self contained so it can serve as a
+teaching example for statistical style ranking pipelines.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping, Sequence
+
+_ALPHA = 0.5
+_SHRINKAGE = 0.1
+_THRESHOLDS = (0.75, 0.5, 0.25)  # S, A, B, else C
+_CAPS = (0.0, 1.0)
+
+
+def _composite(observation: Sequence[float]) -> float:
+    """Combine multiple metrics into a single score.
+
+    A simple arithmetic mean is used which is sufficient for the tests and keeps
+    the function intentionally straightforward.
+    """
+
+    if not observation:
+        return 0.0
+    return float(sum(observation) / len(observation))
+
+
+def _ewma(values: Sequence[float], alpha: float = _ALPHA) -> float:
+    """Compute the exponential weighted moving average for *values*."""
+
+    iterator = iter(values)
+    try:
+        acc = float(next(iterator))
+    except StopIteration:
+        return 0.0
+    for value in iterator:
+        acc = alpha * float(value) + (1.0 - alpha) * acc
+    return acc
+
+
+def _apply_shrinkage(value: float, mean: float, factor: float = _SHRINKAGE) -> float:
+    """Pull *value* towards *mean* by ``factor``."""
+
+    return (1.0 - factor) * value + factor * mean
+
+
+def _band(value: float) -> str:
+    """Return the categorical band for *value*."""
+
+    t_s, t_a, t_b = _THRESHOLDS
+    if value >= t_s:
+        return "S"
+    if value >= t_a:
+        return "A"
+    if value >= t_b:
+        return "B"
+    return "C"
+
+
+def update_ranking(
+    ledger: Mapping[str, Sequence[Sequence[float]]],
+) -> Dict[str, Dict[str, object]]:
+    """Return a ranking snapshot for the given *ledger*.
+
+    Parameters
+    ----------
+    ledger:
+        Mapping of entity identifiers to an ordered sequence of observations.
+        Each observation may contain one or more metrics.  Each metric tuple is
+        collapsed into a single composite value prior to further calculations.
+
+    Returns
+    -------
+    dict
+        A mapping of entity identifier to a dictionary containing ``rank``,
+        ``coefficient`` and ``band`` entries.
+    """
+
+    # Step 1 – build composite score history for each entity.
+    histories: Dict[str, list[float]] = {
+        name: [_composite(obs) for obs in observations]
+        for name, observations in ledger.items()
+    }
+
+    # Step 2 – compute EWMA for each entity.
+    ewmas: Dict[str, float] = {name: _ewma(vals) for name, vals in histories.items()}
+
+    # Step 3 – shrink towards global mean to reduce variance.
+    global_mean = sum(ewmas.values()) / len(ewmas) if ewmas else 0.0
+    coefficients: Dict[str, float] = {
+        name: _apply_shrinkage(value, global_mean) for name, value in ewmas.items()
+    }
+
+    # Step 4 – apply caps.
+    cap_min, cap_max = _CAPS
+    coefficients = {
+        name: min(max(coeff, cap_min), cap_max) for name, coeff in coefficients.items()
+    }
+
+    # Step 5 – assign bands and ranks.
+    ranked_names = sorted(coefficients, key=lambda n: coefficients[n], reverse=True)
+    snapshot: Dict[str, Dict[str, object]] = {}
+    for position, name in enumerate(ranked_names, start=1):
+        coeff = round(coefficients[name], 4)
+        snapshot[name] = {
+            "rank": position,
+            "coefficient": coeff,
+            "band": _band(coeff),
+        }
+
+    return snapshot

--- a/tests/roster/test_ranking.golden.json
+++ b/tests/roster/test_ranking.golden.json
@@ -1,0 +1,17 @@
+{
+  "alice": {
+    "band": "S",
+    "coefficient": 0.8425,
+    "rank": 1
+  },
+  "bob": {
+    "band": "A",
+    "coefficient": 0.505,
+    "rank": 2
+  },
+  "carol": {
+    "band": "B",
+    "coefficient": 0.3025,
+    "rank": 3
+  }
+}

--- a/tests/roster/test_ranking.py
+++ b/tests/roster/test_ranking.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loto.roster.ranking import update_ranking
+
+
+@pytest.fixture
+def golden(request):
+    path = Path(request.node.fspath).with_suffix(".golden.json")
+    expected = json.loads(path.read_text())
+
+    def check(data: object) -> None:
+        assert data == expected
+
+    return check
+
+
+def test_update_ranking(golden):
+    ledger = {
+        "alice": [(0.7, 0.8), (0.8, 0.9), (0.9, 1.0)],
+        "bob": [(0.5, 0.4), (0.4, 0.5), (0.6, 0.5)],
+        "carol": [(0.2, 0.1), (0.3, 0.2), (0.4, 0.3)],
+    }
+
+    snapshot = update_ranking(ledger)
+    golden(snapshot)


### PR DESCRIPTION
## Summary
- add roster ranking module applying composite scores, EWMA smoothing, shrinkage, banding and caps
- record golden snapshot to verify ranking coefficients and bands

## Testing
- `pre-commit run --files loto/roster/__init__.py loto/roster/ranking.py tests/roster/test_ranking.py tests/roster/test_ranking.golden.json`
- `make lint`
- `make typecheck`
- `make test` *(fails: tests/pricing/test_providers.py, tests/pricing/test_providers_cache.py, tests/scheduling/test_gates_inventory_flow.py, tests/sim/test_invariants.py, tests/sim/test_stimulus_types.py, tests/test_config.py, tests/test_graph_builder.py, tests/test_impact_engine.py, tests/test_integrations_adapters.py, tests/test_inventory.py, tests/test_planner_min_cut.py, tests/test_renderer_json.py, tests/test_renderer_pdf.py, tests/test_service_blueprints.py, tests/test_service_scheduling.py, tests/test_sim_apply.py, tests/test_sim_stimuli.py, tests/workflows/test_procurement.py: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68a430908f508322b4eca79f081a1cb1