### PR TITLE
Use bearer token for UI API calls

### DIFF
--- a/apps/maximo-extension-ui/src/lib/api.test.ts
+++ b/apps/maximo-extension-ui/src/lib/api.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { apiFetch } from './api';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  delete process.env.NEXT_PUBLIC_API_TOKEN;
+});
+
+describe('apiFetch', () => {
+  it('adds authorization header when token is set', async () => {
+    const mock = vi.fn().mockResolvedValue(new Response());
+    global.fetch = mock as any;
+    process.env.NEXT_PUBLIC_API_TOKEN = 'token';
+
+    await apiFetch('/test');
+
+    const headers = mock.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer token');
+  });
+
+  it('does not override existing authorization header', async () => {
+    const mock = vi.fn().mockResolvedValue(new Response());
+    global.fetch = mock as any;
+    process.env.NEXT_PUBLIC_API_TOKEN = 'token';
+
+    await apiFetch('/test', { headers: { Authorization: 'Bearer existing' } });
+
+    const headers = mock.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer existing');
+  });
+});
+

--- a/apps/maximo-extension-ui/src/lib/api.ts
+++ b/apps/maximo-extension-ui/src/lib/api.ts
@@ -5,5 +5,10 @@
  */
 export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   const base = process.env.NEXT_PUBLIC_API_BASE ?? '';
-  return fetch(`${base}${path}`, init);
+  const token = process.env.NEXT_PUBLIC_API_TOKEN;
+  const headers = new Headers(init?.headers || {});
+  if (token && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return fetch(`${base}${path}`, { ...init, headers });
 }


### PR DESCRIPTION
## Summary
- attach Authorization header using NEXT_PUBLIC_API_TOKEN when present
- test apiFetch header handling

## Testing
- `pnpm -F maximo-extension-ui test`
- `pre-commit run --files apps/maximo-extension-ui/src/lib/api.ts apps/maximo-extension-ui/src/lib/api.test.ts`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a7e7febcc483228d82d6d13ff9b02e