### PR TITLE
Add reactive hat chooser

### DIFF
--- a/loto/scheduling/__init__.py
+++ b/loto/scheduling/__init__.py
@@ -3,5 +3,14 @@
 from .des_engine import RunResult, Task, run
 from .monte import BandResult, bands
 from .monte_carlo import simulate
+from .reactive import choose_hats_for_reactive
 
-__all__ = ["Task", "RunResult", "run", "simulate", "bands", "BandResult"]
+__all__ = [
+    "Task",
+    "RunResult",
+    "run",
+    "simulate",
+    "bands",
+    "BandResult",
+    "choose_hats_for_reactive",
+]

--- a/loto/scheduling/reactive.py
+++ b/loto/scheduling/reactive.py
@@ -1,0 +1,84 @@
+"""Helpers for selecting hats for reactive work orders."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def choose_hats_for_reactive(
+    wo: Any,
+    candidates: Sequence[str],
+    snapshot: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> list[str]:
+    """Return a list of chosen hats for a reactive work order.
+
+    Parameters
+    ----------
+    wo:
+        Work order object.  The function is agnostic to its structure and only
+        uses it as an opaque handle.
+    candidates:
+        Iterable of hat identifiers that are currently available.
+    snapshot:
+        Mapping of hat identifier to an object exposing a ``c_r`` attribute
+        representing the ranking coefficient for that hat.
+    policy:
+        Mapping defining selection policy.  The following keys are recognised:
+
+        ``rotation`` (mapping):
+            Number of recent rotations for each hat.  Higher values incur a
+            penalty.
+        ``rotation_penalty`` (float):
+            Amount subtracted from the ranking coefficient for each rotation.
+        ``rotation_limit`` (int | None):
+            Maximum number of rotations allowed before a hat is excluded.
+        ``utilization`` (mapping):
+            Current utilization for each hat expressed as a fraction.
+        ``utilization_cap`` (float):
+            Upper bound on utilization; hats meeting or exceeding this value are
+            not considered.
+        ``crew_size`` (int):
+            Number of hats to select.  Defaults to ``1``.
+
+    Returns
+    -------
+    list[str]
+        Chosen hat identifiers.  The list length will not exceed ``crew_size``.
+    """
+
+    rotation = policy.get("rotation", {})
+    rotation_limit = policy.get("rotation_limit")
+    rotation_penalty = policy.get("rotation_penalty", 0.0)
+    utilization = policy.get("utilization", {})
+    util_cap = policy.get("utilization_cap", 1.0)
+    crew_size = int(policy.get("crew_size", 1))
+
+    eligible: list[str] = []
+    weights: list[float] = []
+    for hat in candidates:
+        snap = snapshot.get(hat)
+        if snap is None:
+            continue
+        if utilization.get(hat, 0.0) >= util_cap:
+            continue
+        rot = rotation.get(hat, 0)
+        if rotation_limit is not None and rot >= rotation_limit:
+            continue
+        score = float(getattr(snap, "c_r", 0.0)) - rotation_penalty * rot
+        if score < 0:
+            score = 0.0
+        eligible.append(hat)
+        weights.append(score)
+
+    if not eligible:
+        return []
+
+    weight_seq: Sequence[float] | None = weights
+    if all(w == 0 for w in weights):
+        weight_seq = None
+
+    k = min(crew_size, len(eligible))
+    return random.choices(eligible, weights=weight_seq, k=k)

--- a/tests/scheduling/test_reactive_ranked.py
+++ b/tests/scheduling/test_reactive_ranked.py
@@ -1,0 +1,36 @@
+import random
+from dataclasses import dataclass
+
+from loto.scheduling import choose_hats_for_reactive
+
+
+@dataclass
+class Snap:
+    hat_id: str
+    rank: int
+    c_r: float
+
+
+def test_choose_hats_prefers_higher_rank():
+    wo = object()
+    candidates = ["h1", "h2"]
+    snapshot = {
+        "h1": Snap("h1", 1, 0.9),
+        "h2": Snap("h2", 2, 0.5),
+    }
+    policy = {
+        "rotation": {},
+        "rotation_penalty": 0.1,
+        "rotation_limit": 2,
+        "utilization": {},
+        "utilization_cap": 1.0,
+    }
+
+    random.seed(123)
+    chosen = choose_hats_for_reactive(wo, candidates, snapshot, policy)
+    assert chosen == ["h1"]
+
+    policy["rotation"] = {"h1": 2}
+    random.seed(123)
+    chosen = choose_hats_for_reactive(wo, candidates, snapshot, policy)
+    assert chosen == ["h2"]


### PR DESCRIPTION
## Summary
- select hats for reactive work orders using ranking coefficient, rotation penalties, and utilization limits
- expose choose_hats_for_reactive from scheduling package
- add unit test ensuring higher-ranked hat is chosen unless rotation limit prevents it

## Testing
- `pre-commit run --files loto/scheduling/reactive.py loto/scheduling/__init__.py tests/scheduling/test_reactive_ranked.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test` *(fails: ERROR tests/pricing/test_providers.py, tests/pricing/test_providers_cache.py, tests/scheduling/test_gates_inventory_flow.py, ...)*

------
https://chatgpt.com/codex/tasks/task_b_68a43bee108083228c7afd2e19ee8147