### PR TITLE
Support rule pack review metadata

### DIFF
--- a/loto/models.py
+++ b/loto/models.py
@@ -7,6 +7,7 @@ basic metadata/units for numeric values.
 
 from __future__ import annotations
 
+import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -199,6 +200,18 @@ class ArtifactBundle(BaseModel):
         extra = "forbid"
 
 
+class RulePackReview(BaseModel):
+    """Record of a governance review for a rule pack."""
+
+    version: str = Field(..., description="Reviewed rule pack version")
+    date: datetime.date = Field(..., description="Date of the review")
+    reviewer: str = Field(..., description="Person who performed the review")
+    outcome: str = Field(..., description="Outcome of the review")
+
+    class Config:
+        extra = "forbid"
+
+
 class RulePack(BaseModel):
     """Collection of domain and verification rules with optional risk policies."""
 
@@ -222,6 +235,9 @@ class RulePack(BaseModel):
     )
     risk_policies: Optional[RiskPolicies] = Field(
         None, description="Associated risk policies"
+    )
+    review: Optional[List[RulePackReview]] = Field(
+        default=None, description="Review history for the rule pack"
     )
 
     class Config:

--- a/loto/rule_engine.py
+++ b/loto/rule_engine.py
@@ -113,5 +113,5 @@ class RuleEngine:
         """
 
         data = rule_pack.model_dump(exclude_none=True)
-        canonical = json.dumps(data, sort_keys=True, separators=(",", ":"))
+        canonical = json.dumps(data, sort_keys=True, separators=(",", ":"), default=str)
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()


### PR DESCRIPTION
## Summary
- add RulePackReview model and optional `review` history
- hash rule packs with stringified dates to allow serialization

## Testing
- `pre-commit run --files loto/models.py loto/rule_engine.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a92652331c8322950ac02515f62595