### PR TITLE
refactor: fetch work orders and blueprints via API

### DIFF
--- a/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx
@@ -11,6 +11,7 @@ afterEach(() => {
 
 test('renders audit metadata and disables commit in TEST role', async () => {
   vi.stubEnv('NEXT_PUBLIC_ROLE', 'TEST');
+  vi.stubEnv('NEXT_PUBLIC_USE_API', 'true');
   const blueprint = { diff: 'diff text', audit_metadata: { user: 'alice' } };
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(blueprint) }));
   const queryClient = new QueryClient();
@@ -26,6 +27,7 @@ test('renders audit metadata and disables commit in TEST role', async () => {
 
 test('requires typing COMMIT to confirm', async () => {
   vi.stubEnv('NEXT_PUBLIC_ROLE', 'DEV');
+  vi.stubEnv('NEXT_PUBLIC_USE_API', 'true');
   const blueprint = { diff: 'diff text' };
   const fetchMock = vi
     .fn()

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useBlueprint } from '../../../lib/hooks';
+import { useBlueprintApi } from '../../../lib/hooks';
 import Button from '../../../components/Button';
 
 interface CommitPanelProps {
@@ -8,7 +8,7 @@ interface CommitPanelProps {
 }
 
 export default function CommitPanel({ wo }: CommitPanelProps) {
-  const { data } = useBlueprint(wo);
+  const { data } = useBlueprintApi(wo);
   const role = (process.env.NEXT_PUBLIC_ROLE || 'TEST').toUpperCase();
   const canCommit = role !== 'TEST';
   const diff = data?.diff;

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import yaml from 'js-yaml';
-import { useBlueprint } from '../../../lib/hooks';
+import { useBlueprintApi } from '../../../lib/hooks';
 import PidViewer from '../../../components/PidViewer';
 import { applyPidOverlay, type Overlay } from '../../../lib/pidOverlay';
 import { apiFetch } from '../../../lib/api';
@@ -45,7 +45,7 @@ async function fetchOverlay(wo: string, blueprint: BlueprintData): Promise<Overl
 }
 
 export default function PidTab({ wo }: { wo: string }) {
-  const { data: blueprint } = useBlueprint(wo);
+  const { data: blueprint } = useBlueprintApi(wo);
   const { data } = useQuery({
     queryKey: ['pid', wo],
     enabled: !!blueprint,

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
@@ -31,6 +31,7 @@ test('renders material status chips', async () => {
     ok: true,
     json: async () => shortage
   } as Response);
+  vi.stubEnv('NEXT_PUBLIC_USE_API', 'true');
 
   render(<Page params={{ wo: 'WO-1' }} />);
   const tab = await screen.findByRole('tab', { name: 'Materials' });

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useWorkOrder, useBlueprint } from '../../../lib/hooks';
+import { useWorkOrderApi, useBlueprintApi } from '../../../lib/hooks';
 import Exports from '../../../components/Exports';
 import CommitPanel from './CommitPanel';
 import PidTab from './PidTab';
@@ -14,8 +14,8 @@ const queryClient = new QueryClient();
 
 function PlannerContent({ wo }: { wo: string }) {
   const [activeTab, setActiveTab] = useState('Plan');
-  const { data: workOrder } = useWorkOrder(wo);
-  const { data: blueprint } = useBlueprint(wo);
+  const { data: workOrder } = useWorkOrderApi(wo);
+  const { data: blueprint } = useBlueprintApi(wo);
 
   if (!workOrder) return null;
 

--- a/apps/maximo-extension-ui/src/lib/blueprint.ts
+++ b/apps/maximo-extension-ui/src/lib/blueprint.ts
@@ -1,0 +1,18 @@
+import type { BlueprintData } from '../types/api';
+import { apiFetch } from './api';
+
+/**
+ * Fetch blueprint data for a work order from the API.
+ */
+export async function fetchBlueprint(id: string): Promise<BlueprintData> {
+  const res = await apiFetch('/blueprint', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ workorder_id: id })
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch blueprint');
+  }
+  return res.json();
+}
+

--- a/apps/maximo-extension-ui/src/lib/hooks.ts
+++ b/apps/maximo-extension-ui/src/lib/hooks.ts
@@ -1,9 +1,11 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { fetchPortfolio, type PortfolioData } from '../mocks/portfolio';
-import { fetchWorkOrder } from '../mocks/workorder';
-import { fetchBlueprint } from '../mocks/blueprint';
+import { fetchWorkOrder as fetchWorkOrderMock } from '../mocks/workorder';
+import { fetchBlueprint as fetchBlueprintMock } from '../mocks/blueprint';
 import type { WorkOrderSummary, BlueprintData } from '../types/api';
 import { apiFetch } from './api';
+import { fetchWorkOrder } from './workorders';
+import { fetchBlueprint } from './blueprint';
 
 /**
  * Fetch portfolio data from the API.
@@ -37,14 +39,26 @@ export const usePortfolio = usePortfolioApi;
  * Query hook for an individual work order.
  * @param id Work order identifier
  */
-export function useWorkOrder(id: string): UseQueryResult<WorkOrderSummary> {
-  return useQuery({ queryKey: ['workOrder', id], queryFn: () => fetchWorkOrder(id) });
+export function useWorkOrderApi(id: string): UseQueryResult<WorkOrderSummary> {
+  const useApi = process.env.NEXT_PUBLIC_USE_API === 'true';
+  return useQuery({
+    queryKey: ['workOrder', id],
+    queryFn: () => (useApi ? fetchWorkOrder(id) : fetchWorkOrderMock(id))
+  });
 }
+
+export const useWorkOrder = useWorkOrderApi;
 
 /**
  * Query hook for blueprint data of a work order.
  * @param id Work order identifier
  */
-export function useBlueprint(id: string): UseQueryResult<BlueprintData> {
-  return useQuery({ queryKey: ['blueprint', id], queryFn: () => fetchBlueprint(id) });
+export function useBlueprintApi(id: string): UseQueryResult<BlueprintData> {
+  const useApi = process.env.NEXT_PUBLIC_USE_API === 'true';
+  return useQuery({
+    queryKey: ['blueprint', id],
+    queryFn: () => (useApi ? fetchBlueprint(id) : fetchBlueprintMock(id))
+  });
 }
+
+export const useBlueprint = useBlueprintApi;

--- a/apps/maximo-extension-ui/src/lib/workorders.ts
+++ b/apps/maximo-extension-ui/src/lib/workorders.ts
@@ -1,0 +1,14 @@
+import type { WorkOrderSummary } from '../types/api';
+import { apiFetch } from './api';
+
+/**
+ * Fetch a work order from the API.
+ */
+export async function fetchWorkOrder(id: string): Promise<WorkOrderSummary> {
+  const res = await apiFetch(`/workorders/${id}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch work order');
+  }
+  return res.json();
+}
+

--- a/apps/maximo-extension-ui/src/mocks/blueprint.ts
+++ b/apps/maximo-extension-ui/src/mocks/blueprint.ts
@@ -1,15 +1,14 @@
 import type { BlueprintData } from '../types/api';
-import { apiFetch } from '../lib/api';
 
-export async function fetchBlueprint(id: string): Promise<BlueprintData> {
-  const res = await apiFetch('/blueprint', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ workorder_id: id })
-  });
-  if (!res.ok) {
-    throw new Error('Failed to fetch blueprint');
-  }
-  return res.json();
+export async function fetchBlueprint(_id: string): Promise<BlueprintData> {
+  return {
+    steps: [
+      { component_id: 'PUMP-1', method: 'Remove' },
+      { component_id: 'PUMP-1', method: 'Install' }
+    ],
+    unavailable_assets: [],
+    unit_mw_delta: {},
+    parts_status: {}
+  };
 }
 


### PR DESCRIPTION
## Summary
- replace hook mocks with API-backed fetch helpers for work orders and blueprints
- adjust planner components to use new API hooks with mock fallback
- update tests to set NEXT_PUBLIC_USE_API when stubbing API responses

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/lib/hooks.ts apps/maximo-extension-ui/src/lib/workorders.ts`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a6ef73e2c883228e162b8148184beb