### PR TITLE
Add golden path tests for CLI, API, and UI

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -442,6 +442,13 @@ async def post_schedule(
     )
 
 
+@app.post("/plans", response_model=ScheduleResponse, tags=["LOTO"])
+async def post_plans(payload: ScheduleRequest) -> ScheduleResponse:
+    """Temporary alias for :func:`post_schedule` used in tests."""
+
+    return await post_schedule(payload)
+
+
 @app.get("/workorders/{workorder_id}/jobpack", tags=["LOTO"])
 async def get_jobpack(
     workorder_id: str,

--- a/apps/maximo-extension-ui/e2e/golden-path.spec.ts
+++ b/apps/maximo-extension-ui/e2e/golden-path.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+test('golden path: upload → generate → publish → export PDF', async ({ page }, testInfo) => {
+  const downloads: string[] = [];
+  page.on('download', async (download) => {
+    const filePath = testInfo.outputPath(download.suggestedFilename());
+    await download.saveAs(filePath);
+    downloads.push(filePath);
+  });
+
+  await page.goto('http://localhost:3000/');
+
+  await page.getByRole('button', { name: /upload/i }).click();
+  await page.setInputFiles('input[type="file"]', path.join(__dirname, '../../demo/line_list.csv'));
+
+  await page.getByRole('button', { name: /generate/i }).click();
+  await page.getByRole('button', { name: /publish/i }).click();
+  await page.getByRole('button', { name: /export pdf/i }).click();
+
+  await expect.poll(() => downloads.filter(f => f.endsWith('.pdf')).length).toBeGreaterThan(0);
+  for (const file of downloads) {
+    expect(fs.existsSync(file)).toBeTruthy();
+  }
+});

--- a/loto/cli.py
+++ b/loto/cli.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 from pathlib import Path
 from typing import Optional
+from uuid import uuid4
 
 import networkx as nx  # type: ignore
 import typer
@@ -174,6 +176,12 @@ def demo(out: Path = Path("./out"), open_pdf: bool = False) -> None:
         with tqdm(total=1, desc="Generating demo", unit="step") as progress:
             main(["--demo", "--output", str(out)])
             progress.update(1)
+
+        doclinks_dir = out / "doclinks"
+        doclinks_dir.mkdir(parents=True, exist_ok=True)
+        doc_id = uuid4().hex
+        shutil.copy(out / "LOTO_A.pdf", doclinks_dir / f"{doc_id}.pdf")
+        shutil.copy(out / "LOTO_A.json", doclinks_dir / f"{doc_id}.json")
 
         typer.echo(f"✅ PDF + JSON saved to {out}")
         if open_pdf:

--- a/tests/api/test_plans_golden.py
+++ b/tests/api/test_plans_golden.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from apps.api.schemas import ScheduleResponse
+
+
+def test_plans_endpoint_returns_schedule() -> None:
+    client = TestClient(app)
+    res = client.post("/plans", json={"workorder": "WO-1"})
+    assert res.status_code == 200
+    data = ScheduleResponse.model_validate(res.json())
+    assert data.schedule

--- a/tests/test_cli_golden.py
+++ b/tests/test_cli_golden.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_demo_command_creates_doclinks(tmp_path: Path) -> None:
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    result = subprocess.run(
+        [sys.executable, "-m", "loto.cli", "demo"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    doclinks_dir = tmp_path / "out" / "doclinks"
+    assert doclinks_dir.is_dir()
+    pdfs = list(doclinks_dir.glob("*.pdf"))
+    jsons = list(doclinks_dir.glob("*.json"))
+    assert len(pdfs) == 1
+    assert len(jsons) == 1
+    assert pdfs[0].stem == jsons[0].stem


### PR DESCRIPTION
## Summary
- extend CLI demo to copy outputs into `out/doclinks/<id>` and test for doclink files
- add `/plans` endpoint alias and validate response via new golden test
- script golden path workflow in Playwright e2e test

## Testing
- `make lint`
- `make typecheck`
- `pnpm -F maximo-extension-ui test`
- `pnpm -F maximo-extension-ui exec playwright test apps/maximo-extension-ui/e2e/golden-path.spec.ts` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a86968275083229931d59cf5e04418