### PR TITLE
docs: add production env template handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ storybook-static/
 playwright-report/
 **/.next/
 apps/maximo-extension-ui/test-results/
+
+# Production environment configuration
+prod.env

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,18 @@
+# Deployment
+
+The `prod.env` file contains non-secret configuration. Real credentials such as `MAXIMO_APIKEY` are stored in the team vault.
+
+To populate `prod.env` with secrets:
+
+1. Authenticate to the vault (`op signin` for 1Password or `vault login` for HashiCorp Vault).
+2. Read the required values and append them to `prod.env`:
+
+   ```bash
+   # 1Password example
+   op read "op://LOTO Planner/Production/MAXIMO_APIKEY" >> prod.env
+
+   # HashiCorp Vault example
+   vault kv get -field=MAXIMO_APIKEY secret/loto/prod >> prod.env
+   ```
+
+`prod.env` is ignored by git and should never be committed.


### PR DESCRIPTION
## Summary
- document how to retrieve production credentials from the vault
- ignore `prod.env`

## Testing
- `pre-commit run --files .gitignore docs/DEPLOYMENT.md`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a9158eed708322b350af028c7faced