### PR TITLE
feat: add compose profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,16 @@ NEXT_PUBLIC_USE_API=false
 Run the API and UI with demo data using Docker. Ensure Docker and Docker Compose are installed and the Docker daemon is running:
 
 ```bash
-make demo-up
+docker compose --profile demo up
 ```
 
-This reads `.env.example` and starts the API at <http://localhost:8000> and the
+To start the pilot stack, which includes a Postgres service:
+
+```bash
+docker compose --profile pilot up
+```
+
+These commands read `.env.example` and start the API at <http://localhost:8000> and the
 UI at <http://localhost:3000>. Verify the API is running:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "8000:8000"
     env_file: .env.example
+    profiles: ["demo"]
   ui:
     build:
       context: .
@@ -17,3 +18,13 @@ services:
     env_file: .env.example
     depends_on:
       - api
+    profiles: ["demo"]
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: loto
+      POSTGRES_USER: loto
+      POSTGRES_PASSWORD: loto
+    ports:
+      - "5432:5432"
+    profiles: ["pilot"]


### PR DESCRIPTION
## Summary
- scope API and UI services to the `demo` Docker Compose profile
- add a `postgres` service under a `pilot` profile
- document profile usage in README

## Testing
- `pre-commit run --files docker-compose.yml README.md`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a8ed1a448c8322aacb4423e05d6ddd