### PR TITLE
chore: document env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,43 @@
 # Example environment configuration for LOTO Planner
+
+# General application settings
+APP_ENV=demo
+DATA_IN=data/in
+DATA_OUT=data/out
+RULEPACK_FILE=config/hswa_rules_v1.1.yaml
+
+# Maximo integration
+MAXIMO_MODE=MOCK
 MAXIMO_BASE_URL=https://example.com
 MAXIMO_APIKEY=changeme
 MAXIMO_OS_WORKORDER=WORKORDER
 MAXIMO_OS_ASSET=ASSET
-NEXT_PUBLIC_USE_API=false
+
+# WAPR integration
+WAPR_MODE=MOCK
+WAPR_BASE_URL=https://example.com/wapr
+WAPR_APIKEY=changeme
+
+# Coupa integration
+COUPA_MODE=MOCK
+COUPA_BASE_URL=https://example.com/coupa
+COUPA_APIKEY=changeme
+
+# HATS configuration
+HATS_LEDGER_PATH=hats_ledger.jsonl
+HATS_SNAPSHOT_PATH=hats_snapshot.json
+
 ## API configuration
+NEXT_PUBLIC_USE_API=false
+NEXT_PUBLIC_ROLE=TEST
+NEXT_PUBLIC_API_BASE=http://localhost:8000
+NEXT_PUBLIC_API_TOKEN=devtoken
 # Comma-separated list of origins allowed to access the API
 CORS_ORIGINS=
 # Rate limiting settings
 RATE_LIMIT_CAPACITY=10
 RATE_LIMIT_INTERVAL=60
+# Authentication
 AUTH_REQUIRED=false
 AUTH_TOKEN=devtoken
-NEXT_PUBLIC_API_BASE=http://localhost:8000
-NEXT_PUBLIC_API_TOKEN=devtoken
+


### PR DESCRIPTION
## Summary
- add complete `.env.example` with configuration for all integrations and API options

## Testing
- `pre-commit run --files .env.example`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a83c34eb008322a04262b7a2cd9742