### PR TITLE
test: add golden snapshots for blueprint and schedule

### DIFF
--- a/tests/api/test_blueprint_golden.golden.json
+++ b/tests/api/test_blueprint_golden.golden.json
@@ -1,0 +1,15 @@
+{
+  "blocked_by_parts": false,
+  "parts_status": {
+    "P-100": "ok",
+    "P-200": "ok"
+  },
+  "steps": [
+    {
+      "component_id": "VALVE-1",
+      "method": "lock"
+    }
+  ],
+  "unavailable_assets": [],
+  "unit_mw_delta": {}
+}

--- a/tests/api/test_blueprint_golden.py
+++ b/tests/api/test_blueprint_golden.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from apps.api.schemas import BlueprintResponse
+
+
+@pytest.fixture
+def golden(request):
+    path = Path(request.node.fspath).with_suffix(".golden.json")
+    expected = json.loads(path.read_text())
+
+    def check(data: object) -> None:
+        assert data == expected
+
+    return check
+
+
+def test_blueprint_golden(golden):
+    client = TestClient(app)
+    payload = {"workorder_id": "WO-1"}
+    res1 = client.post("/blueprint", json=payload)
+    assert res1.status_code == 200
+    data1 = BlueprintResponse.model_validate(res1.json()).model_dump()
+    golden(data1)
+
+    res2 = client.post("/blueprint", json=payload)
+    assert res2.status_code == 200
+    data2 = BlueprintResponse.model_validate(res2.json()).model_dump()
+    assert data2 == data1

--- a/tests/api/test_schedule_golden.golden.json
+++ b/tests/api/test_schedule_golden.golden.json
@@ -1,0 +1,26 @@
+{
+  "blocked_by_parts": false,
+  "objective": 0.0,
+  "rulepack_id": "hswa",
+  "rulepack_sha256": "71fca39f45228dd22946c44559aef9b40b68e29e4c2b307c6593731d72ae0938",
+  "rulepack_version": "1.1",
+  "schedule": [
+    {
+      "date": "2024-01-01",
+      "hats": 1,
+      "p10": 1.0,
+      "p50": 1.0,
+      "p90": 1.0,
+      "price": 0.0
+    },
+    {
+      "date": "2024-01-02",
+      "hats": 2,
+      "p10": 3.0,
+      "p50": 3.0,
+      "p90": 3.0,
+      "price": 0.0
+    }
+  ],
+  "seed": "0"
+}

--- a/tests/api/test_schedule_golden.py
+++ b/tests/api/test_schedule_golden.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import apps.api.main as main
+from apps.api.schemas import ScheduleResponse
+
+
+class FixedDate(date):
+    @classmethod
+    def today(cls) -> "FixedDate":
+        return cls(2024, 1, 1)
+
+
+@pytest.fixture
+def golden(request):
+    path = Path(request.node.fspath).with_suffix(".golden.json")
+    expected = json.loads(path.read_text())
+
+    def check(data: object) -> None:
+        assert data == expected
+
+    return check
+
+
+def test_schedule_golden(monkeypatch, golden):
+    monkeypatch.setattr(main, "date", FixedDate)
+    client = TestClient(main.app)
+    payload = {"workorder": "WO-1"}
+    res1 = client.post("/schedule", json=payload)
+    assert res1.status_code == 200
+    data1 = ScheduleResponse.model_validate(res1.json()).model_dump()
+    golden(data1)
+
+    res2 = client.post("/schedule", json=payload)
+    assert res2.status_code == 200
+    data2 = ScheduleResponse.model_validate(res2.json()).model_dump()
+    assert data2 == data1


### PR DESCRIPTION
## Summary
- add golden snapshot tests for blueprint and schedule endpoints
- ensure schedule test uses fixed date for deterministic outputs and verifies idempotency

## Testing
- `pre-commit run --files tests/api/test_blueprint_golden.py tests/api/test_schedule_golden.py tests/api/test_blueprint_golden.golden.json tests/api/test_schedule_golden.golden.json`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68aa4f264e48832280258df770afa80c