### PR TITLE
feat: integrate structlog logging and trace IDs

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 python-multipart
+structlog

--- a/loto/config.py
+++ b/loto/config.py
@@ -5,9 +5,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Optional
 
+import structlog
 from dotenv import load_dotenv
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = structlog.get_logger()
 
 
 class ConfigError(Exception):
@@ -104,7 +107,7 @@ def validate_env_vars(example: Path | None = None) -> None:
     Raises
     ------
     ConfigError
-        If any expected variable is missing. The function prints a table of
+        If any expected variable is missing. The function logs a table of
         expected keys with ``Y``/``N`` indicating presence before raising.
     """
 
@@ -126,9 +129,9 @@ def validate_env_vars(example: Path | None = None) -> None:
 
     if missing:
         col = max(len("Key"), *(len(k) for k, _ in rows))
-        print(f"{'Key'.ljust(col)} Present")
+        logger.info(f"{'Key'.ljust(col)} Present")
         for key, flag in rows:
-            print(f"{key.ljust(col)} {flag}")
+            logger.info(f"{key.ljust(col)} {flag}")
         raise ConfigError(
             code=CONFIG_ERROR_CODE,
             hint="Missing environment variables: " + ", ".join(missing),

--- a/loto/integrations/demo_adapter.py
+++ b/loto/integrations/demo_adapter.py
@@ -6,9 +6,12 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, TypedDict, cast
 
+import structlog
 import yaml
 
 from . import IntegrationAdapter
+
+logger = structlog.get_logger()
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from ..isolation_planner import IsolationPlan
@@ -107,3 +110,9 @@ class DemoIntegrationAdapter(IntegrationAdapter):
         pdf_path = output_dir / f"{parent_object_id}.pdf"
         json_path.write_text(json.dumps(as_json))
         pdf_path.write_bytes(pdf_bytes)
+        logger.info(
+            "artifacts_attached",
+            parent_id=parent_object_id,
+            json_path=str(json_path),
+            pdf_path=str(pdf_path),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "reportlab",
     "qrcode",
     "requests",
+    "structlog",
     "typer",
     "python-dotenv",
     "pandas",

--- a/scripts/hats_backfill.py
+++ b/scripts/hats_backfill.py
@@ -1,18 +1,21 @@
 """Seed hats ranking with synthetic KPI events.
 
 This script fabricates KPI metrics for a set of historical demo work orders
-and writes them to the hats ledger.  After backfilling the ledger it prints a
+and writes them to the hats ledger. After backfilling the ledger it logs a
 ranking snapshot so that ranks and sample counts can be inspected manually.
 """
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
+
+import structlog
+
+logger = structlog.get_logger()
 
 # Allow running the script without installing the package
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -96,7 +99,7 @@ def main() -> None:
         )
 
     snapshots.sort(key=lambda s: int(s["rank"]))
-    print(json.dumps(snapshots, default=str, indent=2))
+    logger.info("ranking_snapshot", snapshots=snapshots)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual script

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -19,5 +19,5 @@ def test_validate_env_vars_reports_missing(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert key in out
     lines = out.strip().splitlines()
-    row = next(line for line in lines if line.startswith(key))
-    assert row.endswith("N")
+    row = next(line for line in lines if key in line)
+    assert row.rstrip().endswith("N")


### PR DESCRIPTION
## Summary
- add `structlog` to project and API dependencies
- switch print statements to structured logging
- bind request `trace_id` via structlog contextvars and log planning metrics

## Testing
- `pre-commit run --files apps/api/main.py apps/api/requirements.txt loto/config.py loto/integrations/demo_adapter.py loto/service/blueprints.py pyproject.toml scripts/hats_backfill.py tests/test_env_validation.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68a8e823899083228311ab0649eca600