### PR TITLE
Enable OIDC RBAC with planner/viewer roles

### DIFF
--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -13,6 +13,18 @@ def test_bearer_token(monkeypatch):
     client = TestClient(main.app)
     payload = {"workorder": "WO-1"}
     token = jwt.encode({"sub": "tester"}, "secret", algorithm="HS256")
+    monkeypatch.setattr(
+        main,
+        "authenticate_user",
+        lambda *_, **__: main.OIDCUser(
+            iss="iss",
+            sub="sub",
+            aud="aud",
+            exp=0,
+            iat=0,
+            roles=["planner"],
+        ),
+    )
     resp_ok = client.post(
         "/schedule", json=payload, headers={"Authorization": f"Bearer {token}"}
     )

--- a/tests/api/test_blueprint_golden.py
+++ b/tests/api/test_blueprint_golden.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import importlib
 import json
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
-from apps.api.main import app
+import apps.api.main as main
 from apps.api.schemas import BlueprintResponse
 
 
@@ -22,7 +23,8 @@ def golden(request):
 
 
 def test_blueprint_golden(golden):
-    client = TestClient(app)
+    importlib.reload(main)
+    client = TestClient(main.app)
     payload = {"workorder_id": "WO-1"}
     res1 = client.post("/blueprint", json=payload)
     assert res1.status_code == 200

--- a/tests/api/test_logging.py
+++ b/tests/api/test_logging.py
@@ -3,19 +3,38 @@ import logging
 
 from fastapi.testclient import TestClient
 
-from apps.api.main import RULE_PACK_HASH, app
+import apps.api.main as main
 from loto.loggers import JsonFormatter
 
 
-def test_structured_logging(caplog):
-    client = TestClient(app)
+def test_structured_logging(caplog, monkeypatch):
+    client = TestClient(main.app)
+    monkeypatch.setattr(
+        main,
+        "authenticate_user",
+        lambda *a, **kw: main.OIDCUser(
+            iss="iss",
+            sub="sub",
+            aud="aud",
+            exp=0,
+            iat=0,
+            roles=["planner"],
+        ),
+    )
     payload = {"workorder": "WO-99"}
     with caplog.at_level(logging.INFO):
-        client.post("/schedule", json=payload)
-    record = next(r for r in caplog.records if r.getMessage() == "request complete")
+        res = client.post(
+            "/schedule", json=payload, headers={"Authorization": "Bearer x"}
+        )
+    assert res.status_code == 200
+    record = next(
+        (r for r in caplog.records if r.getMessage() == "request complete"),
+        None,
+    )
+    assert record is not None
     data = json.loads(JsonFormatter().format(record))
     assert data["msg"] == "request complete"
     assert data["level"] == "info"
     assert data["seed"] == 0
     assert data["request_id"]
-    assert data["rule_hash"] == RULE_PACK_HASH
+    assert data["rule_hash"] == main.RULE_PACK_HASH

--- a/tests/api/test_oidc_rbac.py
+++ b/tests/api/test_oidc_rbac.py
@@ -1,0 +1,52 @@
+import importlib
+from fastapi.testclient import TestClient
+
+import apps.api.main as main
+
+
+def _override(email: str):
+    def _inner(*args, **kwargs):
+        return main.OIDCUser(
+            iss="iss",
+            sub="sub",
+            aud="aud",
+            exp=0,
+            iat=0,
+            email=email,
+        )
+
+    return _inner
+
+
+def test_schedule_requires_auth():
+    importlib.reload(main)
+    client = TestClient(main.app)
+    res = client.post("/schedule", json={"workorder": "WO-1"})
+    assert res.status_code == 401
+
+
+def test_viewer_forbidden_and_role(monkeypatch):
+    monkeypatch.setenv("PLANNER_EMAIL_DOMAIN", "planner.test")
+    importlib.reload(main)
+    client = TestClient(main.app)
+    monkeypatch.setattr(main, "authenticate_user", _override("user@viewer.test"))
+    res = client.post(
+        "/schedule", json={"workorder": "WO-1"}, headers={"Authorization": "Bearer x"}
+    )
+    assert res.status_code == 403
+    res = client.get("/healthz", headers={"Authorization": "Bearer x"})
+    assert res.status_code == 200
+    assert res.json()["role"] == "viewer"
+
+
+def test_planner_allowed(monkeypatch):
+    monkeypatch.setenv("PLANNER_EMAIL_DOMAIN", "planner.test")
+    importlib.reload(main)
+    client = TestClient(main.app)
+    monkeypatch.setattr(main, "authenticate_user", _override("user@planner.test"))
+    res = client.post(
+        "/schedule", json={"workorder": "WO-1"}, headers={"Authorization": "Bearer x"}
+    )
+    assert res.status_code == 200
+    res = client.get("/healthz", headers={"Authorization": "Bearer x"})
+    assert res.json()["role"] == "planner"

--- a/tests/api/test_schedule.py
+++ b/tests/api/test_schedule.py
@@ -1,13 +1,22 @@
+import importlib
 from fastapi.testclient import TestClient
 
-from apps.api.main import RULE_PACK_HASH, app
+import apps.api.main as main
 from loto.integrations.stores_adapter import DemoStoresAdapter
 
 
-def test_schedule_endpoint():
-    client = TestClient(app)
+def _planner():
+    return main.OIDCUser(
+        iss="iss", sub="sub", aud="aud", exp=0, iat=0, roles=["planner"]
+    )
+
+
+def test_schedule_endpoint(monkeypatch):
+    importlib.reload(main)
+    client = TestClient(main.app)
+    monkeypatch.setattr(main, "authenticate_user", lambda *a, **kw: _planner())
     payload = {"workorder": "WO-1"}
-    res = client.post("/schedule", json=payload)
+    res = client.post("/schedule", json=payload, headers={"Authorization": "Bearer x"})
     assert res.status_code == 200
     data = res.json()
     assert "schedule" in data
@@ -16,30 +25,42 @@ def test_schedule_endpoint():
     assert {"date", "p10", "p50", "p90", "price", "hats"} <= first.keys()
     assert data["seed"] == "0"
     assert data["blocked_by_parts"] is False
-    assert data["rulepack_sha256"] == RULE_PACK_HASH
+    assert data["rulepack_sha256"] == main.RULE_PACK_HASH
 
 
-def test_schedule_inventory_gating():
-    client = TestClient(app)
+def test_schedule_inventory_gating(monkeypatch):
+    importlib.reload(main)
+    client = TestClient(main.app)
+    monkeypatch.setattr(main, "authenticate_user", lambda *a, **kw: _planner())
     original = DemoStoresAdapter._INVENTORY["P-200"]["available"]
     try:
         DemoStoresAdapter._INVENTORY["P-200"]["available"] = 0
-        res = client.post("/schedule", json={"workorder": "WO-1"})
+        res = client.post(
+            "/schedule",
+            json={"workorder": "WO-1"},
+            headers={"Authorization": "Bearer x"},
+        )
         assert res.status_code == 200
         data = res.json()
         assert data["blocked_by_parts"] is True
         assert data["schedule"] == []
-        assert data["rulepack_sha256"] == RULE_PACK_HASH
+        assert data["rulepack_sha256"] == main.RULE_PACK_HASH
     finally:
         DemoStoresAdapter._INVENTORY["P-200"]["available"] = original
 
 
-def test_schedule_inventory_gating_strict():
-    client = TestClient(app)
+def test_schedule_inventory_gating_strict(monkeypatch):
+    importlib.reload(main)
+    client = TestClient(main.app)
+    monkeypatch.setattr(main, "authenticate_user", lambda *a, **kw: _planner())
     original = DemoStoresAdapter._INVENTORY["P-200"]["available"]
     try:
         DemoStoresAdapter._INVENTORY["P-200"]["available"] = 0
-        res = client.post("/schedule?strict=true", json={"workorder": "WO-1"})
+        res = client.post(
+            "/schedule?strict=true",
+            json={"workorder": "WO-1"},
+            headers={"Authorization": "Bearer x"},
+        )
         assert res.status_code == 409
         data = res.json()
         assert data["blocked_by_parts"] is True


### PR DESCRIPTION
## Summary
- add OIDC user role mapping by email and expose role via `/healthz`
- restrict `/schedule` endpoint to planner role
- add tests for planner vs viewer access and health reporting

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68aa5d0681748322afdca1053c5f2735