### PR TITLE
feat: centralize api base for ui fetches

### DIFF
--- a/apps/maximo-extension-ui/src/app/conflicts/page.tsx
+++ b/apps/maximo-extension-ui/src/app/conflicts/page.tsx
@@ -3,10 +3,11 @@
 
 import { useEffect, useState } from 'react';
 import { SimulationResult } from '../../types/api';
+import { apiFetch } from '../../lib/api';
 
 // Fetch candidate bundling options for a work order
 async function fetchCandidates(): Promise<SimulationResult[]> {
-  const res = await fetch('/bundling?wo=1');
+  const res = await apiFetch('/bundling?wo=1');
   return res.json();
 }
 
@@ -66,7 +67,7 @@ export default function ConflictsPage() {
       <button
         className="mt-4 rounded border border-[var(--mxc-border)] px-4 py-2"
         onClick={async () => {
-          const res = await fetch('/bundling/recommend', {
+          const res = await apiFetch('/bundling/recommend', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ selected: Array.from(selected) })

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
@@ -6,6 +6,7 @@ import yaml from 'js-yaml';
 import { useBlueprint } from '../../../lib/hooks';
 import PidViewer from '../../../components/PidViewer';
 import { applyPidOverlay, type Overlay } from '../../../lib/pidOverlay';
+import { apiFetch } from '../../../lib/api';
 import type { BlueprintData } from '../../../types/api';
 
 interface OverlayResponse extends Overlay {
@@ -25,7 +26,7 @@ async function fetchOverlay(wo: string, blueprint: BlueprintData): Promise<Overl
     verifications: []
   };
 
-  const res = await fetch('/pid/overlay', {
+  const res = await apiFetch('/pid/overlay', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -25,7 +25,7 @@ test('renders gantt, price curve and hats timeline', async () => {
   const fetchMock = vi
     .spyOn(global, 'fetch')
     .mockImplementation((input: RequestInfo) => {
-      if (typeof input === 'string' && input === '/schedule') {
+      if (typeof input === 'string' && input === apiBase + '/schedule') {
         return Promise.resolve({ ok: true, json: async () => sample } as Response);
       }
       if (typeof input === 'string' && input === apiBase + '/hats') {

--- a/apps/maximo-extension-ui/src/components/Exports.tsx
+++ b/apps/maximo-extension-ui/src/components/Exports.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState } from 'react';
 import Button from './Button';
+import { apiFetch } from '../lib/api';
 
 interface ExportProps {
   wo: string;
@@ -13,7 +14,7 @@ export default function Exports({ wo }: ExportProps) {
   const toolbarRef = useRef<HTMLDivElement>(null);
 
   async function handleExport(format: 'pdf' | 'json') {
-    const res = await fetch('/blueprint', {
+    const res = await apiFetch('/blueprint', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -41,7 +42,7 @@ export default function Exports({ wo }: ExportProps) {
   }
 
   async function downloadPid(a3 = false) {
-    const res = await fetch('/pid/pdf', {
+    const res = await apiFetch('/pid/pdf', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
+++ b/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../lib/api';
 
 interface HatCandidate {
   hat_id: string;
@@ -8,7 +9,7 @@ interface HatCandidate {
 }
 
 async function fetchCandidates(): Promise<HatCandidate[]> {
-  const res = await fetch(process.env.NEXT_PUBLIC_API_BASE + '/hats');
+  const res = await apiFetch('/hats');
   if (!res.ok) throw new Error('Failed to fetch hats');
   return (await res.json()) as HatCandidate[];
 }

--- a/apps/maximo-extension-ui/src/lib/api.ts
+++ b/apps/maximo-extension-ui/src/lib/api.ts
@@ -1,0 +1,9 @@
+/**
+ * Helper to prefix API requests with the configured base URL.
+ *
+ * Uses the `NEXT_PUBLIC_API_BASE` environment variable if set.
+ */
+export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  const base = process.env.NEXT_PUBLIC_API_BASE ?? '';
+  return fetch(`${base}${path}`, init);
+}

--- a/apps/maximo-extension-ui/src/lib/hooks.ts
+++ b/apps/maximo-extension-ui/src/lib/hooks.ts
@@ -3,12 +3,13 @@ import { fetchPortfolio, type PortfolioData } from '../mocks/portfolio';
 import { fetchWorkOrder } from '../mocks/workorder';
 import { fetchBlueprint } from '../mocks/blueprint';
 import type { WorkOrderSummary, BlueprintData } from '../types/api';
+import { apiFetch } from './api';
 
 /**
  * Fetch portfolio data from the API.
  */
 async function fetchPortfolioApi(): Promise<PortfolioData> {
-  const res = await fetch('/portfolio');
+  const res = await apiFetch('/portfolio');
   if (!res.ok) {
     throw new Error('Failed to fetch portfolio');
   }

--- a/apps/maximo-extension-ui/src/lib/schedule.ts
+++ b/apps/maximo-extension-ui/src/lib/schedule.ts
@@ -1,4 +1,5 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { apiFetch } from './api';
 
 export interface SchedulePoint {
   date: string;
@@ -19,7 +20,7 @@ export interface ScheduleResponse {
  * Fetch schedule for a work order.
  */
 export async function fetchSchedule(wo: string): Promise<ScheduleResponse> {
-  const res = await fetch('/schedule', {
+  const res = await apiFetch('/schedule', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ workorder: wo })

--- a/apps/maximo-extension-ui/src/mocks/blueprint.ts
+++ b/apps/maximo-extension-ui/src/mocks/blueprint.ts
@@ -1,7 +1,8 @@
 import type { BlueprintData } from '../types/api';
+import { apiFetch } from '../lib/api';
 
 export async function fetchBlueprint(id: string): Promise<BlueprintData> {
-  const res = await fetch('/blueprint', {
+  const res = await apiFetch('/blueprint', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ workorder_id: id })


### PR DESCRIPTION
## Summary
- add helper for API fetch with configurable base URL
- use centralized API base in PID overlay tab and schedule fetches
- route remaining UI fetches through api helper and update tests

## Testing
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `pre-commit run --files apps/maximo-extension-ui/src/app/conflicts/page.tsx apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx apps/maximo-extension-ui/src/components/Exports.tsx apps/maximo-extension-ui/src/components/ReactivePicker.tsx apps/maximo-extension-ui/src/lib/hooks.ts apps/maximo-extension-ui/src/mocks/blueprint.ts`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a44ceca7c083229bec587787528094