### PR TITLE
Add rank-based duration bias with tests

### DIFF
--- a/loto/scheduling/rank_bias.py
+++ b/loto/scheduling/rank_bias.py
@@ -1,0 +1,34 @@
+"""Utilities for adjusting durations based on hat rank.
+
+This module exposes :func:`duration_with_rank` which applies a simple
+multiplier to a base duration according to a hat's rank.  The multiplier grows
+linearly with the rank and is capped to avoid extreme values.
+"""
+
+from __future__ import annotations
+
+__all__ = ["duration_with_rank"]
+
+_CR = 1.5  # maximum allowed multiplier
+_C = 1.0  # baseline multiplier for rank 1
+_R = 0.1  # incremental multiplier per additional rank
+
+
+def duration_with_rank(base_dur: float, hat_rank: int) -> float:
+    """Return the biased duration for a task.
+
+    Parameters
+    ----------
+    base_dur:
+        The nominal duration of the task.
+    hat_rank:
+        Rank of the hat performing the task (1 = best).
+
+    Returns
+    -------
+    float
+        Duration after applying rank bias.
+    """
+
+    multiplier = min(_CR, _C + (hat_rank - 1) * _R)
+    return base_dur * multiplier

--- a/tests/scheduling/test_rank_bias.py
+++ b/tests/scheduling/test_rank_bias.py
@@ -1,0 +1,18 @@
+import pytest
+
+from loto.scheduling.rank_bias import duration_with_rank
+
+
+@pytest.mark.parametrize(
+    "rank,multiplier",
+    [
+        (1, 1.0),
+        (2, 1.1),
+        (5, 1.4),
+        (6, 1.5),  # cap reached
+        (10, 1.5),  # cap maintained
+    ],
+)
+def test_duration_with_rank(rank, multiplier):
+    base = 10.0
+    assert duration_with_rank(base, rank) == base * multiplier


### PR DESCRIPTION
## Summary
- add `duration_with_rank` helper applying rank-based multipliers with a cap
- test rank bias multipliers and cap via parameterised cases

## Testing
- `pre-commit run --files loto/scheduling/rank_bias.py tests/scheduling/test_rank_bias.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a43bb033408322ae1a251df11922ca