### PR TITLE
Expose hazards and controls in isolation plan outputs

### DIFF
--- a/demo/controls.yaml
+++ b/demo/controls.yaml
@@ -1,0 +1,2 @@
+- Shielding
+- Ventilation

--- a/demo/hazards.yaml
+++ b/demo/hazards.yaml
@@ -1,0 +1,2 @@
+- Radiation
+- Asphyxiation

--- a/loto/isolation_planner.py
+++ b/loto/isolation_planner.py
@@ -117,6 +117,8 @@ class IsolationPlanner:
                     )
                 )
         verifications: List[str] = []
+        hazards: List[str] = []
+        controls: List[str] = []
         for domain, edges in plan.items():
             if not edges:
                 continue
@@ -130,15 +132,26 @@ class IsolationPlanner:
                 ddbb_found = False
                 for node in component:
                     has_upstream_iso = any(
-                        any(data.get("is_isolation_point") for data in graphs[domain].get_edge_data(pred, node).values())
+                        any(
+                            data.get("is_isolation_point")
+                            for data in graphs[domain]
+                            .get_edge_data(pred, node)
+                            .values()
+                        )
                         for pred in graphs[domain].predecessors(node)
                     )
                     has_downstream_iso = any(
-                        any(data.get("is_isolation_point") for data in graphs[domain].get_edge_data(node, succ).values())
+                        any(
+                            data.get("is_isolation_point")
+                            for data in graphs[domain]
+                            .get_edge_data(node, succ)
+                            .values()
+                        )
                         for succ in graphs[domain].successors(node)
                     )
                     has_bleed = any(
-                        data.get("is_bleed") for _, _, data in graphs[domain].out_edges(node, data=True)
+                        data.get("is_bleed")
+                        for _, _, data in graphs[domain].out_edges(node, data=True)
                     )
                     if has_upstream_iso and has_downstream_iso and has_bleed:
                         verifications.append(f"{branch_label} DDBB")
@@ -147,4 +160,10 @@ class IsolationPlanner:
                 if ddbb_found:
                     continue
 
-        return IsolationPlan(plan_id=asset_tag, actions=actions, verifications=verifications)
+        return IsolationPlan(
+            plan_id=asset_tag,
+            actions=actions,
+            verifications=verifications,
+            hazards=hazards,
+            controls=controls,
+        )

--- a/loto/models.py
+++ b/loto/models.py
@@ -117,6 +117,12 @@ class IsolationPlan(BaseModel):
     verifications: List[str] = Field(
         default_factory=list, description="Optional verification checks"
     )
+    hazards: List[str] = Field(
+        default_factory=list, description="Identified hazards associated with the plan"
+    )
+    controls: List[str] = Field(
+        default_factory=list, description="Controls implemented to mitigate hazards"
+    )
 
     class Config:
         extra = "forbid"

--- a/loto/renderer.py
+++ b/loto/renderer.py
@@ -177,6 +177,18 @@ class Renderer:
             story.append(stim_table)
             story.append(Spacer(1, 12))
 
+        if plan.hazards:
+            story.append(Paragraph("Hazards", styles["Heading2"]))
+            for hazard in plan.hazards:
+                story.append(Paragraph(hazard, styles["Normal"]))
+            story.append(Spacer(1, 12))
+
+        if plan.controls:
+            story.append(Paragraph("Controls", styles["Heading2"]))
+            for control in plan.controls:
+                story.append(Paragraph(control, styles["Normal"]))
+            story.append(Spacer(1, 12))
+
         if plan.verifications:
             story.append(Paragraph("Footnotes", styles["Heading2"]))
             for note in plan.verifications:

--- a/tests/test_cli_demo.py
+++ b/tests/test_cli_demo.py
@@ -1,5 +1,7 @@
+import json
 from pathlib import Path
 
+from PyPDF2 import PdfReader
 from typer.testing import CliRunner
 
 from loto.cli import cli
@@ -14,3 +16,13 @@ def test_demo_command_creates_outputs(tmp_path: Path) -> None:
     assert "PDF + JSON saved" in result.stdout
     assert (out_dir / "LOTO_A.pdf").exists()
     assert (out_dir / "LOTO_A.json").exists()
+
+    with (out_dir / "LOTO_A.json").open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    assert payload["plan"]["hazards"] == ["Radiation", "Asphyxiation"]
+    assert payload["plan"]["controls"] == ["Shielding", "Ventilation"]
+
+    reader = PdfReader(out_dir / "LOTO_A.pdf")
+    text = "".join(page.extract_text() for page in reader.pages)
+    assert "Radiation" in text
+    assert "Shielding" in text

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -64,6 +64,8 @@ MODEL_DATA = [
                 {"component_id": "valve1", "method": "lock", "duration_s": 5.0}
             ],
             "verifications": [],
+            "hazards": [],
+            "controls": [],
         },
     ),
     (Stimulus, {"name": "pulse", "magnitude": 3.0, "duration_s": 1.0}),


### PR DESCRIPTION
## Summary
- extend isolation plans with `hazards` and `controls` fields
- surface hazards and controls in rendered PDF/JSON outputs
- add demo fixtures and CLI options to load hazard/control lists

## Testing
- `pre-commit run --files loto/cli.py loto/isolation_planner.py loto/models.py loto/renderer.py tests/test_cli_demo.py tests/test_models.py demo/hazards.yaml demo/controls.yaml`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68a91262e2048322a3ee08a8d97ed655