### PR TITLE
Add hats KPI endpoint

### DIFF
--- a/apps/api/hats_endpoints.py
+++ b/apps/api/hats_endpoints.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, cast
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from loto.roster import storage, update_ranking
+
+from .schemas import HatKpiRequest, HatKpiResponse
+
+router = APIRouter(prefix="/hats", tags=["hats"])
+
+
+class HatSnapshot(BaseModel):
+    """Snapshot of ranking information for a hat."""
+
+    hat_id: str = Field(..., description="Identifier of the hat")
+    rank: int = Field(0, description="Rank among hats (1 = best)")
+    c_r: float = Field(0.5, description="Ranking coefficient")
+    n_samples: int = Field(0, description="Number of KPI events")
+    last_event_at: datetime | None = Field(
+        None, description="Timestamp of the most recent event"
+    )
+
+    class Config:
+        extra = "forbid"
+
+
+def _ledger_path() -> Path:
+    return Path(
+        os.getenv(
+            "HATS_LEDGER_PATH",
+            os.getenv("HATS_LEDGER_FILE", "hats_ledger.jsonl"),
+        )
+    )
+
+
+def _snapshot_path() -> Path:
+    return Path(
+        os.getenv(
+            "HATS_SNAPSHOT_PATH",
+            os.getenv("HATS_SNAPSHOT_FILE", "hats_snapshot.json"),
+        )
+    )
+
+
+def _read_ledger() -> Tuple[Dict[str, List[List[float]]], Dict[str, Dict[str, Any]]]:
+    path = _ledger_path()
+    entries = storage.read_ledger(path)
+    ledger: Dict[str, List[List[float]]] = {}
+    stats: Dict[str, Dict[str, Any]] = {}
+    for entry in entries:
+        hat_id = str(entry.get("hat_id"))
+        metrics_raw = (
+            entry.get("metrics")
+            or entry.get("values")
+            or entry.get("data")
+            or entry.get("value")
+        )
+        if metrics_raw is None:
+            metrics_raw = [
+                float(entry[k]) for k in ("SA", "SP", "RQ", "OF") if k in entry
+            ]
+        if not metrics_raw:
+            continue
+        if not isinstance(metrics_raw, (list, tuple)):
+            metrics_raw = [metrics_raw]
+        metrics = [float(m) for m in metrics_raw]
+        ledger.setdefault(hat_id, []).append(metrics)
+
+        stat = stats.setdefault(hat_id, {"n_samples": 0, "last_event_at": None})
+        stat["n_samples"] += 1
+        ts = entry.get("timestamp") or entry.get("ts")
+        if ts:
+            dt = datetime.fromisoformat(str(ts))
+            prev = stat["last_event_at"]
+            if prev is None or dt > prev:
+                stat["last_event_at"] = dt
+    return ledger, stats
+
+
+def _neutral_snapshot(hat_id: str, stats: Dict[str, Any] | None = None) -> HatSnapshot:
+    stats = stats or {}
+    return HatSnapshot(
+        hat_id=hat_id,
+        rank=0,
+        c_r=0.5,
+        n_samples=int(stats.get("n_samples", 0)),
+        last_event_at=stats.get("last_event_at"),
+    )
+
+
+@router.get("", response_model=list[HatSnapshot])
+async def list_hats() -> list[HatSnapshot]:
+    """Return ranking snapshots for all hats."""
+
+    ledger, stats = _read_ledger()
+    if not ledger:
+        return []
+    ranking = update_ranking(ledger)
+    snapshots: list[HatSnapshot] = []
+    for hat_id, info in ranking.items():
+        stat = stats.get(hat_id)
+        rank = cast(int, info.get("rank", 0))
+        coef = cast(float, info.get("coefficient", 0.5))
+        snapshots.append(
+            HatSnapshot(
+                hat_id=hat_id,
+                rank=rank,
+                c_r=coef,
+                n_samples=int(stat["n_samples"]) if stat else 0,
+                last_event_at=stat.get("last_event_at") if stat else None,
+            )
+        )
+    return sorted(snapshots, key=lambda s: s.rank)
+
+
+@router.get("/{hat_id}", response_model=HatSnapshot)
+async def get_hat(hat_id: str) -> HatSnapshot:
+    """Return ranking snapshot for a single hat."""
+
+    ledger, stats = _read_ledger()
+    if not ledger:
+        return _neutral_snapshot(hat_id)
+    ranking = update_ranking(ledger)
+    info = ranking.get(hat_id)
+    stat = stats.get(hat_id)
+    if not info:
+        return _neutral_snapshot(hat_id, stat)
+    rank = cast(int, info.get("rank", 0))
+    coef = cast(float, info.get("coefficient", 0.5))
+    return HatSnapshot(
+        hat_id=hat_id,
+        rank=rank,
+        c_r=coef,
+        n_samples=int(stat.get("n_samples", 0)) if stat else 0,
+        last_event_at=stat.get("last_event_at") if stat else None,
+    )
+
+
+@router.post("/kpi", response_model=HatKpiResponse)
+async def post_kpi(payload: HatKpiRequest) -> HatKpiResponse:
+    """Record KPI metrics for a hat and return updated ranking."""
+
+    entry = payload.dict(exclude_none=True)
+    ledger_path = _ledger_path()
+    snapshot_path = _snapshot_path()
+    try:
+        storage.append_ledger(ledger_path, entry)
+    except ValueError:
+        # Duplicate entry – idempotent behaviour
+        pass
+
+    entries = storage.read_ledger(ledger_path)
+    snapshot = storage.compute_snapshot(entries)
+    storage.write_snapshot(snapshot_path, snapshot)
+
+    ranking_ledger: Dict[str, List[List[float]]] = defaultdict(list)
+    for e in snapshot.values():
+        metrics: List[float] = []
+        for key in ("SA", "SP", "RQ", "OF"):
+            if key in e:
+                metrics.append(float(e[key]))
+        ranking_ledger[str(e["hat_id"])].append(metrics)
+
+    ranking = update_ranking(ranking_ledger)
+    data = ranking.get(payload.hat_id)
+    if data is None:
+        raise HTTPException(status_code=500, detail="ranking failed")
+    return HatKpiResponse(**data)

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -30,6 +30,7 @@ from loto.scheduling.monte_carlo import simulate
 from loto.service import plan_and_evaluate
 from loto.service.blueprints import inventory_state
 
+from .hats_endpoints import router as hats_router
 from .pid_endpoints import router as pid_router
 from .schemas import (
     BlueprintRequest,
@@ -55,6 +56,7 @@ if origins:
     )
 
 app.include_router(pid_router)
+app.include_router(hats_router)
 
 
 AUTH_REQUIRED = os.getenv("AUTH_REQUIRED", "").lower() == "true"

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -81,3 +81,28 @@ class ScheduleResponse(BaseModel):
 
     class Config:
         extra = "forbid"
+
+
+class HatKpiRequest(BaseModel):
+    """Request body for the /hats/kpi endpoint."""
+
+    wo_id: str = Field(..., description="Work order identifier")
+    hat_id: str = Field(..., description="Hat identifier")
+    SA: float = Field(..., ge=0.0, le=1.0, description="SA metric")
+    SP: float = Field(..., ge=0.0, le=1.0, description="SP metric")
+    RQ: float | None = Field(None, ge=0.0, le=1.0, description="RQ metric", title="RQ")
+    OF: float | None = Field(None, ge=0.0, le=1.0, description="OF metric", title="OF")
+
+    class Config:
+        extra = "forbid"
+
+
+class HatKpiResponse(BaseModel):
+    """Response model for the /hats/kpi endpoint."""
+
+    rank: int = Field(..., description="Position in ranking")
+    coefficient: float = Field(..., description="Composite coefficient")
+    band: str = Field(..., description="Band classification")
+
+    class Config:
+        extra = "forbid"

--- a/tests/api/test_hats_api.py
+++ b/tests/api/test_hats_api.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from loto.roster import storage
+
+
+def _setup_env(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    ledger = tmp_path / "ledger.jsonl"
+    snapshot = tmp_path / "snapshot.json"
+    monkeypatch.setenv("HATS_LEDGER_FILE", str(ledger))
+    monkeypatch.setenv("HATS_SNAPSHOT_FILE", str(snapshot))
+    return ledger, snapshot
+
+
+def test_post_kpi(monkeypatch, tmp_path: Path) -> None:
+    _setup_env(monkeypatch, tmp_path)
+    client = TestClient(app)
+    payload = {"wo_id": "1", "hat_id": "hat1", "SA": 0.5, "SP": 0.7}
+    res = client.post("/hats/kpi", json=payload)
+    assert res.status_code == 200
+    assert res.json() == {"rank": 1, "coefficient": 0.6, "band": "A"}
+
+
+def test_post_kpi_bad_payload(monkeypatch, tmp_path: Path) -> None:
+    _setup_env(monkeypatch, tmp_path)
+    client = TestClient(app)
+    res = client.post("/hats/kpi", json={"wo_id": "1"})
+    assert res.status_code == 422
+
+
+def test_post_kpi_idempotent(monkeypatch, tmp_path: Path) -> None:
+    ledger_path, _ = _setup_env(monkeypatch, tmp_path)
+    client = TestClient(app)
+    payload = {"wo_id": "1", "hat_id": "hat1", "SA": 0.5, "SP": 0.7}
+    res1 = client.post("/hats/kpi", json=payload)
+    res2 = client.post("/hats/kpi", json=payload)
+    assert res1.status_code == res2.status_code == 200
+    assert res1.json() == res2.json()
+    assert len(storage.read_ledger(ledger_path)) == 1


### PR DESCRIPTION
## Summary
- merge hats snapshot listing endpoints with KPI posting
- handle SA/SP/RQ/OF metrics in ledger reader
- keep KPI endpoint writing snapshot and returning ranking

## Testing
- `pre-commit run --files apps/api/hats_endpoints.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a4334764f883229e860f4cd3ac2e2c