### PR TITLE
feat(ui): add wizard upload component

### DIFF
--- a/apps/maximo-extension-ui/package.json
+++ b/apps/maximo-extension-ui/package.json
@@ -17,6 +17,7 @@
     "html2canvas": "^1.4.1",
     "js-yaml": "^4.1.0",
     "jspdf": "^3.0.1",
+    "papaparse": "^5.4.1",
     "next": "^14.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/maximo-extension-ui/src/components/WizardUpload.test.tsx
+++ b/apps/maximo-extension-ui/src/components/WizardUpload.test.tsx
@@ -1,0 +1,31 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import WizardUpload from './WizardUpload';
+
+test('supports multiple csv uploads and parsing', async () => {
+  const setData = vi.fn();
+  const { getByTestId } = render(<WizardUpload setData={setData} />);
+  const input = getByTestId('wizard-upload-input') as HTMLInputElement;
+
+  expect(input.multiple).toBe(true);
+
+  const file1 = new File(['a,b\n1,2'], 'one.csv', { type: 'text/csv' });
+  const file2 = new File(['c,d\n3,4'], 'two.csv', { type: 'text/csv' });
+
+  fireEvent.change(input, { target: { files: [file1, file2] } });
+
+  await waitFor(() =>
+    expect(setData).toHaveBeenCalledWith([
+      { name: 'one.csv', data: [{ a: '1', b: '2' }] },
+      { name: 'two.csv', data: [{ c: '3', d: '4' }] }
+    ])
+  );
+
+  expect(localStorage.getItem('wizardUpload')).toBe(
+    JSON.stringify([
+      { name: 'one.csv', data: [{ a: '1', b: '2' }] },
+      { name: 'two.csv', data: [{ c: '3', d: '4' }] }
+    ])
+  );
+});
+

--- a/apps/maximo-extension-ui/src/components/WizardUpload.tsx
+++ b/apps/maximo-extension-ui/src/components/WizardUpload.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Papa from 'papaparse';
+
+interface ParsedFile {
+  name: string;
+  data: Record<string, unknown>[];
+}
+
+interface WizardUploadProps {
+  setData: (data: ParsedFile[]) => void;
+}
+
+export default function WizardUpload({ setData }: WizardUploadProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    const parsed: ParsedFile[] = new Array(files.length);
+    let remaining = files.length;
+    Array.from(files).forEach((file, index) => {
+      Papa.parse<Record<string, unknown>>(file, {
+        header: true,
+        skipEmptyLines: true,
+        complete: (results) => {
+          parsed[index] = { name: file.name, data: results.data };
+          remaining -= 1;
+          if (remaining === 0) {
+            setData(parsed);
+            localStorage.setItem('wizardUpload', JSON.stringify(parsed));
+          }
+        }
+      });
+    });
+  };
+
+  return (
+    <input
+      type="file"
+      accept=".csv"
+      multiple
+      data-testid="wizard-upload-input"
+      onChange={handleChange}
+    />
+  );
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       next:
         specifier: ^14.0.0
         version: 14.2.31(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      papaparse:
+        specifier: ^5.4.1
+        version: 5.5.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -3945,6 +3948,9 @@ packages:
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  papaparse@5.5.3:
+    resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -9526,6 +9532,8 @@ snapshots:
   package-json-from-dist@1.0.1: {}
 
   pako@0.2.9: {}
+
+  papaparse@5.5.3: {}
 
   parent-module@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add WizardUpload component to parse uploaded CSVs and store results
- document parsing via PapaParse and save data to parent state and localStorage
- test multi-file uploads

## Testing
- `pnpm -F maximo-extension-ui install`
- `pre-commit run --files apps/maximo-extension-ui/package.json apps/maximo-extension-ui/src/components/WizardUpload.tsx apps/maximo-extension-ui/src/components/WizardUpload.test.tsx pnpm-lock.yaml`
- `pnpm -F maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a86311cdbc8322a8aab015115fc058