### PR TITLE
Use Maximo adapter when configured

### DIFF
--- a/loto/integrations/__init__.py
+++ b/loto/integrations/__init__.py
@@ -61,7 +61,7 @@ class IntegrationAdapter(abc.ABC):
 from .demo_adapter import DemoIntegrationAdapter  # noqa: E402
 
 
-def get_integration_adapter() -> IntegrationAdapter:
+def get_integration_adapter() -> IntegrationAdapter | MaximoAdapter:
     """Return an adapter instance based on environment configuration.
 
     If required environment variables are missing, a
@@ -74,11 +74,8 @@ def get_integration_adapter() -> IntegrationAdapter:
         "MAXIMO_OS_WORKORDER",
         "MAXIMO_OS_ASSET",
     ]
-
-    if not all(os.environ.get(var) for var in required):
-        return DemoIntegrationAdapter()
-
-    # Placeholder: return demo adapter until a real one is available
+    if all(os.environ.get(var) for var in required):
+        return MaximoAdapter()
     return DemoIntegrationAdapter()
 
 

--- a/tests/test_integration_adapter_selection.py
+++ b/tests/test_integration_adapter_selection.py
@@ -1,0 +1,32 @@
+"""Tests for integration adapter selection logic."""
+
+from __future__ import annotations
+
+from loto.integrations import (
+    DemoIntegrationAdapter,
+    MaximoAdapter,
+    get_integration_adapter,
+)
+
+
+def test_returns_demo_adapter_when_maximo_env_missing(monkeypatch) -> None:
+    """Demo adapter is used when any MAXIMO_* variable is missing."""
+    for var in [
+        "MAXIMO_BASE_URL",
+        "MAXIMO_APIKEY",
+        "MAXIMO_OS_WORKORDER",
+        "MAXIMO_OS_ASSET",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    adapter = get_integration_adapter()
+    assert isinstance(adapter, DemoIntegrationAdapter)
+
+
+def test_returns_maximo_adapter_when_env_present(monkeypatch) -> None:
+    """Real adapter is returned when all MAXIMO_* variables are set."""
+    monkeypatch.setenv("MAXIMO_BASE_URL", "https://example")
+    monkeypatch.setenv("MAXIMO_APIKEY", "token")
+    monkeypatch.setenv("MAXIMO_OS_WORKORDER", "WORKORDER")
+    monkeypatch.setenv("MAXIMO_OS_ASSET", "ASSET")
+    adapter = get_integration_adapter()
+    assert isinstance(adapter, MaximoAdapter)


### PR DESCRIPTION
## Summary
- return `MaximoAdapter` when `MAXIMO_*` environment variables are present
- test adapter selection based on environment configuration

## Testing
- `pre-commit run --files loto/integrations/__init__.py tests/test_integration_adapter_selection.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a6dbd819788322a0b7bfd8d4dc2af0