### PR TITLE
Add JWT auth and login UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,6 @@ HATS_SNAPSHOT_PATH=hats_snapshot.json
 NEXT_PUBLIC_USE_API=false
 NEXT_PUBLIC_ROLE=TEST
 NEXT_PUBLIC_API_BASE=http://localhost:8000
-NEXT_PUBLIC_API_TOKEN=devtoken
 # Comma-separated list of origins allowed to access the API
 CORS_ORIGINS=http://localhost:3000
 # Rate limiting settings
@@ -40,4 +39,5 @@ RATE_LIMIT_INTERVAL=60
 # Authentication
 AUTH_REQUIRED=false
 AUTH_TOKEN=devtoken
+JWT_SECRET=changeme
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -11,6 +11,10 @@ COPY demo ./demo
 RUN pip install --no-cache-dir -r apps/api/requirements.txt && \
     pip install --no-cache-dir .
 
+# Create non-root user
+RUN useradd --create-home appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 8000
 
 CMD ["./apps/api/entrypoint.sh"]

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -11,6 +11,10 @@ RUN pnpm install --filter maximo-extension-ui... --frozen-lockfile
 
 COPY apps/maximo-extension-ui apps/maximo-extension-ui
 
+# Create non-root user
+RUN adduser -D appuser && chown -R appuser /app
+USER appuser
+
 EXPOSE 3000
 
 CMD ["pnpm", "-F", "maximo-extension-ui", "dev"]

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 python-multipart
 structlog
 alembic
+pyjwt

--- a/apps/maximo-extension-ui/src/app/layout.tsx
+++ b/apps/maximo-extension-ui/src/app/layout.tsx
@@ -3,21 +3,6 @@ import '../styles/globals.css';
 import ThemeToggle from '../components/ThemeToggle';
 import DensityToggle from '../components/DensityToggle';
 
-if (
-  process.env.NODE_ENV === 'development' &&
-  process.env.NEXT_PUBLIC_API_TOKEN
-) {
-  const token = process.env.NEXT_PUBLIC_API_TOKEN;
-  const originalFetch = global.fetch;
-  global.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
-    const headers = new Headers(init?.headers || {});
-    if (!headers.has('Authorization')) {
-      headers.set('Authorization', `Bearer ${token}`);
-    }
-    return originalFetch(input, { ...init, headers });
-  };
-}
-
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="h-full">

--- a/apps/maximo-extension-ui/src/app/login/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/login/page.test.tsx
@@ -1,0 +1,23 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { expect, test, vi, afterEach } from 'vitest';
+import Page from './page';
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  window.localStorage.clear();
+});
+
+test('stores token on successful login', async () => {
+  global.fetch = vi
+    .fn()
+    .mockResolvedValue(new Response(JSON.stringify({ access_token: 'abc' }), { status: 200 }));
+  const { getByText, getByLabelText } = render(<Page />);
+  fireEvent.change(getByLabelText('Username'), { target: { value: 'u' } });
+  fireEvent.change(getByLabelText('Password'), { target: { value: 'p' } });
+  fireEvent.click(getByText('Login'));
+  await waitFor(() => expect(window.localStorage.getItem('token')).toBe('abc'));
+});

--- a/apps/maximo-extension-ui/src/app/login/page.tsx
+++ b/apps/maximo-extension-ui/src/app/login/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { apiFetch } from '../../lib/api';
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await apiFetch('/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      const data = (await res.json()) as { access_token: string };
+      window.localStorage.setItem('token', data.access_token);
+      router.push('/');
+    }
+  }
+
+  return (
+    <main>
+      <form onSubmit={onSubmit}>
+        <label>
+          Username
+          <input
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            type="text"
+          />
+        </label>
+        <label>
+          Password
+          <input
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            type="password"
+          />
+        </label>
+        <button type="submit">Login</button>
+      </form>
+    </main>
+  );
+}

--- a/apps/maximo-extension-ui/src/lib/api.test.ts
+++ b/apps/maximo-extension-ui/src/lib/api.test.ts
@@ -8,7 +8,8 @@ const originalFetch = global.fetch;
 
 afterEach(() => {
   global.fetch = originalFetch;
-  delete process.env.NEXT_PUBLIC_API_TOKEN;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (global as any).localStorage;
   vi.clearAllMocks();
 });
 
@@ -16,7 +17,8 @@ describe('apiFetch', () => {
   it('adds authorization header when token is set', async () => {
     const mock = vi.fn().mockResolvedValue(new Response());
     global.fetch = mock as any;
-    process.env.NEXT_PUBLIC_API_TOKEN = 'token';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).localStorage = { getItem: () => 'token' };
 
     await apiFetch('/test');
 
@@ -27,7 +29,8 @@ describe('apiFetch', () => {
   it('does not override existing authorization header', async () => {
     const mock = vi.fn().mockResolvedValue(new Response());
     global.fetch = mock as any;
-    process.env.NEXT_PUBLIC_API_TOKEN = 'token';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).localStorage = { getItem: () => 'token' };
 
     await apiFetch('/test', { headers: { Authorization: 'Bearer existing' } });
 
@@ -46,6 +49,8 @@ describe('apiFetch', () => {
         })
       );
     global.fetch = mock as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).localStorage = { getItem: () => null };
 
     await apiFetch('/test');
 

--- a/apps/maximo-extension-ui/src/lib/api.ts
+++ b/apps/maximo-extension-ui/src/lib/api.ts
@@ -13,8 +13,9 @@ const ERROR_MESSAGES: Record<string, string> = {
 
 export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   const base = process.env.NEXT_PUBLIC_API_BASE ?? '';
-  const token = process.env.NEXT_PUBLIC_API_TOKEN;
   const headers = new Headers(init?.headers || {});
+  const token =
+    typeof window !== 'undefined' ? window.localStorage.getItem('token') : null;
   if (token && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`);
   }

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,5 +1,6 @@
 import importlib
 
+import jwt
 from fastapi.testclient import TestClient
 
 import apps.api.main as main
@@ -7,12 +8,13 @@ import apps.api.main as main
 
 def test_bearer_token(monkeypatch):
     monkeypatch.setenv("AUTH_REQUIRED", "true")
-    monkeypatch.setenv("AUTH_TOKEN", "secret")
+    monkeypatch.setenv("JWT_SECRET", "secret")
     importlib.reload(main)
     client = TestClient(main.app)
     payload = {"workorder": "WO-1"}
+    token = jwt.encode({"sub": "tester"}, "secret", algorithm="HS256")
     resp_ok = client.post(
-        "/schedule", json=payload, headers={"Authorization": "Bearer secret"}
+        "/schedule", json=payload, headers={"Authorization": f"Bearer {token}"}
     )
     assert resp_ok.status_code == 200
     resp_fail = client.post("/schedule", json=payload)
@@ -21,5 +23,4 @@ def test_bearer_token(monkeypatch):
     resp_public = client.get("/healthz")
     assert resp_public.status_code == 200
     monkeypatch.setenv("AUTH_REQUIRED", "false")
-    monkeypatch.setenv("AUTH_TOKEN", "devtoken")
     importlib.reload(main)


### PR DESCRIPTION
## Summary
- add JWT-protected login endpoint and middleware using PyJWT
- store login tokens in localStorage and attach them via apiFetch
- run API and UI containers as non-root appuser

## Testing
- `pre-commit run --files apps/api/main.py tests/api/test_auth.py apps/api/requirements.txt Dockerfile.api Dockerfile.ui apps/maximo-extension-ui/src/lib/api.ts apps/maximo-extension-ui/src/lib/api.test.ts apps/maximo-extension-ui/src/app/login/page.tsx apps/maximo-extension-ui/src/app/login/page.test.tsx apps/maximo-extension-ui/src/app/layout.tsx .env.example`
- `make fmt`
- `make lint`
- `pip install types-PyYAML`
- `make typecheck`
- `pip install httpx structlog`
- `make test`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a8f23f4f7c8322a442a6ff07a3dd59