### PR TITLE
feat: delay theme selection until after mount

### DIFF
--- a/apps/maximo-extension-ui/src/components/ThemeToggle.tsx
+++ b/apps/maximo-extension-ui/src/components/ThemeToggle.tsx
@@ -4,19 +4,31 @@ import { useEffect, useState } from 'react';
 import Button from './Button';
 
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('theme');
-      if (stored === 'light' || stored === 'dark') return stored;
-      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    return 'light';
-  });
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    setMounted(true);
+    const stored = localStorage.getItem('theme');
+    const initial =
+      stored === 'light' || stored === 'dark'
+        ? stored
+        : window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light';
+    setTheme(initial);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
     document.documentElement.dataset.theme = theme;
     localStorage.setItem('theme', theme);
-  }, [theme]);
+  }, [mounted, theme]);
+
+  if (!mounted) {
+    // avoid mismatched text during hydration
+    return <Button aria-label="Toggle dark mode" />;
+  }
 
   return (
     <Button aria-label="Toggle dark mode" onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>


### PR DESCRIPTION
## Summary
- start ThemeToggle in light mode during SSR and read localStorage on mount
- avoid mismatched text before hydration by delaying toggle rendering until client mount

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/components/ThemeToggle.tsx`
- `pnpm -F maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a56397bf7483228adf0b1dde61fb21