### PR TITLE
Validate env vars on startup

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -14,6 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from loto.config import validate_env_vars
 from loto.impact_config import load_impact_config
 from loto.integrations.stores_adapter import DemoStoresAdapter
 from loto.inventory import (
@@ -44,6 +45,7 @@ from .schemas import (
 from .workorder_endpoints import router as workorder_router
 
 configure_logging()
+validate_env_vars()
 
 _rule_engine = RuleEngine()
 _default_rulepack = (

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -20,6 +20,6 @@ def test_bearer_token(monkeypatch):
     assert resp_fail.headers["X-Env"] == main.ENV_BADGE
     resp_public = client.get("/healthz")
     assert resp_public.status_code == 200
-    monkeypatch.delenv("AUTH_REQUIRED", raising=False)
-    monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("AUTH_REQUIRED", "false")
+    monkeypatch.setenv("AUTH_TOKEN", "devtoken")
     importlib.reload(main)

--- a/tests/api/test_healthz.py
+++ b/tests/api/test_healthz.py
@@ -20,6 +20,6 @@ def test_healthz_reports_rate_limit(monkeypatch):
         assert path in data["rate_limit"]["counters"]
     assert res.headers["X-Env"] == main.ENV_BADGE
 
-    monkeypatch.delenv("RATE_LIMIT_CAPACITY", raising=False)
-    monkeypatch.delenv("RATE_LIMIT_INTERVAL", raising=False)
+    monkeypatch.setenv("RATE_LIMIT_CAPACITY", "10")
+    monkeypatch.setenv("RATE_LIMIT_INTERVAL", "60")
     importlib.reload(main)

--- a/tests/api/test_rate_limit.py
+++ b/tests/api/test_rate_limit.py
@@ -16,6 +16,6 @@ def test_rate_limit(monkeypatch):
     res = client.post("/schedule", json=payload)
     assert res.status_code == 429
     assert res.headers["X-Env"] == main.ENV_BADGE
-    monkeypatch.delenv("RATE_LIMIT_CAPACITY", raising=False)
-    monkeypatch.delenv("RATE_LIMIT_INTERVAL", raising=False)
+    monkeypatch.setenv("RATE_LIMIT_CAPACITY", "10")
+    monkeypatch.setenv("RATE_LIMIT_INTERVAL", "60")
     importlib.reload(main)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,12 @@
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
 
 # Ensure project root is on the import path so ``import loto`` works during
 # test collection even when ``pytest`` changes the working directory.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+# Load default environment variables for tests.
+load_dotenv(PROJECT_ROOT / ".env.example", override=False)

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from loto.config import ConfigError, validate_env_vars
+
+
+def test_validate_env_vars_reports_missing(monkeypatch, capsys):
+    """Ensure missing env vars are reported with a table."""
+    # pick a known key from the example file
+    example = Path(__file__).resolve().parent.parent / ".env.example"
+    key = "DATA_IN"
+    assert any(line.startswith(f"{key}=") for line in example.read_text().splitlines())
+    monkeypatch.delenv(key, raising=False)
+
+    with pytest.raises(ConfigError):
+        validate_env_vars(example)
+
+    out = capsys.readouterr().out
+    assert key in out
+    lines = out.strip().splitlines()
+    row = next(line for line in lines if line.startswith(key))
+    assert row.endswith("N")


### PR DESCRIPTION
## Summary
- validate required environment variables on app startup
- load .env.example during tests and reset env defaults after env-sensitive tests
- add unit test for environment variable validation

## Testing
- `pre-commit run --files apps/api/main.py loto/config.py tests/conftest.py tests/test_env_validation.py tests/api/test_auth.py tests/api/test_healthz.py tests/api/test_rate_limit.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a847a7d1c88322aedfa15548c53c3b