### PR TITLE
feat: add pydantic settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "pydantic",
+    "pydantic-settings",
     "PyYAML",
     "networkx",
     "jinja2",


### PR DESCRIPTION
## Summary
- introduce `Settings` class based on Pydantic `BaseSettings` to load environment configuration and collect `MAXIMO_OS_*` values
- add `pydantic-settings` as a dependency

## Testing
- `pre-commit run --files pyproject.toml loto/config.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a83ee6882c83229103f59ae96d93ce