### PR TITLE
feat(ui): add hats timeline rank badges

### DIFF
--- a/apps/maximo-extension-ui/src/components/HatsTimeline.test.tsx
+++ b/apps/maximo-extension-ui/src/components/HatsTimeline.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import HatsTimeline, { HatLane } from './HatsTimeline';
+
+test('shows rank badge and labelled tooltip', () => {
+  const lanes: HatLane[] = [
+    { id: 'a', rank: 1, cr: 5, c: 4, r: 3, kpis: [1, 2, 3, 4, 5] }
+  ];
+  render(<HatsTimeline lanes={lanes} />);
+  expect(screen.getByText('1')).toBeInTheDocument();
+  const tooltip = screen.getByRole('tooltip', { name: /cr 5/ });
+  expect(tooltip).toBeInTheDocument();
+});

--- a/apps/maximo-extension-ui/src/components/HatsTimeline.tsx
+++ b/apps/maximo-extension-ui/src/components/HatsTimeline.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export interface HatLane {
+  id: string;
+  rank: 1 | 2 | 3 | 4;
+  cr: number;
+  c: number;
+  r: number;
+  kpis: Array<number | string>;
+}
+
+/**
+ * Render a simple timeline for hats with rank badges and accessible tooltips.
+ */
+export default function HatsTimeline({ lanes }: { lanes: HatLane[] }) {
+  return (
+    <div className="flex flex-col space-y-2">
+      {lanes.map((lane) => {
+        const tooltip = `cr ${lane.cr}\nc ${lane.c}\nr ${lane.r}\n${lane.kpis.slice(-3).join(', ')}`;
+        return (
+          <div key={lane.id} className="relative h-6 flex items-center pl-8">
+            <span
+              className="absolute left-0 inline-flex items-center justify-center w-6 h-6 rounded-full bg-blue-500 text-white text-xs font-bold"
+            >
+              {lane.rank}
+            </span>
+            <div
+              role="tooltip"
+              aria-label={tooltip}
+              className="flex-1 h-4 bg-gray-200 rounded"
+              title={tooltip}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add HatsTimeline component to render rank badges for hat lanes with tooltips
- test tooltip labeling

## Testing
- `pnpm -F maximo-extension-ui test`
- `make test` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_b_68a43e37b3b48322b794b7692c6fc0cf