### PR TITLE
feat(ui): add API URL env and proxy

### DIFF
--- a/apps/maximo-extension-ui/.env.example
+++ b/apps/maximo-extension-ui/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/apps/maximo-extension-ui/next.config.mjs
+++ b/apps/maximo-extension-ui/next.config.mjs
@@ -1,3 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async rewrites() {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!apiUrl) return [];
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${apiUrl}/api/:path*`,
+      },
+    ];
+  },
+};
+
 export default nextConfig;

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -11,7 +11,7 @@ test('renders gantt, price curve and hats timeline', async () => {
   // @ts-ignore
   global.ResizeObserver = ResizeObserver;
 
-  const apiBase = 'http://localhost:8000';
+  const apiBase = process.env.NEXT_PUBLIC_API_URL ?? '';
   process.env.NEXT_PUBLIC_API_BASE = apiBase;
 
   const sample = {


### PR DESCRIPTION
## Summary
- expose NEXT_PUBLIC_API_URL in maximo-extension-ui example env
- proxy /api requests to external API when NEXT_PUBLIC_API_URL is set
- reference NEXT_PUBLIC_API_URL in scheduler test

## Testing
- `pnpm -F maximo-extension-ui test`
- `pre-commit run --files apps/maximo-extension-ui/.env.example apps/maximo-extension-ui/next.config.mjs apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a8f0aa96d88322b1a5a71c5718e49f