### PR TITLE
Add OIDC role-based auth

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -8,3 +8,4 @@ prometheus_client
 opentelemetry-sdk
 opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-requests
+fastapi-oidc

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -16,3 +16,15 @@ To populate `prod.env` with secrets:
    ```
 
 `prod.env` is ignored by git and should never be committed.
+
+## OIDC Configuration
+
+The API uses OpenID Connect for authentication. Register a client with your identity
+provider and add the credentials to `prod.env`:
+
+```bash
+OIDC_CLIENT_ID=your-client-id
+OIDC_CLIENT_SECRET=your-client-secret
+```
+
+These values are read by `apps/api/main.py` during startup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "httpx",
     "fastapi",
     "types-PyYAML",
+    "fastapi-oidc",
 ]
 
 [tool.black]

--- a/tests/api/test_roles.py
+++ b/tests/api/test_roles.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+from fastapi_oidc.types import IDToken
+
+import apps.api.main as main
+
+
+class Token(IDToken):
+    roles: list[str] = []
+
+
+def _override(roles: list[str]):
+    def _inner() -> Token:
+        return Token(iss="iss", sub="sub", aud="aud", exp=0, iat=0, roles=roles)
+
+    return _inner
+
+
+def test_role_dependencies():
+    client = TestClient(main.app)
+    cases = [
+        ("/roles/worker", "worker"),
+        ("/roles/supervisor", "supervisor"),
+        ("/roles/hsrep", "HS rep"),
+        ("/roles/admin", "admin"),
+    ]
+    for path, role in cases:
+        main.app.dependency_overrides[main.authenticate_user] = _override([role])
+        assert client.get(path).status_code == 200
+        main.app.dependency_overrides[main.authenticate_user] = _override([])
+        assert client.get(path).status_code == 403
+    main.app.dependency_overrides = {}


### PR DESCRIPTION
## Summary
- integrate fastapi-oidc client and role-based dependencies
- document OIDC client configuration
- test role restrictions for worker, supervisor, HS rep, admin

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `pre-commit run --files apps/api/main.py apps/api/requirements.txt docs/DEPLOYMENT.md pyproject.toml tests/api/test_roles.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a917af46288322ae0202c3cb676ff6