### PR TITLE
Add exponential backoff to Maximo and Coupa adapters

### DIFF
--- a/loto/integrations/__init__.py
+++ b/loto/integrations/__init__.py
@@ -16,7 +16,7 @@ import abc
 import os
 from typing import TYPE_CHECKING, Any, Dict, List
 
-from .coupa_adapter import CoupaAdapter, DemoCoupaAdapter
+from .coupa_adapter import CoupaAdapter, DemoCoupaAdapter, HttpCoupaAdapter
 from .maximo_adapter import MaximoAdapter
 from .stores_adapter import DemoStoresAdapter, StoresAdapter
 from .wapr_adapter import DemoWaprAdapter, WaprAdapter
@@ -85,6 +85,7 @@ __all__ = [
     "get_integration_adapter",
     "CoupaAdapter",
     "DemoCoupaAdapter",
+    "HttpCoupaAdapter",
     "StoresAdapter",
     "DemoStoresAdapter",
     "WaprAdapter",

--- a/loto/integrations/_errors.py
+++ b/loto/integrations/_errors.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AdapterRequestError(Exception):
+    """Structured HTTP error returned by adapters.
+
+    Attributes
+    ----------
+    status_code:
+        HTTP status code returned by the upstream service.
+    retry_after:
+        Number of seconds the client should wait before retrying, if
+        provided by the service.
+    """
+
+    status_code: int
+    retry_after: float | None
+
+    def __str__(self) -> str:
+        return f"HTTP error {self.status_code}"

--- a/tests/integrations/test_adapter_backoff.py
+++ b/tests/integrations/test_adapter_backoff.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+import pytest
+
+from loto.integrations._errors import AdapterRequestError
+from loto.integrations.coupa_adapter import HttpCoupaAdapter
+from loto.integrations.maximo_adapter import MaximoAdapter
+
+
+class DummyResponse:
+    def __init__(
+        self,
+        status_code: int,
+        data: Dict[str, Any] | None = None,
+        headers: Dict[str, str] | None = None,
+    ):
+        self.status_code = status_code
+        self._data = data or {}
+        self.headers = headers or {}
+
+    def json(self) -> Dict[str, Any]:
+        return self._data
+
+
+def _set_maximo_env(monkeypatch) -> None:
+    monkeypatch.setenv("MAXIMO_BASE_URL", "http://maximo.local")
+    monkeypatch.setenv("MAXIMO_APIKEY", "secret")
+    monkeypatch.setenv("MAXIMO_OS_WORKORDER", "WORKORDER")
+    monkeypatch.setenv("MAXIMO_OS_ASSET", "ASSET")
+
+
+def _set_coupa_env(monkeypatch) -> None:
+    monkeypatch.setenv("COUPA_BASE_URL", "http://coupa.local")
+    monkeypatch.setenv("COUPA_APIKEY", "secret")
+
+
+def test_maximo_retry_on_429(monkeypatch) -> None:
+    _set_maximo_env(monkeypatch)
+    adapter = MaximoAdapter()
+    calls = {"count": 0}
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return DummyResponse(429, headers={"Retry-After": "1"})
+        return DummyResponse(200, data={"ok": True})
+
+    monkeypatch.setattr(adapter._session, "get", fake_get)
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+    data = adapter._get("/foo")
+    assert data == {"ok": True}
+    assert sleeps == [1.0]
+
+
+def test_maximo_structured_error_on_500(monkeypatch) -> None:
+    _set_maximo_env(monkeypatch)
+    adapter = MaximoAdapter()
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        return DummyResponse(500)
+
+    monkeypatch.setattr(adapter._session, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    with pytest.raises(AdapterRequestError) as excinfo:
+        adapter._get("/foo")
+    err = excinfo.value
+    assert err.status_code == 500
+    assert err.retry_after is None
+
+
+def test_coupa_retry_on_429(monkeypatch) -> None:
+    _set_coupa_env(monkeypatch)
+    adapter = HttpCoupaAdapter()
+    calls = {"count": 0}
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return DummyResponse(429, headers={"Retry-After": "2"})
+        return DummyResponse(200, data={"ok": True})
+
+    monkeypatch.setattr(adapter._session, "get", fake_get)
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+    data = adapter._get("/foo")
+    assert data == {"ok": True}
+    assert sleeps == [2.0]
+
+
+def test_coupa_structured_error_on_500(monkeypatch) -> None:
+    _set_coupa_env(monkeypatch)
+    adapter = HttpCoupaAdapter()
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        return DummyResponse(500)
+
+    monkeypatch.setattr(adapter._session, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    with pytest.raises(AdapterRequestError) as excinfo:
+        adapter._get("/foo")
+    err = excinfo.value
+    assert err.status_code == 500
+    assert err.retry_after is None

--- a/tests/integrations/test_maximo_adapter.py
+++ b/tests/integrations/test_maximo_adapter.py
@@ -6,11 +6,10 @@ from loto.integrations.maximo_adapter import MaximoAdapter
 
 
 class DummyResponse:
-    def __init__(self, data: Dict[str, Any]):
+    def __init__(self, data: Dict[str, Any], status_code: int = 200):
         self._data = data
-
-    def raise_for_status(self) -> None:  # pragma: no cover - does nothing
-        return None
+        self.status_code = status_code
+        self.headers: Dict[str, str] = {}
 
     def json(self) -> Dict[str, Any]:
         return self._data


### PR DESCRIPTION
## Summary
- handle 429 and server errors with exponential backoff in Maximo and Coupa HTTP adapters
- surface structured AdapterRequestError with status code and Retry-After value
- add tests covering 429 and 500 responses for both adapters

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files loto/integrations/__init__.py loto/integrations/coupa_adapter.py loto/integrations/maximo_adapter.py loto/integrations/_errors.py tests/integrations/test_adapter_backoff.py tests/integrations/test_maximo_adapter.py`


------
https://chatgpt.com/codex/tasks/task_b_68a91d6da0a8832297172f78f52271da