### PR TITLE
Add dual-user verification gate and approval API

### DIFF
--- a/loto/isolation_planner.py
+++ b/loto/isolation_planner.py
@@ -13,12 +13,32 @@ these signatures as a starting point for a full implementation.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Dict, List, Set, Tuple
 
 import networkx as nx  # type: ignore
 
 from .models import IsolationAction, IsolationPlan
 from .rule_engine import RulePack
+
+
+@dataclass
+class VerificationGate:
+    """Require approvals from two distinct users before energization."""
+
+    approved_by: Set[str] = field(default_factory=set)
+
+    def approve(self, user: str) -> bool:
+        """Record approval by ``user`` and return readiness state."""
+
+        self.approved_by.add(user)
+        return self.is_ready
+
+    @property
+    def is_ready(self) -> bool:
+        """Whether energization can proceed."""
+
+        return len(self.approved_by) >= 2
 
 
 class IsolationPlanner:

--- a/tests/planner/test_verifications.py
+++ b/tests/planner/test_verifications.py
@@ -1,6 +1,6 @@
 import networkx as nx
 
-from loto.isolation_planner import IsolationPlanner
+from loto.isolation_planner import IsolationPlanner, VerificationGate
 from loto.rule_engine import RulePack
 
 
@@ -28,7 +28,9 @@ def ddbb_graph():
 
 def test_basic_verifications():
     planner = IsolationPlanner()
-    plan = planner.compute({"p": simple_graph()}, asset_tag="asset", rule_pack=RulePack())
+    plan = planner.compute(
+        {"p": simple_graph()}, asset_tag="asset", rule_pack=RulePack()
+    )
     assert len(plan.verifications) == 2
     assert any("PT=0" in v for v in plan.verifications)
     assert any("no-movement" in v for v in plan.verifications)
@@ -41,3 +43,18 @@ def test_ddbb_hint():
     assert any("PT=0" in v for v in plan.verifications)
     assert any("no-movement" in v for v in plan.verifications)
     assert any("DDBB" in v for v in plan.verifications)
+
+
+def test_gate_single_user_insufficient():
+    gate = VerificationGate()
+    gate.approve("user1")
+    assert not gate.is_ready
+
+
+def test_gate_two_distinct_users_required():
+    gate = VerificationGate()
+    gate.approve("user1")
+    gate.approve("user1")
+    assert not gate.is_ready
+    gate.approve("user2")
+    assert gate.is_ready


### PR DESCRIPTION
## Summary
- add `VerificationGate` requiring approvals from two distinct users before energization
- store approvals via new `/plans/{plan_id}/approve` API endpoint backed by SQLite
- cover single and dual approval flows in planner tests

## Testing
- `pre-commit run --files apps/api/main.py loto/isolation_planner.py tests/planner/test_verifications.py`
- `make lint`
- `make typecheck`
- `make test` *(fails: ValueError Invalid rule pack)*
- `pytest tests/planner/test_verifications.py -vv`


------
https://chatgpt.com/codex/tasks/task_b_68a92486d8c883228e2e13bcb2cd4a06