### PR TITLE
Expose rulepack and seed in jobpack response

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -415,8 +415,10 @@ async def get_jobpack(
     workorder_id: str,
     permit_start: date | None = None,
     lead_days: int = DEFAULT_LEAD_DAYS,
-) -> dict[str, dict[str, object]]:
+) -> dict[str, object]:
     """Return a mock job pack for the given work order."""
+    seed_int = 0
+    seed_var.set(seed_int)
     rule_hash_var.set(RULE_PACK_HASH)
     return build_jobpack(
         workorder_id,
@@ -425,4 +427,5 @@ async def get_jobpack(
         rulepack_sha256=RULE_PACK_HASH,
         rulepack_id=RULE_PACK_ID,
         rulepack_version=RULE_PACK_VERSION,
+        seed=str(seed_int),
     )

--- a/loto/materials/jobpack.py
+++ b/loto/materials/jobpack.py
@@ -29,7 +29,8 @@ def build_jobpack(
     rulepack_sha256: str | None = None,
     rulepack_id: str | None = None,
     rulepack_version: str | None = None,
-) -> Dict[str, Dict[str, object]]:
+    seed: str | None = None,
+) -> Dict[str, object]:
     """Construct a mock job pack for ``workorder_id``.
 
     Parameters
@@ -47,6 +48,8 @@ def build_jobpack(
         Optional identifier of the rule pack.
     rulepack_version:
         Optional version string of the rule pack.
+    seed:
+        Optional random seed recorded for determinism.
     """
 
     permit_start = permit_start or (date.today() + timedelta(days=5))
@@ -64,6 +67,8 @@ def build_jobpack(
         payload["rulepack_id"] = rulepack_id
     if rulepack_version:
         payload["rulepack_version"] = rulepack_version
+    if seed is not None:
+        payload["seed"] = seed
 
     out_dir = Path("out/jobpacks") / f"WO-{workorder_id}"
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -86,7 +91,16 @@ def build_jobpack(
     csv_name = f"{csv_hash}.csv"
     (out_dir / csv_name).write_text(csv_content)
 
-    return {
+    result: Dict[str, object] = {
         "json": {"filename": json_name, "content": payload},
         "csv": {"filename": csv_name, "content": csv_content},
     }
+    if rulepack_sha256 is not None:
+        result["rulepack_sha256"] = rulepack_sha256
+    if rulepack_id is not None:
+        result["rulepack_id"] = rulepack_id
+    if rulepack_version is not None:
+        result["rulepack_version"] = rulepack_version
+    if seed is not None:
+        result["seed"] = seed
+    return result

--- a/tests/api/test_jobpack.py
+++ b/tests/api/test_jobpack.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from apps.api.main import RULE_PACK_HASH, app
+from apps.api.main import RULE_PACK_HASH, RULE_PACK_ID, RULE_PACK_VERSION, app
 
 
 def test_jobpack_endpoint():
@@ -17,6 +17,10 @@ def test_jobpack_endpoint():
     assert res.status_code == 200
     data = res.json()
     assert "csv" in data and "json" in data
+    assert data["rulepack_sha256"] == RULE_PACK_HASH
+    assert data["rulepack_id"] == RULE_PACK_ID
+    assert data["rulepack_version"] == RULE_PACK_VERSION
+    assert data["seed"] == "0"
 
     csv_info = data["csv"]
     json_info = data["json"]
@@ -32,6 +36,9 @@ def test_jobpack_endpoint():
     ).hexdigest()
     assert json_info["filename"].startswith(json_hash)
     assert json_content["rulepack_sha256"] == RULE_PACK_HASH
+    assert json_content["rulepack_id"] == RULE_PACK_ID
+    assert json_content["rulepack_version"] == RULE_PACK_VERSION
+    assert json_content["seed"] == "0"
 
     # pick_by is permit_start minus two days
     permit_start = date.fromisoformat(json_content["permit_start"])


### PR DESCRIPTION
## Summary
- stamp jobpack responses with rulepack_sha256, rulepack_id, rulepack_version, and seed
- propagate seed through build_jobpack and API handler
- validate traceability fields via tests

## Testing
- `pre-commit run --files apps/api/main.py loto/materials/jobpack.py tests/api/test_jobpack.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a4fc4dacac8322b21fa89ccfd6c9b5