### PR TITLE
Copy config directory into API Docker image

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # Install application and API dependencies
 COPY pyproject.toml README.md ./
+COPY config ./config
 COPY loto ./loto
 COPY apps/api ./apps/api
 COPY demo ./demo


### PR DESCRIPTION
## Summary
- Copy the configuration directory earlier in the API Docker build to ensure config files are available before dependencies install

## Testing
- `pre-commit run --files Dockerfile.api`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `docker-compose build api` *(fails: ConnectionRefusedError: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_68a827cb5e7c8322b3f7ec1ced6270a2