### PR TITLE
feat(ui): use configured api base for hats

### DIFF
--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -11,6 +11,9 @@ test('renders gantt, price curve and hats timeline', async () => {
   // @ts-ignore
   global.ResizeObserver = ResizeObserver;
 
+  const apiBase = 'http://localhost:8000';
+  process.env.NEXT_PUBLIC_API_BASE = apiBase;
+
   const sample = {
     schedule: [
       { date: '2024-01-01', p10: 10, p50: 20, p90: 30, price: 40, hats: 1 },
@@ -25,7 +28,7 @@ test('renders gantt, price curve and hats timeline', async () => {
       if (typeof input === 'string' && input === '/schedule') {
         return Promise.resolve({ ok: true, json: async () => sample } as Response);
       }
-      if (typeof input === 'string' && input === '/api/hats') {
+      if (typeof input === 'string' && input === apiBase + '/hats') {
         return Promise.resolve({ ok: true, json: async () => [] } as Response);
       }
       return Promise.resolve({ ok: true, json: async () => ({}) } as Response);

--- a/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
+++ b/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
@@ -8,7 +8,7 @@ interface HatCandidate {
 }
 
 async function fetchCandidates(): Promise<HatCandidate[]> {
-  const res = await fetch('/api/hats');
+  const res = await fetch(process.env.NEXT_PUBLIC_API_BASE + '/hats');
   if (!res.ok) throw new Error('Failed to fetch hats');
   return (await res.json()) as HatCandidate[];
 }


### PR DESCRIPTION
## Summary
- fetch hats from NEXT_PUBLIC_API_BASE instead of hardcoded /api path
- adjust scheduler page test to mock hats endpoint using configured base URL

## Testing
- `pnpm install`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a44abc62e08322a65a7084c5629dca