### PR TITLE
feat(ui): add empty state component

### DIFF
--- a/apps/maximo-extension-ui/src/components/EmptyState.test.tsx
+++ b/apps/maximo-extension-ui/src/components/EmptyState.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import EmptyState from './EmptyState';
+
+const Icon = () => <svg data-testid="icon" />;
+
+const Action = () => <button type="button">Action</button>;
+
+test('matches snapshot', () => {
+  const { container } = render(
+    <EmptyState
+      icon={<Icon />}
+      title="Nothing here"
+      description="There is currently no data to display"
+      action={<Action />}
+    />
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/apps/maximo-extension-ui/src/components/EmptyState.tsx
+++ b/apps/maximo-extension-ui/src/components/EmptyState.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import clsx from 'clsx';
+
+interface EmptyStateProps {
+  icon: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export default function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={clsx(
+        'flex flex-col items-center justify-center gap-4 p-8 text-center',
+        className
+      )}
+    >
+      <div className="text-6xl" aria-hidden="true">
+        {icon}
+      </div>
+      <div>
+        <h3 className="text-lg font-semibold">{title}</h3>
+        {description && (
+          <p className="mt-2 text-sm text-gray-600">{description}</p>
+        )}
+      </div>
+      {action && <div>{action}</div>}
+    </div>
+  );
+}

--- a/apps/maximo-extension-ui/src/components/__snapshots__/EmptyState.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/components/__snapshots__/EmptyState.test.tsx.snap
@@ -1,0 +1,35 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matches snapshot 1`] = `
+<div
+  class="flex flex-col items-center justify-center gap-4 p-8 text-center"
+>
+  <div
+    aria-hidden="true"
+    class="text-6xl"
+  >
+    <svg
+      data-testid="icon"
+    />
+  </div>
+  <div>
+    <h3
+      class="text-lg font-semibold"
+    >
+      Nothing here
+    </h3>
+    <p
+      class="mt-2 text-sm text-gray-600"
+    >
+      There is currently no data to display
+    </p>
+  </div>
+  <div>
+    <button
+      type="button"
+    >
+      Action
+    </button>
+  </div>
+</div>
+`;

--- a/apps/maximo-extension-ui/src/stories/EmptyState.stories.tsx
+++ b/apps/maximo-extension-ui/src/stories/EmptyState.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import EmptyState from '../components/EmptyState';
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'Components/EmptyState',
+  component: EmptyState,
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof EmptyState> = {
+  args: {
+    icon: <div className="h-12 w-12 rounded-full bg-gray-200" />,
+    title: 'No data',
+    description: 'There is nothing to display yet',
+    action: <button type="button">Reload</button>,
+  },
+};


### PR DESCRIPTION
## Summary
- add reusable `EmptyState` component with icon, message, and call-to-action
- document component in Storybook
- cover component with snapshot test

## Testing
- `pnpm -F maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a84aefb940832299406ce499fec88b