### PR TITLE
feat(api): add work order and portfolio endpoints

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -41,6 +41,7 @@ from .schemas import (
     ScheduleResponse,
     Step,
 )
+from .workorder_endpoints import router as workorder_router
 
 configure_logging()
 
@@ -69,6 +70,7 @@ if origins:
 
 app.include_router(pid_router)
 app.include_router(hats_router)
+app.include_router(workorder_router)
 
 
 AUTH_REQUIRED = os.getenv("AUTH_REQUIRED", "").lower() == "true"
@@ -420,12 +422,6 @@ async def post_schedule(
         rulepack_id=RULE_PACK_ID,
         rulepack_version=RULE_PACK_VERSION,
     )
-
-
-@app.get("/workorders/{workorder_id}")
-async def get_workorder(workorder_id: str) -> dict[str, str]:
-    """Mock work order fetch."""
-    return {"workorder_id": workorder_id, "status": "mocked"}
 
 
 @app.get("/workorders/{workorder_id}/jobpack")

--- a/apps/api/workorder_endpoints.py
+++ b/apps/api/workorder_endpoints.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from loto.integrations.maximo_adapter import MaximoAdapter
+
+
+class WorkOrderSummary(BaseModel):
+    """Simplified work order representation."""
+
+    id: str = Field(..., description="Work order identifier")
+    description: str = Field("", description="Work order description")
+    asset_id: str = Field("", description="Related asset identifier")
+
+    class Config:
+        extra = "forbid"
+
+
+class KpiItem(BaseModel):
+    """Basic KPI item."""
+
+    label: str
+    value: int
+
+    class Config:
+        extra = "forbid"
+
+
+class PortfolioResponse(BaseModel):
+    """Response model for the portfolio endpoint."""
+
+    kpis: list[KpiItem] = Field(default_factory=list, description="Portfolio KPIs")
+    workorders: list[WorkOrderSummary] = Field(
+        default_factory=list, description="Open work orders"
+    )
+
+    class Config:
+        extra = "forbid"
+
+
+router = APIRouter(tags=["workorders"])
+
+
+@router.get("/workorders/{workorder_id}", response_model=WorkOrderSummary)
+async def get_workorder(workorder_id: str) -> WorkOrderSummary:
+    """Fetch a work order from the integration adapter."""
+
+    adapter = MaximoAdapter()
+    try:
+        data = adapter.get_work_order(workorder_id)
+    except Exception as exc:  # pragma: no cover - adapter errors handled generically
+        raise HTTPException(
+            status_code=502, detail="failed to fetch work order"
+        ) from exc
+    return WorkOrderSummary(**data)
+
+
+@router.get("/portfolio", response_model=PortfolioResponse)
+async def get_portfolio(window: int = 7) -> PortfolioResponse:
+    """List open work orders and basic KPIs."""
+
+    adapter = MaximoAdapter()
+    try:
+        work_orders = adapter.list_open_work_orders(window)
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(
+            status_code=502, detail="failed to list work orders"
+        ) from exc
+    summaries = [WorkOrderSummary(**wo) for wo in work_orders]
+    kpis = [KpiItem(label="Open", value=len(summaries))]
+    return PortfolioResponse(kpis=kpis, workorders=summaries)


### PR DESCRIPTION
## Summary
- expose work order and portfolio API backed by integration adapter
- register new router in FastAPI app

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `pre-commit run --files apps/api/workorder_endpoints.py apps/api/main.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a6dd9eb58883228108ed4322e98e76