### PR TITLE
Add prerequisite check script and Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint typecheck test run-demo demo-up
+.PHONY: fmt lint typecheck test run-demo demo-up check-prereqs
 
 fmt:
 	black loto tests
@@ -25,3 +25,6 @@ demo-up:
 		echo "Docker Compose is not installed. Install Docker and Docker Compose."; \
 		exit 1; \
 	fi
+
+check-prereqs:
+	./scripts/check-prereqs.sh

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=0
+
+check_cmd() {
+    local cmd="$1"
+    local hint="$2"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd not installed. $hint"
+        missing=1
+    fi
+}
+
+check_cmd docker "Install from https://docs.docker.com/get-docker/"
+check_cmd pnpm "See https://pnpm.io/installation"
+
+if command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)'; then
+        echo "python3 >=3.11 required. Install from your package manager or https://www.python.org/downloads/"
+        missing=1
+    fi
+else
+    echo "python3 not installed. Install from your package manager or https://www.python.org/downloads/"
+    missing=1
+fi
+
+exit "$missing"


### PR DESCRIPTION
## Summary
- add script to verify docker, pnpm, and python3 >=3.11
- add `check-prereqs` make target

## Testing
- `make fmt lint`
- `pre-commit run --files scripts/check-prereqs.sh Makefile`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a82bcbbf488322b835c2415f903da2