### PR TITLE
feat(ui): add reactive hat picker

### DIFF
--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -19,10 +19,17 @@ test('renders gantt, price curve and hats timeline', async () => {
     seed: 'abc',
     objective: 0.95
   };
-  const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
-    ok: true,
-    json: async () => sample
-  } as Response);
+  const fetchMock = vi
+    .spyOn(global, 'fetch')
+    .mockImplementation((input: RequestInfo) => {
+      if (typeof input === 'string' && input === '/schedule') {
+        return Promise.resolve({ ok: true, json: async () => sample } as Response);
+      }
+      if (typeof input === 'string' && input === '/api/hats') {
+        return Promise.resolve({ ok: true, json: async () => [] } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
 
   const { container } = render(<Page params={{ wo: 'WO-1' }} />);
 

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Gantt from '../../../components/Gantt';
+import ReactivePicker from '../../../components/ReactivePicker';
 import { useSchedule } from '../../../lib/schedule';
 
 const queryClient = new QueryClient();
@@ -14,6 +15,7 @@ function SchedulerContent({ wo }: { wo: string }) {
     <main className="h-full flex flex-col">
       <h1 className="mb-4 text-xl font-semibold">Scheduler: {wo}</h1>
       <Gantt data={schedule} />
+      <ReactivePicker wo={wo} />
       <footer className="mt-4 text-sm text-gray-500" data-testid="schedule-meta">
         Seed: {seed} Objective: {objective}
       </footer>

--- a/apps/maximo-extension-ui/src/components/ReactivePicker.test.tsx
+++ b/apps/maximo-extension-ui/src/components/ReactivePicker.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, afterEach, test, expect, vi } from 'vitest';
+import ReactivePicker from './ReactivePicker';
+
+const mockHats = [
+  { hat_id: 'h1', c_r: 0.8, rotation: 1 },
+  { hat_id: 'h2', c_r: 0.6 }
+];
+
+beforeEach(() => {
+  vi.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => mockHats
+  } as any);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('renders hats with rotation penalty highlighted', async () => {
+  const client = new QueryClient();
+  render(
+    <QueryClientProvider client={client}>
+      <ReactivePicker wo="100" />
+    </QueryClientProvider>
+  );
+  await waitFor(() => screen.getByText(/h1/));
+  expect(screen.getByText(/h1/)).toBeInTheDocument();
+  expect(screen.getByText(/rotation penalty/)).toBeInTheDocument();
+});
+

--- a/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
+++ b/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+interface HatCandidate {
+  hat_id: string;
+  c_r: number;
+  rotation?: number;
+}
+
+async function fetchCandidates(): Promise<HatCandidate[]> {
+  const res = await fetch('/api/hats');
+  if (!res.ok) throw new Error('Failed to fetch hats');
+  return (await res.json()) as HatCandidate[];
+}
+
+export default function ReactivePicker({ wo }: { wo: string }) {
+  const { data } = useQuery({ queryKey: ['reactive', wo], queryFn: fetchCandidates });
+  if (!data) return null;
+  return (
+    <section className="mt-4">
+      <h2 className="text-lg font-semibold mb-2">Reactive candidates</h2>
+      <ul className="space-y-1">
+        {data.map((hat) => {
+          const delta = 1 - hat.c_r; // predicted finish delta from ranking coeff
+          const penalized = (hat.rotation ?? 0) > 0;
+          return (
+            <li key={hat.hat_id} className={penalized ? 'text-red-600' : ''}>
+              <span className="font-mono">{hat.hat_id}</span>
+              {` \u2013 Δfinish ${delta.toFixed(2)}`}
+              {penalized && (
+                <span className="ml-2 text-xs">(rotation penalty)</span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- list candidate hats with finish delta and rotation penalty
- show reactive hat candidates on scheduler page
- cover picker with unit tests

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/components/ReactivePicker.tsx apps/maximo-extension-ui/src/components/ReactivePicker.test.tsx apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a43e46e3948322ad0781727c6f8828