### PR TITLE
feat: add feature flag infrastructure

### DIFF
--- a/apps/maximo-extension-ui/src/app/conflicts/page.tsx
+++ b/apps/maximo-extension-ui/src/app/conflicts/page.tsx
@@ -2,9 +2,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { notFound } from 'next/navigation';
 import { SimulationResult } from '../../types/api';
 import { apiFetch } from '../../lib/api';
 import { toastError } from '../../lib/toast';
+import { isFeatureEnabled } from '../../lib/featureFlags';
 
 // Fetch candidate bundling options for a work order
 async function fetchCandidates(): Promise<SimulationResult[]> {
@@ -14,6 +16,9 @@ async function fetchCandidates(): Promise<SimulationResult[]> {
 }
 
 export default function ConflictsPage() {
+  if (!isFeatureEnabled('conflicts')) {
+    notFound();
+  }
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [candidates, setCandidates] = useState<SimulationResult[]>([]);
   const [toast, setToast] = useState<string | null>(null);

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useState } from 'react';
+import { notFound } from 'next/navigation';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useWorkOrderApi, useBlueprintApi } from '../../../lib/hooks';
 import Exports from '../../../components/Exports';
 import CommitPanel from './CommitPanel';
 import PidTab from './PidTab';
 import type { MaterialStatus } from '../../../types/api';
+import { isFeatureEnabled } from '../../../lib/featureFlags';
 
 const tabs = ['Plan', 'Materials', 'P&ID', 'Simulation', 'Impact', 'Commit'];
 
@@ -151,6 +153,9 @@ function PlannerContent({ wo }: { wo: string }) {
 }
 
 export default function PlannerPage({ params }: { params: { wo: string } }) {
+  if (!isFeatureEnabled('planner')) {
+    notFound();
+  }
   return (
     <QueryClientProvider client={queryClient}>
       <PlannerContent wo={params.wo} />

--- a/apps/maximo-extension-ui/src/app/portfolio/page.tsx
+++ b/apps/maximo-extension-ui/src/app/portfolio/page.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import KpiCards from '../../components/KpiCards';
 import Skeleton from '../../components/Skeleton';
 import { usePortfolio } from '../../lib/hooks';
+import { isFeatureEnabled } from '../../lib/featureFlags';
 
 const queryClient = new QueryClient();
 
@@ -59,8 +60,12 @@ function PortfolioContent() {
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.status}</td>
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'}`}>{wo.owner}</td>
               <td className={`px-4 ${dense ? 'py-1' : 'py-2'} space-x-2`}>
-                <a href={`/planner/${wo.id}${search}`}>Planner</a>
-                <a href={`/scheduler/${wo.id}${search}`}>Scheduler</a>
+                {isFeatureEnabled('planner') && (
+                  <a href={`/planner/${wo.id}${search}`}>Planner</a>
+                )}
+                {isFeatureEnabled('scheduler') && (
+                  <a href={`/scheduler/${wo.id}${search}`}>Scheduler</a>
+                )}
               </td>
             </tr>
           ))}

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { notFound } from 'next/navigation';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Gantt from '../../../components/Gantt';
 import ReactivePicker from '../../../components/ReactivePicker';
 import { useSchedule } from '../../../lib/schedule';
+import { isFeatureEnabled } from '../../../lib/featureFlags';
 
 const queryClient = new QueryClient();
 
@@ -24,6 +26,9 @@ function SchedulerContent({ wo }: { wo: string }) {
 }
 
 export default function SchedulerPage({ params }: { params: { wo: string } }) {
+  if (!isFeatureEnabled('scheduler')) {
+    notFound();
+  }
   return (
     <QueryClientProvider client={queryClient}>
       <SchedulerContent wo={params.wo} />

--- a/apps/maximo-extension-ui/src/app/wizard/page.tsx
+++ b/apps/maximo-extension-ui/src/app/wizard/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { notFound } from 'next/navigation';
 import Stepper from '../../components/Stepper';
 import WizardExport from '../../components/WizardExport';
+import { isFeatureEnabled } from '../../lib/featureFlags';
 
 interface WizardData {
   name: string;
@@ -12,6 +14,9 @@ interface WizardData {
 const steps = ['Step One', 'Step Two', 'Step Three', 'Export'];
 
 export default function WizardPage() {
+  if (!isFeatureEnabled('wizard')) {
+    notFound();
+  }
   const [step, setStep] = useState(0);
   const [data, setData] = useState<WizardData>({ name: '', age: '' });
 

--- a/apps/maximo-extension-ui/src/lib/featureFlags.ts
+++ b/apps/maximo-extension-ui/src/lib/featureFlags.ts
@@ -1,0 +1,10 @@
+const flags = (process.env.NEXT_PUBLIC_FEATURE_FLAGS || '')
+  .split(',')
+  .map((f) => f.trim())
+  .filter(Boolean);
+
+export const FEATURE_FLAGS: Record<string, boolean> = Object.fromEntries(
+  flags.map((f) => [f, true])
+);
+
+export const isFeatureEnabled = (flag: string): boolean => !!FEATURE_FLAGS[flag];

--- a/apps/maximo-extension-ui/src/test/setup.ts
+++ b/apps/maximo-extension-ui/src/test/setup.ts
@@ -1,1 +1,4 @@
 import '@testing-library/jest-dom/vitest';
+
+process.env.NEXT_PUBLIC_FEATURE_FLAGS =
+  'planner,scheduler,wizard,conflicts';

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,7 +57,12 @@ def test_load_config_valid(tmp_path, monkeypatch, app_env, contents, check):
             "DATA_OUT",
             "RULEPACK_FILE",
         }
-        if k.startswith("MAXIMO") or k.startswith("WAPR") or k.startswith("COUPA") or k in tracked:
+        if (
+            k.startswith("MAXIMO")
+            or k.startswith("WAPR")
+            or k.startswith("COUPA")
+            or k in tracked
+        ):
             monkeypatch.delenv(k, raising=False)
     monkeypatch.setenv("APP_ENV", app_env)
     cfg = load_config()
@@ -106,10 +111,49 @@ def test_load_config_invalid(tmp_path, monkeypatch, app_env, contents, missing):
             "DATA_OUT",
             "RULEPACK_FILE",
         }
-        if k.startswith("MAXIMO") or k.startswith("WAPR") or k.startswith("COUPA") or k in tracked:
+        if (
+            k.startswith("MAXIMO")
+            or k.startswith("WAPR")
+            or k.startswith("COUPA")
+            or k in tracked
+        ):
             monkeypatch.delenv(k, raising=False)
     monkeypatch.setenv("APP_ENV", app_env)
     with pytest.raises(ConfigError) as exc:
         load_config()
     assert exc.value.code == "CONFIG/ENV"
     assert missing in exc.value.hint
+
+
+def test_load_config_feature_flags(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env.demo"
+    env_file.write_text(
+        "\n".join(
+            [
+                "APP_ENV=demo",
+                "DATA_IN=in",
+                "DATA_OUT=out",
+                "RULEPACK_FILE=rules.yml",
+                "FEATURE_FLAGS=wizard,planner",
+            ]
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    for k in list(os.environ):
+        tracked = {
+            "APP_ENV",
+            "DATA_IN",
+            "DATA_OUT",
+            "RULEPACK_FILE",
+            "FEATURE_FLAGS",
+        }
+        if (
+            k.startswith("MAXIMO")
+            or k.startswith("WAPR")
+            or k.startswith("COUPA")
+            or k in tracked
+        ):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("APP_ENV", "demo")
+    cfg = load_config()
+    assert cfg.feature_flags == {"wizard": True, "planner": True}


### PR DESCRIPTION
## Summary
- load FEATURE_FLAGS from env in backend config
- add frontend feature flag utility and gate unfinished pages
- document feature flag parsing with tests

## Testing
- `pre-commit run --files loto/config.py tests/test_config.py apps/maximo-extension-ui/src/lib/featureFlags.ts apps/maximo-extension-ui/src/app/portfolio/page.tsx apps/maximo-extension-ui/src/app/wizard/page.tsx apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx apps/maximo-extension-ui/src/app/conflicts/page.tsx apps/maximo-extension-ui/src/test/setup.ts`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm --filter maximo-extension-ui install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68a908be6db08322a48601bb23a5bd93