### PR TITLE
Add Typer demo command with progress bar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 	pytest
 
 run-demo:
-	python -m loto.cli --demo
+	python -m loto.cli demo
 
 demo-up:
 	@COMPOSE="docker compose"; \
@@ -41,3 +41,4 @@ demo-up:
 
 check-prereqs:
 	./scripts/check-prereqs.sh
+

--- a/loto/cli.py
+++ b/loto/cli.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Optional
 
 import networkx as nx  # type: ignore
+import typer
+from tqdm import tqdm
 
 from .graph_builder import GraphBuilder
 from .isolation_planner import IsolationPlanner
@@ -21,6 +23,14 @@ from .models import SimReport, Stimulus
 from .renderer import Renderer
 from .rule_engine import RuleEngine
 from .sim_engine import SimEngine
+
+cli = typer.Typer()
+
+
+@cli.callback()
+def main_callback() -> None:
+    """LOTO command line interface."""
+    return None
 
 
 def parse_args(args: Optional[list[str]] = None) -> argparse.Namespace:
@@ -157,5 +167,25 @@ def main(argv: Optional[list[str]] = None) -> None:
     return None
 
 
+@cli.command()
+def demo(out: Path = Path("./out"), open_pdf: bool = False) -> None:
+    """Generate demo PDF and JSON outputs."""
+    try:
+        with tqdm(total=1, desc="Generating demo", unit="step") as progress:
+            main(["--demo", "--output", str(out)])
+            progress.update(1)
+
+        typer.echo(f"✅ PDF + JSON saved to {out}")
+        if open_pdf:
+            pdf_path = out / "LOTO_A.pdf"
+            try:
+                typer.launch(str(pdf_path))
+            except Exception:  # pragma: no cover - opening may fail in CI
+                pass
+    except Exception as exc:  # pragma: no cover - ensure friendly error
+        typer.secho(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+
+
 if __name__ == "__main__":
-    main()
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pandas",
     "PyPDF2",
     "weasyprint",
+    "tqdm",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cli_demo.py
+++ b/tests/test_cli_demo.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from loto.cli import cli
+
+
+def test_demo_command_creates_outputs(tmp_path: Path) -> None:
+    runner = CliRunner()
+    out_dir = tmp_path / "out"
+    result = runner.invoke(cli, ["demo", "--out", str(out_dir)])
+
+    assert result.exit_code == 0
+    assert "PDF + JSON saved" in result.stdout
+    assert (out_dir / "LOTO_A.pdf").exists()
+    assert (out_dir / "LOTO_A.json").exists()


### PR DESCRIPTION
## Summary
- add Typer-based `demo` command with progress bar and optional PDF open
- call new command from `run-demo` Makefile target and include `tqdm` dependency
- test demo command generation

## Testing
- `make fmt lint`
- `pre-commit run --files loto/cli.py Makefile pyproject.toml tests/test_cli_demo.py`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a83849a568832282504402dae069eb