### PR TITLE
Clamp hat rank bias to 10%

### DIFF
--- a/loto/scheduling/rank_bias.py
+++ b/loto/scheduling/rank_bias.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 __all__ = ["duration_with_rank"]
 
-_CR = 1.5  # maximum allowed multiplier
+_CR = 1.1  # maximum allowed multiplier
 _C = 1.0  # baseline multiplier for rank 1
-_R = 0.1  # incremental multiplier per additional rank
+_R = 0.025  # incremental multiplier per additional rank
 
 
 def duration_with_rank(base_dur: float, hat_rank: int) -> float:

--- a/tests/scheduling/test_rank_bias.py
+++ b/tests/scheduling/test_rank_bias.py
@@ -7,12 +7,17 @@ from loto.scheduling.rank_bias import duration_with_rank
     "rank,multiplier",
     [
         (1, 1.0),
-        (2, 1.1),
-        (5, 1.4),
-        (6, 1.5),  # cap reached
-        (10, 1.5),  # cap maintained
+        (2, 1.025),
+        (5, 1.1),
+        (6, 1.1),  # cap reached
+        (10, 1.1),  # cap maintained
     ],
 )
 def test_duration_with_rank(rank, multiplier):
     base = 10.0
     assert duration_with_rank(base, rank) == base * multiplier
+
+
+def test_max_multiplier():
+    base = 10.0
+    assert duration_with_rank(base, 999) <= base * 1.1


### PR DESCRIPTION
## Summary
- reduce maximum rank multiplier to 10%
- ensure worst-case rank grows linearly to cap
- add tests for capped rank bias

## Testing
- `make fmt`
- `pre-commit run --files loto/scheduling/rank_bias.py tests/scheduling/test_rank_bias.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a4e26fd1588322ba145c07d39477df