### PR TITLE
chore(ui): serve demo P&ID map via public directory

### DIFF
--- a/apps/maximo-extension-ui/public/demo/pids/pid_map.yaml
+++ b/apps/maximo-extension-ui/public/demo/pids/pid_map.yaml
@@ -1,0 +1,7 @@
+# Mapping of P&ID tags to CSS selectors used by overlay utilities.
+V-101: '#V101'
+V-102:
+  - '#V102A'
+  - '#V102B'
+A-100: '#A100'
+src: '#SRC'


### PR DESCRIPTION
## Summary
- copy demo P&ID map YAML into UI public directory so it's served at `/demo/pids/pid_map.yaml`

## Testing
- `pre-commit run --files apps/maximo-extension-ui/public/demo/pids/pid_map.yaml`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68a44942fdd08322ba5319d24cd9674a