### PR TITLE
feat: fallback to mock data when API fails

### DIFF
--- a/apps/maximo-extension-ui/src/lib/hooks.ts
+++ b/apps/maximo-extension-ui/src/lib/hooks.ts
@@ -28,7 +28,14 @@ export function usePortfolioApi(): UseQueryResult<PortfolioData> {
   const useApi = process.env.NEXT_PUBLIC_USE_API === 'true';
   return useQuery({
     queryKey: ['portfolio'],
-    queryFn: useApi ? fetchPortfolioApi : fetchPortfolio
+    queryFn: async () => {
+      if (!useApi) return fetchPortfolio();
+      try {
+        return await fetchPortfolioApi();
+      } catch {
+        return fetchPortfolio();
+      }
+    }
   });
 }
 
@@ -43,7 +50,14 @@ export function useWorkOrderApi(id: string): UseQueryResult<WorkOrderSummary> {
   const useApi = process.env.NEXT_PUBLIC_USE_API === 'true';
   return useQuery({
     queryKey: ['workOrder', id],
-    queryFn: () => (useApi ? fetchWorkOrder(id) : fetchWorkOrderMock(id))
+    queryFn: async () => {
+      if (!useApi) return fetchWorkOrderMock(id);
+      try {
+        return await fetchWorkOrder(id);
+      } catch {
+        return fetchWorkOrderMock(id);
+      }
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- fallback to mocked data when portfolio API errors
- fallback to mocked data when work order API errors

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/lib/hooks.ts`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a7e6ca501483229a7aaa07ad9ca5d5