### PR TITLE
Add LOTO tags to FastAPI endpoints

### DIFF
--- a/apps/api/hats_endpoints.py
+++ b/apps/api/hats_endpoints.py
@@ -11,7 +11,7 @@ from loto.roster import storage, update_ranking
 
 from .schemas import HatKpiRequest, HatSnapshot
 
-router = APIRouter(prefix="/hats", tags=["hats"])
+router = APIRouter(prefix="/hats", tags=["hats", "LOTO"])
 
 
 def _ledger_path() -> Path:

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -189,7 +189,7 @@ class ProposeResponse(BaseModel):
         extra = "forbid"
 
 
-@app.get("/healthz", include_in_schema=False)
+@app.get("/healthz", include_in_schema=False, tags=["LOTO"])
 async def healthz() -> dict[str, Any]:
     """Health check endpoint including rate limit counters."""
     return {
@@ -224,7 +224,7 @@ class DemoMaximoAdapter:
         }
 
 
-@app.post("/blueprint", response_model=BlueprintResponse)
+@app.post("/blueprint", response_model=BlueprintResponse, tags=["LOTO"])
 async def post_blueprint(payload: BlueprintRequest) -> BlueprintResponse:
     """Plan isolations for a work order and return impact metrics."""
 
@@ -319,7 +319,7 @@ def _diff(
     return delta
 
 
-@app.post("/propose", response_model=ProposeResponse)
+@app.post("/propose", response_model=ProposeResponse, tags=["LOTO"])
 async def post_propose(payload: ProposeRequest) -> ProposeResponse:
     """Return diffs between proposed plan/schedule and current state."""
 
@@ -336,7 +336,7 @@ async def post_propose(payload: ProposeRequest) -> ProposeResponse:
     return ProposeResponse(diff=diff, idempotency_key=str(uuid4()))
 
 
-@app.post("/schedule", response_model=ScheduleResponse)
+@app.post("/schedule", response_model=ScheduleResponse, tags=["LOTO"])
 async def post_schedule(
     payload: ScheduleRequest, strict: bool = False
 ) -> ScheduleResponse:
@@ -426,7 +426,7 @@ async def post_schedule(
     )
 
 
-@app.get("/workorders/{workorder_id}/jobpack")
+@app.get("/workorders/{workorder_id}/jobpack", tags=["LOTO"])
 async def get_jobpack(
     workorder_id: str,
     permit_start: date | None = None,

--- a/apps/api/pid_endpoints.py
+++ b/apps/api/pid_endpoints.py
@@ -14,7 +14,7 @@ from loto.models import IsolationPlan
 from loto.pid import build_overlay
 from loto.pid.validator import validate_svg_map
 
-router = APIRouter(prefix="/pid", tags=["pid"])
+router = APIRouter(prefix="/pid", tags=["pid", "LOTO"])
 
 
 def _stat_path(path: Path) -> tuple[float, bool]:

--- a/apps/api/workorder_endpoints.py
+++ b/apps/api/workorder_endpoints.py
@@ -39,7 +39,7 @@ class PortfolioResponse(BaseModel):
         extra = "forbid"
 
 
-router = APIRouter(tags=["workorders"])
+router = APIRouter(tags=["workorders", "LOTO"])
 
 
 @router.get("/workorders/{workorder_id}", response_model=WorkOrderSummary)


### PR DESCRIPTION
## Summary
- tag all router and application endpoints with `tags=["LOTO"]`

## Testing
- `pre-commit run --files apps/api/hats_endpoints.py apps/api/main.py apps/api/pid_endpoints.py apps/api/workorder_endpoints.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a8553d69988322a2d856ad2bc8e66f