### PR TITLE
Add inventory unit normalization from config

### DIFF
--- a/config/inventory_units.yaml
+++ b/config/inventory_units.yaml
@@ -1,0 +1,8 @@
+ea: ea
+each: ea
+m: m
+metre: m
+kg: kg
+kilogram: kg
+l: L
+litre: L


### PR DESCRIPTION
## Summary
- add `config/inventory_units.yaml` for canonical unit mappings
- normalize units during inventory ingestion using this mapping
- test inventory ingestion unit normalization

## Testing
- `pre-commit run --files config/inventory_units.yaml loto/inventory.py tests/test_inventory.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a91f7185f883229b1fb386e38ecc2b