### PR TITLE
feat: rank-aware assignment

### DIFF
--- a/loto/scheduling/assign.py
+++ b/loto/scheduling/assign.py
@@ -1,0 +1,61 @@
+"""Simple assignment helper.
+
+This module provides minimal functionality for allocating tasks to hats
+based on skill and availability gates with an optional rank bias.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Sequence
+
+
+class RankBias(Protocol):
+    """Protocol describing a rank bias helper."""
+
+    def duration_with_rank(self, duration_s: float, rank: int) -> float:
+        """Return objective duration adjusted for ``rank``."""
+
+
+@dataclass(frozen=True)
+class Hat:
+    """Representation of a worker hat in the scheduler."""
+
+    id: str
+    skills: set[str]
+    calendar: set[int]
+    rank: int
+
+
+@dataclass(frozen=True)
+class Task:
+    """Representation of a schedulable task."""
+
+    skill: str
+    start: int
+    duration_s: float = 0.0
+
+
+def simulate(task: Task, hats: Sequence[Hat], rank_bias: RankBias) -> Hat | None:
+    """Return the best hat candidate for ``task``.
+
+    Hats are filtered by skill and calendar availability.  Among the
+    eligible candidates the one with the lowest adjusted duration
+    according to ``rank_bias`` is returned.  ``None`` is returned when no
+    candidate satisfies the gating criteria.
+    """
+
+    candidates: list[tuple[float, Hat]] = []
+    for hat in hats:
+        if task.skill not in hat.skills:
+            continue
+        if task.start not in hat.calendar:
+            continue
+        objective = rank_bias.duration_with_rank(task.duration_s, hat.rank)
+        candidates.append((objective, hat))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda pair: pair[0])
+    return candidates[0][1]

--- a/tests/scheduling/test_assign_ranked.py
+++ b/tests/scheduling/test_assign_ranked.py
@@ -1,0 +1,31 @@
+from loto.scheduling.assign import Hat, Task, simulate
+
+
+class _Bias:
+    """Deterministic rank bias for testing."""
+
+    def duration_with_rank(self, duration_s: float, rank: int) -> float:
+        # Increase the objective by the rank value so lower rank numbers are preferred
+        return duration_s + rank
+
+
+def test_prefers_higher_rank():
+    hats = [
+        Hat(id="h1", skills={"w"}, calendar={0}, rank=2),
+        Hat(id="h2", skills={"w"}, calendar={0}, rank=1),
+    ]
+    task = Task(skill="w", start=0, duration_s=1)
+    chosen = simulate(task, hats, _Bias())
+    assert chosen is not None
+    assert chosen.id == "h2"
+
+
+def test_respects_calendar():
+    hats = [
+        Hat(id="h1", skills={"w"}, calendar={1}, rank=1),
+        Hat(id="h2", skills={"w"}, calendar={0}, rank=2),
+    ]
+    task = Task(skill="w", start=0, duration_s=1)
+    chosen = simulate(task, hats, _Bias())
+    assert chosen is not None
+    assert chosen.id == "h2"


### PR DESCRIPTION
## Summary
- add rank-aware candidate simulation
- test assignment bias toward higher-ranked hats while respecting availability

## Testing
- `pre-commit run --files loto/scheduling/assign.py tests/scheduling/test_assign_ranked.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a43bc263c08322a445ce25708aedf6