### PR TITLE
feat(ui): add stepper component with tests

### DIFF
--- a/apps/maximo-extension-ui/src/components/Stepper.test.tsx
+++ b/apps/maximo-extension-ui/src/components/Stepper.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import Stepper from './Stepper';
+
+test('matches snapshot', () => {
+  const { container } = render(
+    <Stepper steps={['Step 1', 'Step 2', 'Step 3']} active={1} />
+  );
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/apps/maximo-extension-ui/src/components/Stepper.tsx
+++ b/apps/maximo-extension-ui/src/components/Stepper.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export interface StepperProps {
+  steps: string[];
+  active: number;
+  className?: string;
+}
+
+export default function Stepper({ steps, active, className }: StepperProps) {
+  return (
+    <ol className={clsx('flex gap-2', className)}>
+      {steps.map((step, index) => (
+        <li
+          key={step}
+          className={clsx(
+            'rounded px-3 py-1',
+            index === active
+              ? 'bg-[var(--mxc-topbar-bg)] text-[var(--mxc-topbar-fg)]'
+              : 'bg-[var(--mxc-sheet)] text-[var(--mxc-fg-subtle)]'
+          )}
+        >
+          {step}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/maximo-extension-ui/src/components/__snapshots__/Stepper.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/components/__snapshots__/Stepper.test.tsx.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matches snapshot 1`] = `
+<ol
+  class="flex gap-2"
+>
+  <li
+    class="rounded px-3 py-1 bg-[var(--mxc-sheet)] text-[var(--mxc-fg-subtle)]"
+  >
+    Step 1
+  </li>
+  <li
+    class="rounded px-3 py-1 bg-[var(--mxc-topbar-bg)] text-[var(--mxc-topbar-fg)]"
+  >
+    Step 2
+  </li>
+  <li
+    class="rounded px-3 py-1 bg-[var(--mxc-sheet)] text-[var(--mxc-fg-subtle)]"
+  >
+    Step 3
+  </li>
+</ol>
+`;


### PR DESCRIPTION
## Summary
- add Stepper component to render and highlight progress steps
- cover Stepper with snapshot test

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/components/Stepper.tsx apps/maximo-extension-ui/src/components/Stepper.test.tsx`
- `pnpm -F maximo-extension-ui test`
- `make test` *(fails: The starlette.testclient module requires the httpx package to be installed.)*

------
https://chatgpt.com/codex/tasks/task_b_68a85f0fead4832298914f4e9efce924