### PR TITLE
feat(ui): add schedule generation step

### DIFF
--- a/apps/maximo-extension-ui/src/components/WizardGenerate.test.tsx
+++ b/apps/maximo-extension-ui/src/components/WizardGenerate.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import WizardGenerate from './WizardGenerate';
+import { apiFetch } from '../lib/api';
+
+vi.mock('../lib/api', () => ({ apiFetch: vi.fn() }));
+
+test('posts data and shows spinner while waiting', async () => {
+  localStorage.clear();
+  const plan = { plan: 'ok' };
+  let resolve: (value: any) => void = () => {};
+  (apiFetch as unknown as vi.Mock).mockReturnValue(
+    new Promise((res) => {
+      resolve = res;
+    })
+  );
+
+  const setPlan = vi.fn();
+  const setStep = vi.fn();
+
+  render(<WizardGenerate data={[]} setPlan={setPlan} setStep={setStep} />);
+
+  expect(screen.getByTestId('wizard-generate-spinner')).toBeInTheDocument();
+
+  resolve({ ok: true, json: () => Promise.resolve(plan) });
+
+  await waitFor(() => expect(setPlan).toHaveBeenCalledWith(plan));
+  expect(localStorage.getItem('wizardPlan')).toBe(JSON.stringify(plan));
+  expect(setStep).toHaveBeenCalledWith(3);
+  expect(screen.queryByTestId('wizard-generate-spinner')).toBeNull();
+});
+

--- a/apps/maximo-extension-ui/src/components/WizardGenerate.tsx
+++ b/apps/maximo-extension-ui/src/components/WizardGenerate.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { apiFetch } from '../lib/api';
+
+interface ParsedFile {
+  name: string;
+  data: Record<string, unknown>[];
+}
+
+interface WizardGenerateProps {
+  data: ParsedFile[];
+  setPlan: (plan: unknown) => void;
+  setStep: (step: number) => void;
+}
+
+export default function WizardGenerate({ data, setPlan, setStep }: WizardGenerateProps) {
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function generate() {
+      setLoading(true);
+      try {
+        const res = await apiFetch('/schedule', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ files: data })
+        });
+        if (!cancelled && res.ok) {
+          const plan = await res.json();
+          setPlan(plan);
+          localStorage.setItem('wizardPlan', JSON.stringify(plan));
+          setStep(3);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    generate();
+    return () => {
+      cancelled = true;
+    };
+  }, [data, setPlan, setStep]);
+
+  if (!loading) return null;
+  return <div data-testid="wizard-generate-spinner">Loading...</div>;
+}
+


### PR DESCRIPTION
## Summary
- add WizardGenerate component to post CSV data and save plan
- test schedule generation spinner behavior

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/components/WizardGenerate.tsx apps/maximo-extension-ui/src/components/WizardGenerate.test.tsx`
- `pnpm -F maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a8656e818883228683f72274039e75