### PR TITLE
feat(ui): add hats admin telemetry page

### DIFF
--- a/apps/maximo-extension-ui/src/lib/hats.ts
+++ b/apps/maximo-extension-ui/src/lib/hats.ts
@@ -1,0 +1,20 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import type { HatSnapshot } from '../types/api';
+
+/**
+ * Fetch ranking snapshots for all hats from the API.
+ */
+async function fetchHats(): Promise<HatSnapshot[]> {
+  const res = await fetch('/hats');
+  if (!res.ok) {
+    throw new Error('Failed to fetch hats');
+  }
+  return res.json();
+}
+
+/**
+ * Query hook for hat ranking snapshots.
+ */
+export function useHats(): UseQueryResult<HatSnapshot[]> {
+  return useQuery({ queryKey: ['hats'], queryFn: fetchHats });
+}

--- a/apps/maximo-extension-ui/src/pages/HatsAdmin.tsx
+++ b/apps/maximo-extension-ui/src/pages/HatsAdmin.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from 'react';
+import { useHats } from '../lib/hats';
+import type { HatSnapshot } from '../types/api';
+
+function Sparkline({ value }: { value: number }) {
+  const h = 20;
+  const w = 60;
+  const y = h - value * h;
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} className="text-[var(--mxc-topbar-bg)]">
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        points={`0,${y} ${w},${y}`}
+      />
+    </svg>
+  );
+}
+
+export default function HatsAdmin() {
+  const { data } = useHats();
+  const hats: HatSnapshot[] = data ?? [];
+
+  const [weights, setWeights] = useState<Record<string, number>>({});
+  const [locked, setLocked] = useState<Record<string, boolean>>({});
+  const [showInfo, setShowInfo] = useState(false);
+
+  const weighted = useMemo(() => {
+    return hats
+      .map((h) => {
+        const weight = weights[h.hat_id] ?? 1;
+        return { ...h, weight, preview: h.c_r * weight };
+      })
+      .sort((a, b) => b.preview - a.preview);
+  }, [hats, weights]);
+
+  const updateWeight = (id: string, v: number) => {
+    setWeights((prev) => ({ ...prev, [id]: v }));
+  };
+
+  const toggleLock = (id: string) => {
+    setLocked((prev) => ({ ...prev, [id]: !(prev[id] ?? true) }));
+  };
+
+  return (
+    <main>
+      <h1 className="mb-4 text-xl font-semibold">Hats Admin</h1>
+      <div className="mb-4 text-sm">
+        <button
+          className="underline"
+          type="button"
+          onClick={() => setShowInfo(!showInfo)}
+        >
+          explain rank
+        </button>
+        {showInfo && (
+          <div className="mt-2 max-w-md rounded border bg-white p-2 shadow">
+            Rankings use an exponentially weighted moving average (EWMA)
+            with shrinkage toward neutral performance.
+          </div>
+        )}
+      </div>
+      <table className="min-w-full border border-[var(--mxc-border)]">
+        <thead className="bg-[var(--mxc-nav-bg)] text-left">
+          <tr>
+            <th className="px-4 py-2">Hat</th>
+            <th className="px-4 py-2">Rank</th>
+            <th className="px-4 py-2">c_r</th>
+            <th className="px-4 py-2">Samples</th>
+            <th className="px-4 py-2">Last event</th>
+            <th className="px-4 py-2">Trend</th>
+            <th className="px-4 py-2">Weight</th>
+          </tr>
+        </thead>
+        <tbody>
+          {weighted.map((h) => (
+            <tr key={h.hat_id}>
+              <td className="px-4 py-2">{h.hat_id}</td>
+              <td className="px-4 py-2">{h.rank}</td>
+              <td className="px-4 py-2">{h.c_r.toFixed(2)}</td>
+              <td className="px-4 py-2">{h.n_samples}</td>
+              <td className="px-4 py-2">
+                {h.last_event_at ? new Date(h.last_event_at).toLocaleString() : '-'}
+              </td>
+              <td className="px-4 py-2">
+                <Sparkline value={h.c_r} />
+              </td>
+              <td className="px-4 py-2">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="range"
+                    min={0}
+                    max={2}
+                    step={0.1}
+                    value={weights[h.hat_id] ?? 1}
+                    disabled={locked[h.hat_id] ?? true}
+                    onChange={(e) => updateWeight(h.hat_id, Number(e.target.value))}
+                  />
+                  <button
+                    type="button"
+                    className="text-xl"
+                    onClick={() => toggleLock(h.hat_id)}
+                  >
+                    {locked[h.hat_id] ?? true ? '🔒' : '🔓'}
+                  </button>
+                </div>
+              </td>
+            </tr>
+          ))}
+          {weighted.length === 0 && (
+            <tr>
+              <td className="px-4 py-6 text-center" colSpan={7}>
+                No data
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/apps/maximo-extension-ui/src/types/api.ts
+++ b/apps/maximo-extension-ui/src/types/api.ts
@@ -54,3 +54,11 @@ export interface InventoryItem {
   eta?: string;
   status: InventoryStatus;
 }
+
+export interface HatSnapshot {
+  hat_id: string;
+  rank: number;
+  c_r: number;
+  n_samples: number;
+  last_event_at?: string;
+}


### PR DESCRIPTION
## Summary
- add Hook to fetch hat ranking data
- add Hats admin page with rank table, weight sliders, and info popover
- define HatSnapshot API type

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/lib/hats.ts apps/maximo-extension-ui/src/pages/HatsAdmin.tsx apps/maximo-extension-ui/src/types/api.ts`
- `pnpm -F maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a43e2e2068832299925dcc6ffe60e1