### PR TITLE
feat(ui): add wizard page with persisted steps

### DIFF
--- a/apps/maximo-extension-ui/src/app/wizard/__snapshots__/page.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/app/wizard/__snapshots__/page.test.tsx.snap
@@ -1,0 +1,37 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matches snapshot 1`] = `
+<main>
+  <ol
+    class="flex gap-2"
+  >
+    <li
+      class="rounded px-3 py-1 bg-[var(--mxc-topbar-bg)] text-[var(--mxc-topbar-fg)]"
+    >
+      Step One
+    </li>
+    <li
+      class="rounded px-3 py-1 bg-[var(--mxc-sheet)] text-[var(--mxc-fg-subtle)]"
+    >
+      Step Two
+    </li>
+    <li
+      class="rounded px-3 py-1 bg-[var(--mxc-sheet)] text-[var(--mxc-fg-subtle)]"
+    >
+      Step Three
+    </li>
+  </ol>
+  <div>
+    <label>
+      Name
+      <input
+        aria-label="name"
+        value=""
+      />
+    </label>
+    <button>
+      Next
+    </button>
+  </div>
+</main>
+`;

--- a/apps/maximo-extension-ui/src/app/wizard/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/wizard/page.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import Page from './page';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+test('matches snapshot', () => {
+  const { container } = render(<Page />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('initializes from and persists to localStorage', async () => {
+  window.localStorage.setItem('wizard-step', '1');
+  window.localStorage.setItem(
+    'wizard-data',
+    JSON.stringify({ name: 'Bob', age: '42' })
+  );
+  render(<Page />);
+  const age = screen.getByLabelText('age');
+  expect(age).toHaveValue('42');
+
+  fireEvent.change(age, { target: { value: '30' } });
+  fireEvent.click(screen.getByText('Next'));
+
+  expect(window.localStorage.getItem('wizard-step')).toBe('2');
+  const stored = window.localStorage.getItem('wizard-data');
+  expect(stored && JSON.parse(stored)).toEqual({ name: 'Bob', age: '30' });
+});
+

--- a/apps/maximo-extension-ui/src/app/wizard/page.tsx
+++ b/apps/maximo-extension-ui/src/app/wizard/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Stepper from '../../components/Stepper';
+
+interface WizardData {
+  name: string;
+  age: string;
+}
+
+const steps = ['Step One', 'Step Two', 'Step Three'];
+
+export default function WizardPage() {
+  const [step, setStep] = useState(0);
+  const [data, setData] = useState<WizardData>({ name: '', age: '' });
+
+  // Load initial state from localStorage
+  useEffect(() => {
+    const storedStep = window.localStorage.getItem('wizard-step');
+    const storedData = window.localStorage.getItem('wizard-data');
+    if (storedStep) {
+      const parsed = parseInt(storedStep, 10);
+      if (!Number.isNaN(parsed)) setStep(parsed);
+    }
+    if (storedData) {
+      try {
+        const parsed = JSON.parse(storedData) as WizardData;
+        setData(parsed);
+      } catch {
+        /* ignore bad data */
+      }
+    }
+  }, []);
+
+  // Persist step to storage
+  useEffect(() => {
+    window.localStorage.setItem('wizard-step', String(step));
+  }, [step]);
+
+  // Persist data to storage
+  useEffect(() => {
+    window.localStorage.setItem('wizard-data', JSON.stringify(data));
+  }, [data]);
+
+  const StepOne = () => (
+    <div>
+      <label>
+        Name
+        <input
+          aria-label="name"
+          value={data.name}
+          onChange={(e) => setData({ ...data, name: e.target.value })}
+        />
+      </label>
+      <button onClick={() => setStep(1)}>Next</button>
+    </div>
+  );
+
+  const StepTwo = () => (
+    <div>
+      <label>
+        Age
+        <input
+          aria-label="age"
+          value={data.age}
+          onChange={(e) => setData({ ...data, age: e.target.value })}
+        />
+      </label>
+      <button onClick={() => setStep(2)}>Next</button>
+    </div>
+  );
+
+  const StepThree = () => (
+    <div>
+      <p>
+        Name: {data.name || '-'}, Age: {data.age || '-'}
+      </p>
+      <button onClick={() => setStep(0)}>Restart</button>
+    </div>
+  );
+
+  const stepComponents = [<StepOne key={0} />, <StepTwo key={1} />, <StepThree key={2} />];
+
+  return (
+    <main>
+      <Stepper steps={steps} active={step} />
+      {stepComponents[step]}
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add wizard page that renders stepper with three steps and persists progress to localStorage
- test wizard initialization and persistence, include snapshot

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/app/wizard/page.tsx apps/maximo-extension-ui/src/app/wizard/page.test.tsx`
- `pnpm -F maximo-extension-ui test`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68a86112ade48322922a2d82577e0a0f