### PR TITLE
restrict egress to Maximo and Coupa

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
     ports:
       - "8000:8000"
     env_file: .env.example
+    user: root
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - ./scripts/restrict-egress.sh:/app/scripts/restrict-egress.sh:ro
+    entrypoint: ["/bin/sh", "/app/scripts/restrict-egress.sh"]
     profiles: ["demo"]
   ui:
     build:

--- a/docs/network.md
+++ b/docs/network.md
@@ -1,0 +1,15 @@
+# Network Requirements
+
+Outbound network access from the LOTO services must be limited to the Maximo and Coupa SaaS endpoints.
+
+## Maximo
+- Hostname: maximo.example.com
+- IP address: 203.0.113.10
+- Port: 443 (HTTPS)
+
+## Coupa
+- Hostname: api.coupahost.com
+- IP address: 198.51.100.20
+- Port: 443 (HTTPS)
+
+All other outbound traffic should be blocked. See `docker-compose.yml` for container-level egress restrictions implemented via iptables.

--- a/scripts/restrict-egress.sh
+++ b/scripts/restrict-egress.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# Restrict outbound traffic to Maximo and Coupa endpoints only
+iptables -P OUTPUT DROP
+iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+# Allow DNS queries
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+# Allow HTTPS to Maximo and Coupa
+iptables -A OUTPUT -p tcp -d 203.0.113.10 --dport 443 -j ACCEPT # Maximo
+iptables -A OUTPUT -p tcp -d 198.51.100.20 --dport 443 -j ACCEPT # Coupa
+
+exec ./apps/api/entrypoint.sh


### PR DESCRIPTION
## Summary
- document Maximo and Coupa network requirements
- restrict api container egress to Maximo and Coupa endpoints

## Testing
- `pre-commit run --files docs/network.md docker-compose.yml scripts/restrict-egress.sh`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `curl -I https://www.ibm.com`
- `curl -I https://www.coupa.com`


------
https://chatgpt.com/codex/tasks/task_b_68a916960d2c8322bca5c082d85a431d