### PR TITLE
Add plan export wizard step

### DIFF
--- a/apps/maximo-extension-ui/src/app/wizard/__snapshots__/page.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/app/wizard/__snapshots__/page.test.tsx.snap
@@ -20,6 +20,11 @@ exports[`matches snapshot 1`] = `
     >
       Step Three
     </li>
+    <li
+      class="rounded px-3 py-1 bg-[var(--mxc-sheet)] text-[var(--mxc-fg-subtle)]"
+    >
+      Export
+    </li>
   </ol>
   <div>
     <label>

--- a/apps/maximo-extension-ui/src/app/wizard/page.tsx
+++ b/apps/maximo-extension-ui/src/app/wizard/page.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useState } from 'react';
 import Stepper from '../../components/Stepper';
+import WizardExport from '../../components/WizardExport';
 
 interface WizardData {
   name: string;
   age: string;
 }
 
-const steps = ['Step One', 'Step Two', 'Step Three'];
+const steps = ['Step One', 'Step Two', 'Step Three', 'Export'];
 
 export default function WizardPage() {
   const [step, setStep] = useState(0);
@@ -75,11 +76,23 @@ export default function WizardPage() {
       <p>
         Name: {data.name || '-'}, Age: {data.age || '-'}
       </p>
+      <button onClick={() => setStep(3)}>Next</button>
+    </div>
+  );
+
+  const StepFour = () => (
+    <div>
+      <WizardExport plan={data} />
       <button onClick={() => setStep(0)}>Restart</button>
     </div>
   );
 
-  const stepComponents = [<StepOne key={0} />, <StepTwo key={1} />, <StepThree key={2} />];
+  const stepComponents = [
+    <StepOne key={0} />,
+    <StepTwo key={1} />,
+    <StepThree key={2} />,
+    <StepFour key={3} />
+  ];
 
   return (
     <main>

--- a/apps/maximo-extension-ui/src/components/WizardExport.test.tsx
+++ b/apps/maximo-extension-ui/src/components/WizardExport.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import WizardExport from './WizardExport';
+
+test('matches snapshot', () => {
+  const { container } = render(<WizardExport plan={{}} />);
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/apps/maximo-extension-ui/src/components/WizardExport.tsx
+++ b/apps/maximo-extension-ui/src/components/WizardExport.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import Button from './Button';
+import { apiFetch } from '../lib/api';
+import { toastError } from '../lib/toast';
+
+interface WizardExportProps {
+  plan: unknown;
+}
+
+export default function WizardExport({ plan }: WizardExportProps) {
+  const [hash, setHash] = useState<string | null>(null);
+  const [seed, setSeed] = useState<string | null>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+
+  async function handleExport(format: 'pdf' | 'json') {
+    try {
+      const res = await apiFetch('/blueprint', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: format === 'pdf' ? 'application/pdf' : 'application/json'
+        },
+        body: JSON.stringify(plan)
+      });
+      if ('ok' in res && !res.ok) throw new Error('Failed to export plan');
+
+      const h = res.headers.get('x-loto-hash');
+      const s = res.headers.get('x-loto-seed');
+      if (h) setHash(h);
+      if (s) setSeed(s);
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const ext = format === 'pdf' ? 'pdf' : 'json';
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `plan_${h ?? 'unknown'}.${ext}`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toastError('Failed to export plan');
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (!toolbarRef.current) return;
+    const buttons = toolbarRef.current.querySelectorAll<HTMLButtonElement>('button');
+    const currentIndex = Array.from(buttons).indexOf(
+      document.activeElement as HTMLButtonElement
+    );
+    if (e.key === 'ArrowRight') {
+      const next = buttons[(currentIndex + 1) % buttons.length];
+      next.focus();
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft') {
+      const prev = buttons[(currentIndex - 1 + buttons.length) % buttons.length];
+      prev.focus();
+      e.preventDefault();
+    }
+  }
+
+  return (
+    <div
+      ref={toolbarRef}
+      role="toolbar"
+      aria-label="Export options"
+      onKeyDown={handleKeyDown}
+      className="mb-4 flex items-center space-x-2"
+    >
+      <Button aria-label="Export PDF" onClick={() => handleExport('pdf')}>
+        Export PDF
+      </Button>
+      <Button aria-label="Export JSON" onClick={() => handleExport('json')}>
+        Export JSON
+      </Button>
+      {hash && <span>Hash: {hash}</span>}
+      {seed && <span>Seed: {seed}</span>}
+    </div>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/components/__snapshots__/WizardExport.test.tsx.snap
+++ b/apps/maximo-extension-ui/src/components/__snapshots__/WizardExport.test.tsx.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matches snapshot 1`] = `
+<div
+  aria-label="Export options"
+  class="mb-4 flex items-center space-x-2"
+  role="toolbar"
+>
+  <button
+    aria-label="Export PDF"
+    class="rounded-[var(--mxc-radius-sm)] bg-[var(--mxc-topbar-bg)] px-4 py-2 text-[var(--mxc-topbar-fg)] shadow-[var(--mxc-shadow-sm)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--mxc-topbar-bg)]"
+    type="button"
+  >
+    Export PDF
+  </button>
+  <button
+    aria-label="Export JSON"
+    class="rounded-[var(--mxc-radius-sm)] bg-[var(--mxc-topbar-bg)] px-4 py-2 text-[var(--mxc-topbar-fg)] shadow-[var(--mxc-shadow-sm)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--mxc-topbar-bg)]"
+    type="button"
+  >
+    Export JSON
+  </button>
+</div>
+`;


### PR DESCRIPTION
## Summary
- add WizardExport component to download plan as PDF or JSON
- include export step in wizard flow
- cover new component with snapshot test

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/components/WizardExport.tsx apps/maximo-extension-ui/src/components/WizardExport.test.tsx`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a866eb3aa0832288f1404ded13dbe2