### PR TITLE
Include localhost in CORS defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ NEXT_PUBLIC_ROLE=TEST
 NEXT_PUBLIC_API_BASE=http://localhost:8000
 NEXT_PUBLIC_API_TOKEN=devtoken
 # Comma-separated list of origins allowed to access the API
-CORS_ORIGINS=
+CORS_ORIGINS=http://localhost:3000
 # Rate limiting settings
 RATE_LIMIT_CAPACITY=10
 RATE_LIMIT_INTERVAL=60

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -61,14 +61,16 @@ logging.info("loaded rulepack %s sha256=%s", _rulepack_path, RULE_PACK_HASH)
 app = FastAPI(title="loto API")
 
 origins = [o.strip() for o in os.getenv("CORS_ORIGINS", "").split(",") if o.strip()]
-if origins:
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+if "http://localhost:3000" not in origins:
+    origins.append("http://localhost:3000")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(pid_router)
 app.include_router(hats_router)


### PR DESCRIPTION
## Summary
- add http://localhost:3000 to API CORS origins by default
- document default CORS origin in `.env.example`

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `pre-commit run --files apps/api/main.py .env.example`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a8581ed3988322ab94e08b3ae3632f