### PR TITLE
feat: stamp rulepack hash

### DIFF
--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -83,6 +83,11 @@ class ScheduleResponse(BaseModel):
         False,
         description="Whether execution is blocked due to missing parts",
     )
+    rulepack_sha256: str = Field(
+        ..., description="SHA-256 digest of the rule pack used"
+    )
+    rulepack_id: str | None = Field(None, description="Identifier of the rule pack")
+    rulepack_version: str | None = Field(None, description="Version of the rule pack")
 
     class Config:
         extra = "forbid"

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -20,7 +20,9 @@ test('renders gantt, price curve and hats timeline', async () => {
       { date: '2024-01-02', p10: 12, p50: 22, p90: 32, price: 42, hats: 2 }
     ],
     seed: 'abc',
-    objective: 0.95
+    objective: 0.95,
+    blocked_by_parts: false,
+    rulepack_sha256: 'abc123'
   };
   const fetchMock = vi
     .spyOn(global, 'fetch')

--- a/apps/maximo-extension-ui/src/lib/schedule.ts
+++ b/apps/maximo-extension-ui/src/lib/schedule.ts
@@ -14,6 +14,10 @@ export interface ScheduleResponse {
   schedule: SchedulePoint[];
   seed: string;
   objective: number;
+  blocked_by_parts: boolean;
+  rulepack_sha256: string;
+  rulepack_id?: string;
+  rulepack_version?: string;
 }
 
 /**

--- a/config/hswa_rules_v1.1.yaml
+++ b/config/hswa_rules_v1.1.yaml
@@ -1,0 +1,35 @@
+metadata:
+  id: hswa
+  version: "1.1"
+  jurisdiction: NZ
+  seed: 12345
+policy:
+  control_hierarchy: [eliminate, substitute, isolate, engineer, admin, ppe]
+  permit_categories: [general]
+  ddbb_threshold_kpag: 50
+  max_hat_bias_multiplier: 1.1
+domain_rules:
+  - name: isolation hierarchy
+    expression: prefer_elimination_substitution
+    statutory: ["GRWM r6"]
+    evidence: ["control_selection"]
+  - name: positive isolation
+    expression: require_ddbb_and_bleed
+    statutory: ["GRWM r22"]
+    evidence: ["ddbb_record", "bleed_path"]
+verification_rules:
+  - name: zero potential
+    check: ptw_zero
+    statutory: ["HSWA s30", "HSWA s36"]
+    evidence: ["gas_test", "tav_reading"]
+  - name: stored energy released
+    check: stored_energy_zero
+    statutory: ["ISO 14118"]
+    evidence: ["pressure_gauge", "tav_reading"]
+governance:
+  rulepack_id: hswa
+  rulepack_version: "1.1"
+  seed: 12345
+datasets:
+  drains_register: []
+  line_list: []

--- a/loto/materials/jobpack.py
+++ b/loto/materials/jobpack.py
@@ -26,6 +26,9 @@ def build_jobpack(
     *,
     permit_start: date | None = None,
     lead_days: int = DEFAULT_LEAD_DAYS,
+    rulepack_sha256: str | None = None,
+    rulepack_id: str | None = None,
+    rulepack_version: str | None = None,
 ) -> Dict[str, Dict[str, object]]:
     """Construct a mock job pack for ``workorder_id``.
 
@@ -38,6 +41,12 @@ def build_jobpack(
         future is used.
     lead_days:
         Number of days prior to ``permit_start`` that materials should be picked.
+    rulepack_sha256:
+        Optional SHA-256 hash of the rule pack used to generate the job pack.
+    rulepack_id:
+        Optional identifier of the rule pack.
+    rulepack_version:
+        Optional version string of the rule pack.
     """
 
     permit_start = permit_start or (date.today() + timedelta(days=5))
@@ -49,6 +58,12 @@ def build_jobpack(
         "pick_by": pick_by.isoformat(),
         "items": items,
     }
+    if rulepack_sha256:
+        payload["rulepack_sha256"] = rulepack_sha256
+    if rulepack_id:
+        payload["rulepack_id"] = rulepack_id
+    if rulepack_version:
+        payload["rulepack_version"] = rulepack_version
 
     out_dir = Path("out/jobpacks") / f"WO-{workorder_id}"
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/loto/models.py
+++ b/loto/models.py
@@ -17,6 +17,10 @@ class DomainRule(BaseModel):
 
     name: str = Field(..., description="Rule name")
     expression: str = Field(..., description="Expression used to evaluate the rule")
+    statutory: List[str] = Field(
+        ..., description="Statutory references supporting the rule"
+    )
+    evidence: List[str] = Field(..., description="Evidence requirements for compliance")
 
     class Config:
         extra = "forbid"
@@ -27,6 +31,10 @@ class VerificationRule(BaseModel):
 
     name: str = Field(..., description="Verification rule name")
     check: str = Field(..., description="Expression or callable for verification")
+    statutory: List[str] = Field(
+        ..., description="Statutory references supporting the rule"
+    )
+    evidence: List[str] = Field(..., description="Evidence requirements for compliance")
 
     class Config:
         extra = "forbid"
@@ -63,8 +71,7 @@ class Edge(BaseModel):
 
     source: str = Field(..., description="Identifier of the source node")
     target: str = Field(..., description="Identifier of the target node")
-    weight: Optional[float] = Field(
-        None, description="Edge weight (unitless)")
+    weight: Optional[float] = Field(None, description="Edge weight (unitless)")
 
     class Config:
         extra = "forbid"
@@ -91,9 +98,7 @@ class IsolationAction(BaseModel):
     """Action executed to isolate a component."""
 
     component_id: str = Field(..., description="Identifier of the component")
-    method: str = Field(
-        ..., description="Isolation method such as 'lock' or 'tag'"
-    )
+    method: str = Field(..., description="Isolation method such as 'lock' or 'tag'")
     duration_s: Optional[float] = Field(
         None, description="Expected duration in seconds"
     )
@@ -154,9 +159,7 @@ class SimReport(BaseModel):
     results: List[SimResultItem] = Field(
         default_factory=list, description="Individual simulation results"
     )
-    total_time_s: float = Field(
-        ..., description="Total simulation time in seconds"
-    )
+    total_time_s: float = Field(..., description="Total simulation time in seconds")
 
     class Config:
         extra = "forbid"
@@ -193,6 +196,18 @@ class ArtifactBundle(BaseModel):
 class RulePack(BaseModel):
     """Collection of domain and verification rules with optional risk policies."""
 
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict, description="Informational metadata about the rules"
+    )
+    policy: Dict[str, Any] = Field(
+        default_factory=dict, description="Policy settings influencing execution"
+    )
+    governance: Dict[str, Any] = Field(
+        default_factory=dict, description="Governance stamping information"
+    )
+    datasets: Dict[str, Any] = Field(
+        default_factory=dict, description="Dataset references used by rules"
+    )
     domain_rules: List[DomainRule] = Field(
         default_factory=list, description="Rules describing domain constraints"
     )

--- a/tests/api/test_jobpack.py
+++ b/tests/api/test_jobpack.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from apps.api.main import app
+from apps.api.main import RULE_PACK_HASH, app
 
 
 def test_jobpack_endpoint():
@@ -31,6 +31,7 @@ def test_jobpack_endpoint():
         json.dumps(json_content, sort_keys=True).encode()
     ).hexdigest()
     assert json_info["filename"].startswith(json_hash)
+    assert json_content["rulepack_sha256"] == RULE_PACK_HASH
 
     # pick_by is permit_start minus two days
     permit_start = date.fromisoformat(json_content["permit_start"])

--- a/tests/api/test_logging.py
+++ b/tests/api/test_logging.py
@@ -3,7 +3,7 @@ import logging
 
 from fastapi.testclient import TestClient
 
-from apps.api.main import app
+from apps.api.main import RULE_PACK_HASH, app
 from loto.loggers import JsonFormatter
 
 
@@ -18,4 +18,4 @@ def test_structured_logging(caplog):
     assert data["level"] == "info"
     assert data["seed"] == 0
     assert data["request_id"]
-    assert "rule_hash" in data
+    assert data["rule_hash"] == RULE_PACK_HASH

--- a/tests/api/test_schedule.py
+++ b/tests/api/test_schedule.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from apps.api.main import app
+from apps.api.main import RULE_PACK_HASH, app
 from loto.integrations.stores_adapter import DemoStoresAdapter
 
 
@@ -16,6 +16,7 @@ def test_schedule_endpoint():
     assert {"date", "p10", "p50", "p90", "price", "hats"} <= first.keys()
     assert data["seed"] == "0"
     assert data["blocked_by_parts"] is False
+    assert data["rulepack_sha256"] == RULE_PACK_HASH
 
 
 def test_schedule_inventory_gating():
@@ -28,5 +29,6 @@ def test_schedule_inventory_gating():
         data = res.json()
         assert data["blocked_by_parts"] is True
         assert data["schedule"] == []
+        assert data["rulepack_sha256"] == RULE_PACK_HASH
     finally:
         DemoStoresAdapter._INVENTORY["P-200"]["available"] = original

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
-import json
 import copy
+import json
 
 import pytest
 from pydantic import ValidationError
@@ -23,8 +23,24 @@ from loto.models import (
 
 # Example instances for round-trip tests
 MODEL_DATA = [
-    (DomainRule, {"name": "r1", "expression": "x > 0"}),
-    (VerificationRule, {"name": "v1", "check": "x < 1"}),
+    (
+        DomainRule,
+        {
+            "name": "r1",
+            "expression": "x > 0",
+            "statutory": ["HSWA"],
+            "evidence": ["record"],
+        },
+    ),
+    (
+        VerificationRule,
+        {
+            "name": "v1",
+            "check": "x < 1",
+            "statutory": ["HSWA"],
+            "evidence": ["record"],
+        },
+    ),
     (RiskPolicies, {"levels": {"low": 0.1, "high": 0.9}}),
     (Node, {"id": "n1", "label": "Node 1"}),
     (Edge, {"source": "n1", "target": "n2", "weight": 1.0}),
@@ -87,9 +103,27 @@ MODEL_DATA = [
     (
         RulePack,
         {
-            "domain_rules": [{"name": "r1", "expression": "x > 0"}],
-            "verification_rules": [{"name": "v1", "check": "x < 1"}],
+            "domain_rules": [
+                {
+                    "name": "r1",
+                    "expression": "x > 0",
+                    "statutory": ["HSWA"],
+                    "evidence": ["record"],
+                }
+            ],
+            "verification_rules": [
+                {
+                    "name": "v1",
+                    "check": "x < 1",
+                    "statutory": ["HSWA"],
+                    "evidence": ["record"],
+                }
+            ],
             "risk_policies": {"levels": {"low": 0.1}},
+            "metadata": {},
+            "policy": {},
+            "governance": {},
+            "datasets": {},
         },
     ),
 ]


### PR DESCRIPTION
## Summary
- load rule pack at API startup and log its SHA-256
- surface rulepack hash/id/version in schedule responses and job pack manifests
- require statutory and evidence fields on rule definitions

## Testing
- `pre-commit run --files apps/api/main.py apps/api/schemas.py apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx apps/maximo-extension-ui/src/lib/schedule.ts loto/materials/jobpack.py loto/models.py tests/api/test_jobpack.py tests/api/test_logging.py tests/api/test_schedule.py tests/test_models.py config/hswa_rules_v1.1.yaml`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a4f06f47888322bdc66aa6896ae833