### PR TITLE
Add safety safeguards to roster metrics

### DIFF
--- a/tests/roster/test_safeguards.py
+++ b/tests/roster/test_safeguards.py
@@ -1,0 +1,38 @@
+import datetime
+
+from loto.roster.metrics import KpiEvent, safety_rank
+
+
+def test_clamp_and_demotion():
+    now = datetime.datetime.utcnow()
+    events = [KpiEvent(timestamp=now, incidents=10, total=1)]
+    rank = safety_rank(events)
+    assert rank.band == "red"
+    assert rank.score == 0.0
+
+
+def test_min_samples_neutral_rank():
+    now = datetime.datetime.utcnow()
+    events = [KpiEvent(timestamp=now, incidents=0, total=2)]
+    rank = safety_rank(events, min_samples=5)
+    assert rank.band == "amber"
+    assert rank.score == 0.5
+
+
+def test_cooldown_before_rank_lifts():
+    start = datetime.datetime(2024, 1, 1)
+    events = [
+        KpiEvent(timestamp=start, incidents=1, total=10),
+        KpiEvent(timestamp=start + datetime.timedelta(hours=1), incidents=0, total=10),
+    ]
+    rank = safety_rank(
+        events, now=start + datetime.timedelta(hours=2), cooldown_hours=24
+    )
+    assert rank.band == "red"
+    assert rank.score == 0.0
+
+    rank_after = safety_rank(
+        events, now=start + datetime.timedelta(days=2), cooldown_hours=24
+    )
+    assert rank_after.band == "green"
+    assert rank_after.score > 0.8


### PR DESCRIPTION
## Summary
- add clamp and safety_rank helpers for roster metrics
- guard rank lifts with min samples, incident demotion and cooldown
- cover safeguard scenarios with tests

## Testing
- `pre-commit run --files loto/roster/metrics.py tests/roster/test_safeguards.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a44197b63483229840c501135b9474