### PR TITLE
Handle fetch errors with toast

### DIFF
--- a/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useBlueprintApi } from '../../../lib/hooks';
 import Button from '../../../components/Button';
+import { toastError } from '../../../lib/toast';
 
 interface CommitPanelProps {
   wo: string;
@@ -17,7 +18,12 @@ export default function CommitPanel({ wo }: CommitPanelProps) {
   const handleCommit = async () => {
     const input = window.prompt('Type COMMIT to confirm');
     if (input !== 'COMMIT') return;
-    await fetch(`/api/commit/${wo}`, { method: 'POST' });
+    try {
+      const res = await fetch(`/api/commit/${wo}`, { method: 'POST' });
+      if ('ok' in res && !res.ok) throw new Error('Failed to commit');
+    } catch (err) {
+      toastError('Failed to commit');
+    }
   };
 
   return (

--- a/apps/maximo-extension-ui/src/components/PidTiles.tsx
+++ b/apps/maximo-extension-ui/src/components/PidTiles.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import '../styles/pid.css';
+import { toastError } from '../lib/toast';
 
 type Highlight = 'primary' | 'warning' | null;
 
@@ -27,9 +28,11 @@ export default function PidTiles({ src, highlight = null }: PidTilesProps) {
   const debounceTimer = useRef<number>();
 
   useEffect(() => {
-    fetch(src)
-      .then((r) => r.text())
-      .then((txt) => {
+    async function load() {
+      try {
+        const r = await fetch(src);
+        if ('ok' in r && !r.ok) throw new Error('Failed to load PID');
+        const txt = await r.text();
         const div = hiddenRef.current;
         if (!div) return;
         div.innerHTML = txt;
@@ -48,7 +51,11 @@ export default function PidTiles({ src, highlight = null }: PidTilesProps) {
         elementsRef.current = entries;
         div.innerHTML = '';
         fitToScreen(svg);
-      });
+      } catch (err) {
+        toastError('Failed to load PID');
+      }
+    }
+    load();
   }, [src]);
 
   useEffect(() => {

--- a/apps/maximo-extension-ui/src/components/PidViewer.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import '../styles/pid.css';
+import { toastError } from '../lib/toast';
 
 type Highlight = 'primary' | 'warning' | null;
 
@@ -31,9 +32,11 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
   }
 
   useEffect(() => {
-    fetch(src)
-      .then((r) => r.text())
-      .then((txt) => {
+    async function load() {
+      try {
+        const r = await fetch(src);
+        if ('ok' in r && !r.ok) throw new Error('Failed to load PID');
+        const txt = await r.text();
         if (svgContainerRef.current) {
           svgContainerRef.current.innerHTML = txt;
           svgRef.current = svgContainerRef.current.querySelector('svg');
@@ -41,7 +44,11 @@ export default function PidViewer({ src, highlight = null, warnings = [] }: PidV
           applyHighlight();
           fitToScreen();
         }
-      });
+      } catch (err) {
+        toastError('Failed to load PID');
+      }
+    }
+    load();
   }, [src]);
 
   useEffect(() => {

--- a/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
+++ b/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '../lib/api';
+import { toastError } from '../lib/toast';
 
 interface HatCandidate {
   hat_id: string;
@@ -15,7 +16,17 @@ async function fetchCandidates(): Promise<HatCandidate[]> {
 }
 
 export default function ReactivePicker({ wo }: { wo: string }) {
-  const { data } = useQuery({ queryKey: ['reactive', wo], queryFn: fetchCandidates });
+  const { data } = useQuery({
+    queryKey: ['reactive', wo],
+    queryFn: async () => {
+      try {
+        return await fetchCandidates();
+      } catch (err) {
+        toastError('Failed to fetch reactive candidates');
+        throw err;
+      }
+    }
+  });
   if (!data) return null;
   return (
     <section className="mt-4">

--- a/apps/maximo-extension-ui/src/lib/hooks.ts
+++ b/apps/maximo-extension-ui/src/lib/hooks.ts
@@ -6,6 +6,7 @@ import type { WorkOrderSummary, BlueprintData } from '../types/api';
 import { apiFetch } from './api';
 import { fetchWorkOrder } from './workorders';
 import { fetchBlueprint } from './blueprint';
+import { toastError } from './toast';
 
 /**
  * Fetch portfolio data from the API.
@@ -32,7 +33,8 @@ export function usePortfolioApi(): UseQueryResult<PortfolioData> {
       if (!useApi) return fetchPortfolio();
       try {
         return await fetchPortfolioApi();
-      } catch {
+      } catch (err) {
+        toastError('Failed to fetch portfolio');
         return fetchPortfolio();
       }
     }
@@ -54,7 +56,8 @@ export function useWorkOrderApi(id: string): UseQueryResult<WorkOrderSummary> {
       if (!useApi) return fetchWorkOrderMock(id);
       try {
         return await fetchWorkOrder(id);
-      } catch {
+      } catch (err) {
+        toastError('Failed to fetch work order');
         return fetchWorkOrderMock(id);
       }
     }
@@ -71,7 +74,15 @@ export function useBlueprintApi(id: string): UseQueryResult<BlueprintData> {
   const useApi = process.env.NEXT_PUBLIC_USE_API === 'true';
   return useQuery({
     queryKey: ['blueprint', id],
-    queryFn: () => (useApi ? fetchBlueprint(id) : fetchBlueprintMock(id))
+    queryFn: async () => {
+      if (!useApi) return fetchBlueprintMock(id);
+      try {
+        return await fetchBlueprint(id);
+      } catch (err) {
+        toastError('Failed to fetch blueprint');
+        return fetchBlueprintMock(id);
+      }
+    }
   });
 }
 

--- a/apps/maximo-extension-ui/src/lib/schedule.ts
+++ b/apps/maximo-extension-ui/src/lib/schedule.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { apiFetch } from './api';
+import { toastError } from './toast';
 
 export interface SchedulePoint {
   date: string;
@@ -38,6 +39,16 @@ export async function fetchSchedule(wo: string): Promise<ScheduleResponse> {
  * React Query hook for schedule data.
  */
 export function useSchedule(wo: string): UseQueryResult<ScheduleResponse> {
-  return useQuery({ queryKey: ['schedule', wo], queryFn: () => fetchSchedule(wo) });
+  return useQuery({
+    queryKey: ['schedule', wo],
+    queryFn: async () => {
+      try {
+        return await fetchSchedule(wo);
+      } catch (err) {
+        toastError('Failed to fetch schedule');
+        throw err;
+      }
+    }
+  });
 }
 

--- a/apps/maximo-extension-ui/src/lib/toast.ts
+++ b/apps/maximo-extension-ui/src/lib/toast.ts
@@ -1,0 +1,10 @@
+export function toastError(message: string): void {
+  if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+    try {
+      window.alert(message);
+    } catch {
+      /* ignore environments without alert */
+    }
+  }
+  console.error(message);
+}


### PR DESCRIPTION
## Summary
- add `toastError` helper to surface API failures to users
- wrap fetch-based hooks and components with try/catch and toast errors
- guard against missing `ok` in mocked responses

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/lib/toast.ts apps/maximo-extension-ui/src/lib/hooks.ts apps/maximo-extension-ui/src/lib/schedule.ts apps/maximo-extension-ui/src/components/ReactivePicker.tsx apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx apps/maximo-extension-ui/src/app/conflicts/page.tsx apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx apps/maximo-extension-ui/src/components/PidViewer.tsx apps/maximo-extension-ui/src/components/PidTiles.tsx apps/maximo-extension-ui/src/components/Exports.tsx`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a84ca24f908322925efdcfab396c75