### PR TITLE
feat: add Sentry error reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ DATA_IN=data/in
 DATA_OUT=data/out
 RULEPACK_FILE=config/hswa_rules_v1.1.yaml
 
+# Sentry error reporting (optional)
+SENTRY_DSN=
+
 # Maximo integration
 MAXIMO_MODE=MOCK
 MAXIMO_BASE_URL=https://example.com

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 import jwt
 import structlog
+import sentry_sdk
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -292,6 +293,7 @@ async def _handle_loto_error(request: Request, exc: LotoError) -> None:
 async def _handle_exception(request: Request, exc: Exception) -> JSONResponse:
     """Catch-all handler to wrap unexpected exceptions."""
     logging.exception("Unhandled exception: %s", exc)
+    sentry_sdk.capture_exception(exc)
     return JSONResponse(status_code=500, content={"error": str(exc)})
 
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -41,3 +41,13 @@ OIDC_CLIENT_SECRET=your-client-secret
 ```
 
 These values are read by `apps/api/main.py` during startup.
+
+## Sentry configuration
+
+Set `SENTRY_DSN` in `.env` and `prod.env` to enable error reporting to Sentry:
+
+```bash
+SENTRY_DSN=https://public@example.ingest.sentry.io/0
+```
+
+Omit the variable to disable Sentry in a given environment.

--- a/loto/loggers.py
+++ b/loto/loggers.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import contextvars
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Any
+
+import sentry_sdk
 
 request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
     "request_id", default=""
@@ -46,3 +49,7 @@ def configure_logging() -> None:
     root.handlers.clear()
     root.addHandler(handler)
     root.setLevel(logging.INFO)
+
+    dsn = os.getenv("SENTRY_DSN")
+    if dsn:
+        sentry_sdk.init(dsn=dsn)

--- a/prod.env
+++ b/prod.env
@@ -1,3 +1,4 @@
 # Production environment configuration for LOTO Planner
 # Comma-separated list of origins allowed to access the API
 CORS_ORIGINS=https://loto.example.com
+SENTRY_DSN=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "PyPDF2",
     "weasyprint",
     "tqdm",
+    "sentry-sdk",
 ]
 
 [project.optional-dependencies]

--- a/requirements.in
+++ b/requirements.in
@@ -15,6 +15,7 @@ PyPDF2
 weasyprint
 tqdm
 prometheus-client
+sentry-sdk
 
 # Development dependencies
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ certifi==2025.8.3
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
 cffi==1.17.1
     # via weasyprint
 cfgv==3.4.0
@@ -196,6 +197,8 @@ rich==14.1.0
     # via typer
 ruff==0.12.10
     # via -r requirements.in
+sentry-sdk==2.35.0
+    # via -r requirements.in
 shellingham==1.5.4
     # via typer
 six==1.17.0
@@ -241,6 +244,7 @@ urllib3==2.5.0
     # via
     #   requests
     #   responses
+    #   sentry-sdk
 virtualenv==20.34.0
     # via pre-commit
 weasyprint==66.0


### PR DESCRIPTION
## Summary
- initialize Sentry via `SENTRY_DSN` in logging setup
- capture FastAPI exceptions to Sentry
- document `SENTRY_DSN` and add dependency

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a91bd0c560832299c9faac5fb0090e