### PR TITLE
Add inventory normalization and reorder flag stubs

### DIFF
--- a/tests/test_inventory_tasks.py
+++ b/tests/test_inventory_tasks.py
@@ -1,0 +1,35 @@
+from loto.inventory import InventoryRecord, normalize_units, reorder_flags
+
+
+def test_normalize_units() -> None:
+    items = [
+        InventoryRecord(
+            description="M12x35 bolt 8.8",
+            unit="L",
+            qty_onhand=5,
+            reorder_point=0,
+        )
+    ]
+    mapping = {"M12x35 bolt 8.8": "ea"}
+    normalised = normalize_units(items, mapping)
+    assert normalised[0].unit == "ea"
+
+
+def test_reorder_flags() -> None:
+    items = [
+        InventoryRecord(
+            description="Nitrile gasket DN50",
+            unit="ea",
+            qty_onhand=0,
+            reorder_point=10,
+            site="PLANT-02",
+        ),
+        InventoryRecord(
+            description="Widget",
+            unit="ea",
+            qty_onhand=5,
+            reorder_point=2,
+        ),
+    ]
+    flagged = reorder_flags(items)
+    assert flagged == [items[0]]


### PR DESCRIPTION
## Summary
- add InventoryRecord model and utilities to normalize units and flag low stock
- cover new helpers with basic tests

## Testing
- `pre-commit run --files loto/inventory.py tests/test_inventory_tasks.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a90e4a62d883229d6d5d7d03b807de