### PR TITLE
feat: add demo data source

### DIFF
--- a/apps/api/demo_data.py
+++ b/apps/api/demo_data.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+DATA_DIR = Path(__file__).with_name("demo_data")
+
+
+class DemoDataSource:
+    """Load demo data from JSON files on startup."""
+
+    def __init__(self) -> None:
+        self.work_orders: List[Dict[str, Any]] = self._load_list("workorders.json")
+        self.assets: List[Dict[str, Any]] = self._load_list("assets.json")
+        self.locations: List[Dict[str, Any]] = self._load_list("locations.json")
+        self.inventory: List[Dict[str, Any]] = self._load_list("inventory.json")
+        self.blueprints: Dict[str, Dict[str, Any]] = self._load_dict("blueprints.json")
+        self._work_orders_by_id = {wo["id"]: wo for wo in self.work_orders}
+
+    def _load_list(self, filename: str) -> List[Dict[str, Any]]:
+        path = DATA_DIR / filename
+        if path.exists():
+            return json.loads(path.read_text())
+        return []
+
+    def _load_dict(self, filename: str) -> Dict[str, Dict[str, Any]]:
+        path = DATA_DIR / filename
+        if path.exists():
+            return json.loads(path.read_text())
+        return {}
+
+    def list_work_orders(self) -> List[Dict[str, Any]]:
+        return list(self._work_orders_by_id.values())
+
+    def get_work_order(self, work_order_id: str) -> Dict[str, Any]:
+        return self._work_orders_by_id[work_order_id]
+
+    def get_blueprint(self, work_order_id: str) -> Dict[str, Any] | None:
+        return self.blueprints.get(work_order_id)
+
+
+demo_data = DemoDataSource()

--- a/apps/api/demo_data/assets.json
+++ b/apps/api/demo_data/assets.json
@@ -1,0 +1,4 @@
+[
+  {"id": "A-1", "description": "Pump A", "location": "L-1"},
+  {"id": "A-2", "description": "Motor B", "location": "L-2"}
+]

--- a/apps/api/demo_data/blueprints.json
+++ b/apps/api/demo_data/blueprints.json
@@ -1,0 +1,16 @@
+{
+  "WO-1": {
+    "steps": [{"component_id": "VALVE-1", "method": "lock"}],
+    "unavailable_assets": [],
+    "unit_mw_delta": {},
+    "blocked_by_parts": false,
+    "parts_status": {"P-100": "ok"}
+  },
+  "WO-2": {
+    "steps": [{"component_id": "VALVE-2", "method": "tag"}],
+    "unavailable_assets": [],
+    "unit_mw_delta": {},
+    "blocked_by_parts": false,
+    "parts_status": {"P-200": "low"}
+  }
+}

--- a/apps/api/demo_data/inventory.json
+++ b/apps/api/demo_data/inventory.json
@@ -1,0 +1,4 @@
+[
+  {"id": "P-100", "available": 5},
+  {"id": "P-200", "available": 1}
+]

--- a/apps/api/demo_data/locations.json
+++ b/apps/api/demo_data/locations.json
@@ -1,0 +1,4 @@
+[
+  {"id": "L-1", "description": "Building 1"},
+  {"id": "L-2", "description": "Building 2"}
+]

--- a/apps/api/demo_data/workorders.json
+++ b/apps/api/demo_data/workorders.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "WO-1",
+    "description": "Pump replacement",
+    "status": "Active",
+    "owner": "Jane",
+    "plannedStart": "2024-05-01",
+    "plannedFinish": "2024-05-03"
+  },
+  {
+    "id": "WO-2",
+    "description": "Motor upgrade",
+    "status": "Draft",
+    "owner": "John",
+    "plannedStart": "2024-05-10",
+    "plannedFinish": "2024-05-12"
+  },
+  {
+    "id": "WO-3",
+    "description": "Energy audit",
+    "status": "Completed",
+    "owner": "Ben",
+    "plannedStart": "2024-04-20",
+    "plannedFinish": "2024-04-21"
+  }
+]


### PR DESCRIPTION
## Summary
- load demo JSON data for work orders, assets, locations, inventory, and blueprints on API startup
- expose demo-backed /portfolio and /workorders endpoints with expanded work order fields
- serve precomputed blueprints while retaining inventory gating

## Testing
- `pre-commit run --files apps/api/main.py apps/api/workorder_endpoints.py apps/api/demo_data.py apps/api/demo_data/workorders.json apps/api/demo_data/assets.json apps/api/demo_data/locations.json apps/api/demo_data/inventory.json apps/api/demo_data/blueprints.json`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68a98792fad88322bbc9aff30fcb43fa