### PR TITLE
Add typed error classes and API error mapping

### DIFF
--- a/apps/maximo-extension-ui/src/lib/api.ts
+++ b/apps/maximo-extension-ui/src/lib/api.ts
@@ -3,12 +3,30 @@
  *
  * Uses the `NEXT_PUBLIC_API_BASE` environment variable if set.
  */
-export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+import { toastError } from './toast';
+
+const ERROR_MESSAGES: Record<string, string> = {
+  VALIDATION_ERROR: 'Request validation failed',
+  IMPORT_ERROR: 'Unable to import requested resource',
+  GENERATION_ERROR: 'Failed to generate response',
+};
+
+export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   const base = process.env.NEXT_PUBLIC_API_BASE ?? '';
   const token = process.env.NEXT_PUBLIC_API_TOKEN;
   const headers = new Headers(init?.headers || {});
   if (token && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`);
   }
-  return fetch(`${base}${path}`, { ...init, headers });
+  const res = await fetch(`${base}${path}`, { ...init, headers });
+  if (!res.ok) {
+    try {
+      const data = (await res.clone().json()) as { code?: string };
+      const msg = data.code && ERROR_MESSAGES[data.code];
+      if (msg) toastError(msg);
+    } catch {
+      /* ignore */
+    }
+  }
+  return res;
 }

--- a/loto/errors.py
+++ b/loto/errors.py
@@ -71,6 +71,33 @@ class RenderError(LotoError):
     """Failures while rendering documents or reports."""
 
 
+class ValidationError(LotoError):
+    """Input failed validation."""
+
+    code = "VALIDATION_ERROR"
+
+    def __init__(self, hint: str):
+        super().__init__(self.code, hint)
+
+
+class ImportError(LotoError):  # noqa: A001 - intended name clash with builtin
+    """Importing external data failed."""
+
+    code = "IMPORT_ERROR"
+
+    def __init__(self, hint: str):
+        super().__init__(self.code, hint)
+
+
+class GenerationError(LotoError):
+    """Generating output failed."""
+
+    code = "GENERATION_ERROR"
+
+    def __init__(self, hint: str):
+        super().__init__(self.code, hint)
+
+
 __all__ = [
     "LotoError",
     "ConfigError",
@@ -79,4 +106,7 @@ __all__ = [
     "PlanError",
     "IntegrationError",
     "RenderError",
+    "ValidationError",
+    "ImportError",
+    "GenerationError",
 ]

--- a/tests/api/test_error_handler.py
+++ b/tests/api/test_error_handler.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from loto.errors import GenerationError
+from loto.errors import ImportError as LotoImportError
+from loto.errors import ValidationError
+
+
+@app.get("/test/validation")
+def _raise_validation():  # pragma: no cover - endpoint for testing
+    raise ValidationError("bad input")
+
+
+@app.get("/test/import")
+def _raise_import():  # pragma: no cover - endpoint for testing
+    raise LotoImportError("failed import")
+
+
+@app.get("/test/generation")
+def _raise_generation():  # pragma: no cover - endpoint for testing
+    raise GenerationError("cannot generate")
+
+
+def test_validation_error_handler() -> None:
+    client = TestClient(app)
+    res = client.get("/test/validation")
+    assert res.status_code == 400
+    assert res.json() == {"code": "VALIDATION_ERROR", "message": "bad input"}
+
+
+def test_import_error_handler() -> None:
+    client = TestClient(app)
+    res = client.get("/test/import")
+    assert res.status_code == 500
+    assert res.json() == {"code": "IMPORT_ERROR", "message": "failed import"}
+
+
+def test_generation_error_handler() -> None:
+    client = TestClient(app)
+    res = client.get("/test/generation")
+    assert res.status_code == 500
+    assert res.json() == {"code": "GENERATION_ERROR", "message": "cannot generate"}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,13 +1,18 @@
+from typing import Any, Type
+
 import pytest
 
 from loto.errors import (
     ConfigError,
+    GenerationError,
     GraphError,
+    ImportError,
     IntegrationError,
     LotoError,
     PlanError,
     RenderError,
     RulesError,
+    ValidationError,
 )
 
 
@@ -23,6 +28,22 @@ def test_error_subclassing(exc_cls: type[LotoError]) -> None:
     # The string representation should include both the code and hint
     msg = str(err)
     assert "E001" in msg and "something went wrong" in msg
+
+
+@pytest.mark.parametrize(
+    "exc_cls, code",
+    [
+        (ValidationError, "VALIDATION_ERROR"),
+        (ImportError, "IMPORT_ERROR"),
+        (GenerationError, "GENERATION_ERROR"),
+    ],
+)
+def test_fixed_code_errors(exc_cls: Type[Any], code: str) -> None:
+    err = exc_cls("something went wrong")
+    assert err.code == code
+    assert err.hint == "something went wrong"
+    msg = str(err)
+    assert code in msg and "something went wrong" in msg
 
 
 def test_loto_error_str_contains_code() -> None:


### PR DESCRIPTION
## Summary
- add ValidationError, ImportError and GenerationError with fixed codes
- map these errors to HTTP responses and surface structured code/message
- show friendly banners in UI for new error codes

## Testing
- `pre-commit run --files apps/api/main.py apps/maximo-extension-ui/src/lib/api.test.ts apps/maximo-extension-ui/src/lib/api.ts loto/errors.py tests/test_errors.py tests/api/test_error_handler.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a8eaa4942c832288e85503e0d931c5