### PR TITLE
docs: add on-call guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ To run the CLI demo instead:
 make run-demo
 ```
 
+## On-Call Support
+
+See [On-Call Guide](docs/on_call.md) for contact rotations, escalation paths, and rollback steps.
+
 ## Screenshots
 
 Due to repository constraints, screenshots are not stored in git. Run the demo and capture your own screenshots of the API and UI, or view placeholder images below.

--- a/docs/PILOT_RUNBOOK.md
+++ b/docs/PILOT_RUNBOOK.md
@@ -26,6 +26,7 @@ All deadlines are recorded in New Zealand time; for example
 ## Support
 
 Contact the platform team via `#pilot-support` for assistance.
+Refer to [On-Call Guide](on_call.md) for contact rotations, escalation paths, and rollback procedures.
 
 ## References
 

--- a/docs/on_call.md
+++ b/docs/on_call.md
@@ -1,0 +1,25 @@
+# On-Call Guide
+
+This document outlines how to reach the team during incidents, how to escalate issues, and how to roll back deployments safely.
+
+## Contact Rotations
+
+- Weekdays: primary engineer rotates weekly; see the internal calendar for current assignments.
+- Weekends/holidays: duty manager is on call; rotate monthly.
+- Contact channels: `#on-call` Slack for non-urgent issues; phone escalation for urgent outages.
+
+## Escalation Paths
+
+1. Notify the primary on-call engineer via Slack or phone.
+2. If no response within 15 minutes, escalate to the duty manager.
+3. For critical outages lasting over 30 minutes, page the platform lead and post an update in `#status`.
+
+## Deployment Rollback Steps
+
+1. Identify the last known good deployment tag.
+2. Use the deployment tooling to redeploy the previous version:
+   ```bash
+   make deploy TAG=<previous-tag>
+   ```
+3. Verify service health and confirm resolution in the incident channel.
+4. Open a post-mortem ticket to track follow-up actions.


### PR DESCRIPTION
## Summary
- document on-call rotations, escalation paths, and rollback steps
- link the new on-call guide from README and pilot runbook

## Testing
- `pre-commit run --files README.md docs/PILOT_RUNBOOK.md docs/on_call.md`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68a92b1135a48322b1b4f23def1272ff