### PR TITLE
feat: enforce rate limiting and CORS headers

### DIFF
--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -21,6 +21,7 @@ def test_disallowed_origin(monkeypatch):
     )
     assert response.status_code == 400
     assert "access-control-allow-origin" not in response.headers
+    assert response.headers["X-Env"] == main.ENV_BADGE
 
     monkeypatch.setenv("CORS_ORIGINS", original)
     importlib.reload(main)

--- a/tests/api/test_healthz.py
+++ b/tests/api/test_healthz.py
@@ -22,6 +22,6 @@ def test_healthz_reports_rate_limit(monkeypatch):
     assert data["integrity"]["missing_assets"] == 0
     assert data["integrity"]["missing_locations"] == 0
 
-    monkeypatch.setenv("RATE_LIMIT_CAPACITY", "10")
+    monkeypatch.setenv("RATE_LIMIT_CAPACITY", "100000")
     monkeypatch.setenv("RATE_LIMIT_INTERVAL", "60")
     importlib.reload(main)

--- a/tests/api/test_rate_limit.py
+++ b/tests/api/test_rate_limit.py
@@ -10,12 +10,24 @@ def test_rate_limit(monkeypatch):
     monkeypatch.setenv("RATE_LIMIT_INTERVAL", "60")
     importlib.reload(main)
     client = TestClient(main.app)
+
+    assert client.get("/version").status_code == 200
+    assert client.get("/version").status_code == 200
+    res = client.get("/version")
+    assert res.status_code == 429
+    assert res.headers["X-Env"] == main.ENV_BADGE
+    assert "Retry-After" in res.headers
+
+    importlib.reload(main)
+    client = TestClient(main.app)
     payload = {"workorder": "WO-1"}
     assert client.post("/schedule", json=payload).status_code == 200
     assert client.post("/schedule", json=payload).status_code == 200
     res = client.post("/schedule", json=payload)
     assert res.status_code == 429
     assert res.headers["X-Env"] == main.ENV_BADGE
-    monkeypatch.setenv("RATE_LIMIT_CAPACITY", "10")
+    assert "Retry-After" in res.headers
+
+    monkeypatch.setenv("RATE_LIMIT_CAPACITY", "100000")
     monkeypatch.setenv("RATE_LIMIT_INTERVAL", "60")
     importlib.reload(main)


### PR DESCRIPTION
## Summary
- add CORS middleware that always returns X-Env header and rejects unknown origins
- apply global rate limiting and per-route buckets with Retry-After headers
- expose rate limit counters via /healthz

## Testing
- `pre-commit run --files apps/api/main.py tests/api/test_rate_limit.py tests/api/test_cors.py tests/api/test_healthz.py`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68aa58374a8083228fcab4bef45d90fe