### PR TITLE
feat: add work order integrity validation

### DIFF
--- a/apps/api/demo_data.py
+++ b/apps/api/demo_data.py
@@ -17,6 +17,8 @@ class DemoDataSource:
         self.inventory: List[Dict[str, Any]] = self._load_list("inventory.json")
         self.blueprints: Dict[str, Dict[str, Any]] = self._load_dict("blueprints.json")
         self._work_orders_by_id = {wo["id"]: wo for wo in self.work_orders}
+        self.asset_ids = {asset["id"] for asset in self.assets}
+        self.location_ids = {loc["id"] for loc in self.locations}
 
     def _load_list(self, filename: str) -> List[Dict[str, Any]]:
         path = DATA_DIR / filename
@@ -38,6 +40,29 @@ class DemoDataSource:
 
     def get_blueprint(self, work_order_id: str) -> Dict[str, Any] | None:
         return self.blueprints.get(work_order_id)
+
+    def validate(self) -> Dict[str, List[Dict[str, str | None]]]:
+        """Check referential integrity of work orders.
+
+        Returns a mapping with lists of missing assets and locations.
+        """
+        missing_assets: List[Dict[str, str | None]] = []
+        missing_locations: List[Dict[str, str | None]] = []
+        for wo in self.work_orders:
+            asset = wo.get("assetnum")
+            if not asset or asset not in self.asset_ids:
+                missing_assets.append(
+                    {"workorder": wo.get("id", ""), "assetnum": asset}
+                )
+            location = wo.get("location")
+            if not location or location not in self.location_ids:
+                missing_locations.append(
+                    {"workorder": wo.get("id", ""), "location": location}
+                )
+        return {
+            "missing_assets": missing_assets,
+            "missing_locations": missing_locations,
+        }
 
 
 demo_data = DemoDataSource()

--- a/apps/api/demo_data/workorders.json
+++ b/apps/api/demo_data/workorders.json
@@ -5,7 +5,9 @@
     "status": "Active",
     "owner": "Jane",
     "plannedStart": "2024-05-01",
-    "plannedFinish": "2024-05-03"
+    "plannedFinish": "2024-05-03",
+    "assetnum": "A-1",
+    "location": "L-1"
   },
   {
     "id": "WO-2",
@@ -13,7 +15,9 @@
     "status": "Draft",
     "owner": "John",
     "plannedStart": "2024-05-10",
-    "plannedFinish": "2024-05-12"
+    "plannedFinish": "2024-05-12",
+    "assetnum": "A-2",
+    "location": "L-2"
   },
   {
     "id": "WO-3",
@@ -21,6 +25,8 @@
     "status": "Completed",
     "owner": "Ben",
     "plannedStart": "2024-04-20",
-    "plannedFinish": "2024-04-21"
+    "plannedFinish": "2024-04-21",
+    "assetnum": "A-1",
+    "location": "L-1"
   }
 ]

--- a/apps/api/workorder_endpoints.py
+++ b/apps/api/workorder_endpoints.py
@@ -19,6 +19,8 @@ class WorkOrderSummary(BaseModel):
     planned_finish: str | None = Field(
         None, alias="plannedFinish", description="Planned finish date"
     )
+    assetnum: str | None = Field(None, description="Associated asset identifier")
+    location: str | None = Field(None, description="Associated location identifier")
 
     class Config:
         extra = "forbid"
@@ -59,6 +61,12 @@ async def get_workorder(workorder_id: str) -> WorkOrderSummary:
         data = demo_data.get_work_order(workorder_id)
     except KeyError as exc:  # pragma: no cover - simple error path
         raise HTTPException(status_code=404, detail="work order not found") from exc
+    asset = data.get("assetnum")
+    if not asset or asset not in demo_data.asset_ids:
+        raise HTTPException(status_code=400, detail=f"unknown asset: {asset}")
+    loc = data.get("location")
+    if not loc or loc not in demo_data.location_ids:
+        raise HTTPException(status_code=400, detail=f"unknown location: {loc}")
     return WorkOrderSummary(**data)
 
 

--- a/tests/api/test_admin_validate.py
+++ b/tests/api/test_admin_validate.py
@@ -1,0 +1,43 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def test_admin_validate_reports_missing_refs():
+    import apps.api.main as main
+
+    importlib.reload(main)
+
+    client = TestClient(main.app)
+
+    res = client.post("/admin/validate")
+    assert res.status_code == 200
+    assert res.json() == {"missing_assets": [], "missing_locations": []}
+
+    bad_asset = {
+        "id": "WO-X",
+        "description": "",
+        "status": "",
+        "assetnum": "BAD",
+        "location": "L-1",
+    }
+    bad_location = {
+        "id": "WO-Y",
+        "description": "",
+        "status": "",
+        "assetnum": "A-1",
+        "location": "BADLOC",
+    }
+    main.demo_data.work_orders.extend([bad_asset, bad_location])
+    main.demo_data._work_orders_by_id[bad_asset["id"]] = bad_asset
+    main.demo_data._work_orders_by_id[bad_location["id"]] = bad_location
+
+    res = client.post("/admin/validate")
+    assert res.status_code == 400
+    data = res.json()
+    assert data["missing_assets"] == [{"workorder": "WO-X", "assetnum": "BAD"}]
+    assert data["missing_locations"] == [{"workorder": "WO-Y", "location": "BADLOC"}]
+    import apps.api.demo_data as demo_module
+
+    importlib.reload(demo_module)
+    importlib.reload(main)

--- a/tests/api/test_healthz.py
+++ b/tests/api/test_healthz.py
@@ -19,6 +19,8 @@ def test_healthz_reports_rate_limit(monkeypatch):
     for path in main.RATE_LIMIT_PATHS:
         assert path in data["rate_limit"]["counters"]
     assert res.headers["X-Env"] == main.ENV_BADGE
+    assert data["integrity"]["missing_assets"] == 0
+    assert data["integrity"]["missing_locations"] == 0
 
     monkeypatch.setenv("RATE_LIMIT_CAPACITY", "10")
     monkeypatch.setenv("RATE_LIMIT_INTERVAL", "60")


### PR DESCRIPTION
## Summary
- validate work order asset and location references
- surface integrity counts in `/healthz`
- add `/admin/validate` endpoint for structured integrity reports

## Testing
- `pre-commit run --files apps/api/demo_data.py apps/api/demo_data/workorders.json apps/api/main.py apps/api/workorder_endpoints.py tests/api/test_healthz.py tests/api/test_admin_validate.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a98b34fd9883229e6ccfb45d26bb07