### PR TITLE
Expose health and version endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ UI at <http://localhost:3000>. Verify the API is running:
 
 ```bash
 curl :8000/healthz
+curl :8000/version
 ```
 
 Open the UI in your browser to view the Portfolio page at

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -4,7 +4,8 @@ This directory contains a minimal [FastAPI](https://fastapi.tiangolo.com/) servi
 
 ## Endpoints
 
-- `GET /healthz` – basic health check (excluded from OpenAPI schema).
+- `GET /healthz` – basic health check.
+- `GET /version` – return the application version.
 - `POST /blueprint` – placeholder accepting a CSV upload or work order ID.
 - `POST /schedule` – placeholder endpoint for creating schedules.
 - `GET /workorders/{id}` – mock endpoint returning a work order.
@@ -25,4 +26,4 @@ Start the development server:
 uvicorn apps.api.main:app --reload
 ```
 
-OpenAPI documentation is available at `/docs` and lists the three placeholder endpoints.
+OpenAPI documentation is available at `/docs`.

--- a/tests/api/test_version.py
+++ b/tests/api/test_version.py
@@ -1,0 +1,24 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def test_version_endpoint():
+    import apps.api.main as main
+
+    importlib.reload(main)
+    client = TestClient(main.app)
+    res = client.get("/version")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["version"] == main.APP_VERSION
+    assert res.headers["X-Env"] == main.ENV_BADGE
+
+
+def test_openapi_includes_health_and_version():
+    import apps.api.main as main
+
+    client = TestClient(main.app)
+    spec = client.get("/openapi.json").json()
+    assert "/healthz" in spec["paths"]
+    assert "/version" in spec["paths"]


### PR DESCRIPTION
## Summary
- include /healthz in OpenAPI and add /version endpoint
- document health and version endpoints
- test API version endpoint

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files README.md apps/api/README.md apps/api/main.py tests/api/test_version.py`


------
https://chatgpt.com/codex/tasks/task_b_68a8596910e883229a9c82a2f494dd08