### PR TITLE
Add KPI endpoint for hats

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -30,7 +30,7 @@ from loto.scheduling.monte_carlo import simulate
 from loto.service import plan_and_evaluate
 from loto.service.blueprints import inventory_state
 
-from .hats_endpoints import router as hats_router
+from .hats_endpoints import router as hats_router  # provides hats KPI endpoints
 from .pid_endpoints import router as pid_router
 from .schemas import (
     BlueprintRequest,

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Dict, List
 
 from pydantic import BaseModel, Field
@@ -78,6 +79,36 @@ class ScheduleResponse(BaseModel):
     )
     seed: str = Field(..., description="Seed used for deterministic simulation")
     objective: float = Field(..., description="Objective value for the schedule")
+
+    class Config:
+        extra = "forbid"
+
+
+class HatKpiRequest(BaseModel):
+    """Payload for recording hat KPI metrics."""
+
+    wo_id: str = Field(..., description="Work order identifier")
+    hat_id: str = Field(..., description="Hat identifier")
+    SA: float = Field(..., description="Safety metric A")
+    SP: float = Field(..., description="Safety metric P")
+    RQ: float | None = Field(None, description="Optional RQ metric")
+    OF: float | None = Field(None, description="Optional OF metric")
+
+    class Config:
+        extra = "forbid"
+
+
+class HatSnapshot(BaseModel):
+    """Snapshot of ranking information for a hat."""
+
+    hat_id: str = Field(..., description="Identifier of the hat")
+    rank: int = Field(0, description="Rank among hats (1 = best)")
+    c_r: float = Field(0.5, description="Ranking coefficient")
+    n_samples: int = Field(0, description="Number of KPI events")
+    last_event_at: datetime | None = Field(
+        None,
+        description="Timestamp of the most recent event",
+    )
 
     class Config:
         extra = "forbid"

--- a/tests/api/test_hats_api.py
+++ b/tests/api/test_hats_api.py
@@ -1,0 +1,46 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+
+
+def test_post_kpi_and_idempotent(tmp_path, monkeypatch):
+    ledger = tmp_path / "ledger.jsonl"
+    snapshot = tmp_path / "snapshot.json"
+    monkeypatch.setenv("HATS_LEDGER_PATH", str(ledger))
+    monkeypatch.setenv("HATS_SNAPSHOT_PATH", str(snapshot))
+
+    client = TestClient(app)
+    payload = {"wo_id": "1", "hat_id": "h1", "SA": 0.8, "SP": 0.9}
+
+    res = client.post("/hats/kpi", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["hat_id"] == "h1"
+    assert data["rank"] == 1
+    assert data["c_r"] == 0.85
+    assert data["n_samples"] == 1
+
+    # Ledger and snapshot written
+    assert ledger.exists() and snapshot.exists()
+    assert len(ledger.read_text().strip().splitlines()) == 1
+    snap = json.loads(snapshot.read_text())
+    assert snap  # not empty
+
+    # Second post is idempotent
+    res2 = client.post("/hats/kpi", json=payload)
+    assert res2.status_code == 200
+    assert res2.json() == data
+    assert len(ledger.read_text().strip().splitlines()) == 1
+
+
+def test_post_kpi_bad_payload(monkeypatch, tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    snapshot = tmp_path / "snapshot.json"
+    monkeypatch.setenv("HATS_LEDGER_PATH", str(ledger))
+    monkeypatch.setenv("HATS_SNAPSHOT_PATH", str(snapshot))
+
+    client = TestClient(app)
+    res = client.post("/hats/kpi", json={"wo_id": "1"})
+    assert res.status_code == 422


### PR DESCRIPTION
## Summary
- support recording hat KPIs with POST `/hats/kpi`
- expose HatKpiRequest and HatSnapshot schemas
- test KPI endpoint success, idempotence and validation

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `pre-commit run --files apps/api/hats_endpoints.py apps/api/main.py apps/api/schemas.py tests/api/test_hats_api.py`
- `make test` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68a4397657ec8322967b573056992834