### PR TITLE
Validate Maximo asset/location IDs before planning

### DIFF
--- a/loto/service/scheduling.py
+++ b/loto/service/scheduling.py
@@ -8,13 +8,18 @@ from ..models import IsolationPlan
 from ..scheduling import assemble, des_engine, monte_carlo
 from ..scheduling.des_engine import RunResult, Task
 from ..scheduling.monte_carlo import MonteCarloResult
+from .blueprints import validate_fk_integrity
 
 
 def assemble_tasks(
-    work_order: object, plan: IsolationPlan, check_parts: assemble.InventoryFn | None = None
+    work_order: object,
+    plan: IsolationPlan,
+    check_parts: assemble.InventoryFn | None = None,
 ) -> dict[str, Task]:
     """Return tasks assembled from a work order and plan."""
-
+    validate_fk_integrity(
+        getattr(work_order, "asset_id", None), getattr(work_order, "location", None)
+    )
     return assemble.from_work_order(work_order, plan, check_parts)
 
 

--- a/tests/service/test_fk_integrity.py
+++ b/tests/service/test_fk_integrity.py
@@ -1,0 +1,42 @@
+from typing import cast
+
+import pytest
+
+from loto.integrations._errors import AdapterRequestError
+from loto.integrations.maximo_adapter import MaximoAdapter
+from loto.service.blueprints import validate_fk_integrity
+
+
+class DummyAdapter:
+    def __init__(self, *, assets=None, locations=None):
+        self.assets = assets or set()
+        self.locations = locations or set()
+        self.base_url = "http://maximo"
+
+    def get_asset(self, asset_id: str):
+        if asset_id not in self.assets:
+            raise AdapterRequestError(status_code=404, retry_after=None)
+        return {"id": asset_id}
+
+    def _get(self, path: str, params=None):  # pragma: no cover - params unused
+        location_id = path.split("/")[-1]
+        if location_id not in self.locations:
+            raise AdapterRequestError(status_code=404, retry_after=None)
+        return {"id": location_id}
+
+
+def test_valid_ids() -> None:
+    adapter = cast(MaximoAdapter, DummyAdapter(assets={"A1"}, locations={"L1"}))
+    validate_fk_integrity("A1", "L1", adapter=adapter)
+
+
+def test_invalid_asset() -> None:
+    adapter = cast(MaximoAdapter, DummyAdapter(locations={"L1"}))
+    with pytest.raises(ValueError, match="Unknown asset 'A1'"):
+        validate_fk_integrity("A1", "L1", adapter=adapter)
+
+
+def test_invalid_location() -> None:
+    adapter = cast(MaximoAdapter, DummyAdapter(assets={"A1"}))
+    with pytest.raises(ValueError, match="Unknown location 'L1'"):
+        validate_fk_integrity("A1", "L1", adapter=adapter)

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -49,7 +49,10 @@ def test_adequate_stock_marks_work_order_ready():
     assert not status.missing
 
 
-def test_blueprint_inventory_gating():
+def test_blueprint_inventory_gating(monkeypatch):
+    monkeypatch.setattr(
+        "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
+    )
     client = TestClient(app)
     original = DemoStoresAdapter._INVENTORY["P-200"]["available"]
     try:

--- a/tests/test_service_blueprints.py
+++ b/tests/test_service_blueprints.py
@@ -6,7 +6,10 @@ from loto.models import RulePack
 from loto.service.blueprints import plan_and_evaluate
 
 
-def test_plan_and_evaluate_deterministic():
+def test_plan_and_evaluate_deterministic(monkeypatch):
+    monkeypatch.setattr(
+        "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
+    )
     line_df = pd.DataFrame(
         [
             {"domain": "steam", "from_tag": "S", "to_tag": "V"},


### PR DESCRIPTION
## Summary
- add `validate_fk_integrity` to confirm Maximo asset and location IDs exist
- invoke foreign key validation before planning and scheduling
- cover valid/invalid asset and location combinations with unit tests

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files loto/service/blueprints.py loto/service/scheduling.py tests/service/test_fk_integrity.py tests/test_inventory.py tests/test_service_blueprints.py`


------
https://chatgpt.com/codex/tasks/task_b_68a920f154b0832282928377f56d15cb