### PR TITLE
Expose build info and stamp version in PDFs

### DIFF
--- a/apps/maximo-extension-ui/src/app/layout.tsx
+++ b/apps/maximo-extension-ui/src/app/layout.tsx
@@ -2,8 +2,18 @@ import type { ReactNode } from 'react';
 import '../styles/globals.css';
 import ThemeToggle from '../components/ThemeToggle';
 import DensityToggle from '../components/DensityToggle';
+import Footer from '../components/Footer';
+import { apiFetch } from '../lib/api';
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  let version = 'unknown';
+  try {
+    const res = await apiFetch('/version');
+    const data = (await res.json()) as { version: string; git_sha?: string };
+    version = data.git_sha ? `${data.version} (${data.git_sha})` : data.version;
+  } catch {
+    /* ignore */
+  }
   return (
     <html lang="en" className="h-full">
       <body className="min-h-screen">
@@ -26,6 +36,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               {/* Right drawer placeholder */}
             </aside>
           </div>
+          <Footer version={version} />
         </div>
       </body>
     </html>

--- a/apps/maximo-extension-ui/src/components/Footer.tsx
+++ b/apps/maximo-extension-ui/src/components/Footer.tsx
@@ -1,0 +1,15 @@
+import type { FC } from 'react';
+
+interface FooterProps {
+  version: string;
+}
+
+const Footer: FC<FooterProps> = ({ version }) => {
+  return (
+    <footer className="h-8 border-t border-[var(--mxc-border)] text-xs text-[var(--mxc-nav-fg)] flex items-center justify-center">
+      <span>Version: {version}</span>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/apps/maximo-extension-ui/src/lib/exportPid.ts
+++ b/apps/maximo-extension-ui/src/lib/exportPid.ts
@@ -7,10 +7,12 @@ import jsPDF from 'jspdf';
  *
  * @param filename - Name of the downloaded PDF file
  * @param elementId - DOM element id that contains the SVG and overlays
+ * @param version - Version string to stamp on the document
  */
 export async function exportPid(
   filename: string,
-  elementId = 'pid-container'
+  elementId = 'pid-container',
+  version = ''
 ): Promise<void> {
   const element = document.getElementById(elementId);
   if (!element) return;
@@ -24,5 +26,9 @@ export async function exportPid(
   const pageHeight = pdf.internal.pageSize.getHeight();
 
   pdf.addImage(imgData, 'PNG', 0, 0, pageWidth, pageHeight);
+  if (version) {
+    pdf.setFontSize(10);
+    pdf.text(version, 10, pageHeight - 10);
+  }
   pdf.save(filename);
 }


### PR DESCRIPTION
## Summary
- include git commit in `/version` endpoint
- show app version in UI footer and client PDF export
- stamp version + git SHA on generated PDFs

## Testing
- `pre-commit run --files apps/api/main.py loto/renderer.py apps/maximo-extension-ui/src/components/Footer.tsx apps/maximo-extension-ui/src/app/layout.tsx apps/maximo-extension-ui/src/lib/exportPid.ts`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a905f060b083229bc4be9dc72a18e2