### PR TITLE
Add file-backed demo adapter for work orders and assets

### DIFF
--- a/demo/assets.yaml
+++ b/demo/assets.yaml
@@ -1,0 +1,9 @@
+- id: ASSET-1
+  description: Pump A
+  location: Plant 1
+- id: ASSET-2
+  description: Valve B
+  location: Plant 2
+- id: ASSET-3
+  description: Tank C
+  location: Plant 3

--- a/demo/work_orders.csv
+++ b/demo/work_orders.csv
@@ -1,0 +1,4 @@
+id,description,asset_id,status
+WO-1,Replace gasket,ASSET-1,OPEN
+WO-2,Inspect valve,ASSET-2,CLOSED
+WO-3,Test pump,ASSET-3,OPEN

--- a/loto/integrations/demo_adapter.py
+++ b/loto/integrations/demo_adapter.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import csv
 import json
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, TypedDict, cast
+
+import yaml
 
 from . import IntegrationAdapter
 
@@ -12,16 +15,75 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from ..models import SimReport
 
 
+DEMO_DIR = Path(__file__).resolve().parents[2] / "demo"
+
+
+class WorkOrder(TypedDict):
+    """Shape of a work order returned by the adapter."""
+
+    id: str
+    description: str
+    asset_id: str
+
+
+class Asset(TypedDict):
+    """Shape of an asset returned by the adapter."""
+
+    id: str
+    description: str
+    location: str
+
+
 class DemoIntegrationAdapter(IntegrationAdapter):
-    """Demo adapter that fabricates responses and writes artifacts to disk."""
+    """Demo adapter that reads fixture data and writes artifacts to disk."""
+
+    def __init__(self) -> None:
+        self._work_orders_raw = {
+            row["id"]: row for row in self._load_records("work_orders")
+        }
+        self._assets = {row["id"]: row for row in self._load_records("assets")}
+
+    # internal helpers
+    def _load_records(self, name: str) -> List[Dict[str, Any]]:
+        stem = DEMO_DIR / name
+        csv_path = stem.with_suffix(".csv")
+        yaml_path = stem.with_suffix(".yaml")
+        yml_path = stem.with_suffix(".yml")
+        if csv_path.exists():
+            with csv_path.open(newline="") as fh:
+                return list(csv.DictReader(fh))
+        if yaml_path.exists():
+            return yaml.safe_load(yaml_path.read_text()) or []
+        if yml_path.exists():
+            return yaml.safe_load(yml_path.read_text()) or []
+        return []
+
+    def get_work_order(self, work_order_id: str) -> WorkOrder:
+        row = self._work_orders_raw[work_order_id]
+        return {
+            "id": row["id"],
+            "description": row.get("description", ""),
+            "asset_id": row.get("asset_id", ""),
+        }
+
+    def list_open_work_orders(self, window: int) -> List[WorkOrder]:
+        return [
+            self.get_work_order(row["id"])
+            for row in self._work_orders_raw.values()
+            if row.get("status", "").upper() == "OPEN"
+        ]
+
+    def get_asset(self, asset_id: str) -> Asset:
+        row = self._assets[asset_id]
+        return {
+            "id": row["id"],
+            "description": row.get("description", ""),
+            "location": row.get("location", ""),
+        }
 
     def fetch_work_order(self, work_order_id: str) -> Dict[str, Any]:
         """Return fixture information about a work order."""
-        return {
-            "id": work_order_id,
-            "description": f"Demo work order {work_order_id}",
-            "asset_id": "ASSET-DEMO",
-        }
+        return cast(Dict[str, Any], self.get_work_order(work_order_id))
 
     def create_child_work_orders(
         self, parent_work_order_id: str, plan: IsolationPlan


### PR DESCRIPTION
## Summary
- load demo work orders and assets from CSV/YAML files under `demo/`
- expose lookup helpers for work orders and assets, mirroring Maximo adapter shapes

## Testing
- `pre-commit run --files loto/integrations/demo_adapter.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a6d82058288322a0a3adb3b4c1dfef