### PR TITLE
Add configurable roster policy

### DIFF
--- a/config/hats_policy.yaml
+++ b/config/hats_policy.yaml
@@ -1,0 +1,6 @@
+weights: [0.5, 0.5]
+half_life: 1
+pseudo_count: 0.1
+incident_cap: 10
+rotation_window: 2
+daily_utilization_cap: 1.0

--- a/loto/roster/policy.py
+++ b/loto/roster/policy.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_DEFAULT_PATH = Path(__file__).resolve().parents[2] / "config" / "hats_policy.yaml"
+
+
+def load_policy(path: str | Path = _DEFAULT_PATH) -> dict[str, Any]:
+    """Return policy configuration from *path*.
+
+    The file is expected to contain YAML with keys defining ranking and chooser
+    behaviour.  The returned mapping is normalised to the keys used by the
+    ranking and scheduling helpers.
+    """
+
+    data = yaml.safe_load(Path(path).read_text()) or {}
+    policy: dict[str, Any] = {
+        "weights": data.get("weights"),
+        "half_life": data.get("half_life"),
+        "pseudo_count": data.get("pseudo_count"),
+        "incident_cap": data.get("incident_cap"),
+        "rotation_limit": data.get("rotation_window"),
+        "utilization_cap": data.get("daily_utilization_cap"),
+    }
+    return policy

--- a/tests/roster/test_policy.py
+++ b/tests/roster/test_policy.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from loto.roster import policy, ranking
+from loto.scheduling import choose_hats_for_reactive
+
+
+@dataclass
+class Snap:
+    c_r: float
+
+
+def test_yaml_affects_ranking(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "hats_policy.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump(
+            {
+                "weights": [1, 0],
+                "half_life": 1,
+                "pseudo_count": 0.0,
+                "incident_cap": 10,
+                "rotation_window": 1,
+                "daily_utilization_cap": 1.0,
+            }
+        )
+    )
+
+    ledger = {"h1": [(1.0, 0.0)], "h2": [(0.0, 1.0)]}
+    pol = policy.load_policy(cfg_path)
+    snap = ranking.update_ranking(ledger, pol)
+    assert snap["h1"]["rank"] == 1
+
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["weights"] = [0, 1]
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    pol = policy.load_policy(cfg_path)
+    snap = ranking.update_ranking(ledger, pol)
+    assert snap["h1"]["rank"] == 2
+
+
+def test_yaml_affects_chooser(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "hats_policy.yaml"
+    cfg = {
+        "weights": [0.5, 0.5],
+        "half_life": 1,
+        "pseudo_count": 0.0,
+        "incident_cap": 10,
+        "rotation_window": 1,
+        "daily_utilization_cap": 1.0,
+    }
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    wo = object()
+    candidates = ["h1", "h2"]
+    snapshot = {"h1": Snap(0.9), "h2": Snap(0.5)}
+
+    pol = policy.load_policy(cfg_path)
+    pol["rotation"] = {"h1": 1}
+    pol["utilization"] = {}
+    random.seed(123)
+    chosen = choose_hats_for_reactive(wo, candidates, snapshot, pol)
+    assert chosen == ["h2"]
+
+    cfg["rotation_window"] = 2
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    pol = policy.load_policy(cfg_path)
+    pol["rotation"] = {"h1": 1}
+    pol["utilization"] = {}
+    random.seed(123)
+    chosen = choose_hats_for_reactive(wo, candidates, snapshot, pol)
+    assert chosen == ["h1"]
+
+    cfg["daily_utilization_cap"] = 0.8
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    pol = policy.load_policy(cfg_path)
+    pol["rotation"] = {}
+    pol["utilization"] = {"h1": 0.9}
+    random.seed(123)
+    chosen = choose_hats_for_reactive(wo, candidates, snapshot, pol)
+    assert chosen == ["h2"]


### PR DESCRIPTION
## Summary
- support loading hat policy from YAML
- allow ranking to honor policy weights and decay
- test policy affects ranking and chooser

## Testing
- `pre-commit run --files loto/roster/ranking.py loto/roster/policy.py config/hats_policy.yaml tests/roster/test_policy.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a440bb89e48322991ed1f8c09d03e1