### PR TITLE
docs: expand security runbook and scan dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
           pre-commit install
+      - name: Dependency vulnerability scan
+        run: |
+          pip install pip-audit
+          pip-audit
+          pnpm audit --audit-level=high
       - name: Frontend build and test
         run: |
           pnpm -C apps/maximo-extension-ui i

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,3 +6,29 @@ Security considerations for the pilot process.
 - Data flows only through approved environments (`dev`, `staging`, `prod`).
 - Apply least-privilege permissions when accessing pilot resources.
 - Report incidents immediately in `#pilot-support`.
+
+## Runbook
+
+### CORS origins
+
+The API only responds to requests from approved origins:
+
+- `http://localhost:3000` for local development
+- `https://loto.example.com` for production
+
+### Authentication modes
+
+- API key via the `MAXIMO_APIKEY` environment variable for server-to-server communication
+- OAuth2 bearer tokens for user-facing flows
+
+### Rate-limit defaults
+
+Requests are limited to **100 per minute per IP**. The limit can be overridden via the `RATE_LIMIT` configuration value when necessary.
+
+### Key rotation
+
+Rotate API keys and credentials at least every **90 days**. Revoke and regenerate keys immediately if compromise is suspected.
+
+### Log retention
+
+Audit and access logs are retained for **30 days** in centralized storage and then purged.


### PR DESCRIPTION
## Summary
- document CORS origins, auth modes, rate limits, key rotation, and log retention
- add dependency vulnerability scanning to CI

## Testing
- `pre-commit run --files docs/SECURITY.md .github/workflows/ci.yml`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a4f557c650832281a9576c156502ff