### PR TITLE
feat: toggle api usage

### DIFF
--- a/apps/maximo-extension-ui/src/app/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/page.test.tsx
@@ -1,8 +1,8 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { test, expect } from 'vitest';
 import Page from './page';
 
-test('renders page', () => {
-  const { container } = render(<Page />);
-  expect(container.querySelector('main')).not.toBeNull();
+test('renders portfolio', async () => {
+  render(<Page />);
+  expect(await screen.findByText('Portfolio')).toBeInTheDocument();
 });

--- a/apps/maximo-extension-ui/src/app/page.tsx
+++ b/apps/maximo-extension-ui/src/app/page.tsx
@@ -1,23 +1,58 @@
-export default function Page() {
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import KpiCards from '../components/KpiCards';
+import Skeleton from '../components/Skeleton';
+import { usePortfolio } from '../lib/hooks';
+
+const queryClient = new QueryClient();
+
+function HomeContent() {
+  const { data, isLoading } = usePortfolio();
+
+  if (isLoading) {
+    return (
+      <main>
+        <h1 className="mb-4 text-xl font-semibold">Portfolio</h1>
+        <KpiCards items={[]} loading />
+        <Skeleton className="h-64 w-full" />
+      </main>
+    );
+  }
+
+  if (!data) return null;
+
   return (
     <main>
       <h1 className="mb-4 text-xl font-semibold">Portfolio</h1>
+      <KpiCards items={data.kpis} />
       <table className="min-w-full border border-[var(--mxc-border)]">
         <thead className="bg-[var(--mxc-nav-bg)] text-left">
           <tr>
-            <th className="px-4 py-2">Name</th>
+            <th className="px-4 py-2">Description</th>
             <th className="px-4 py-2">Status</th>
             <th className="px-4 py-2">Owner</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td className="px-4 py-6 text-center" colSpan={3}>
-              No data
-            </td>
-          </tr>
+          {data.workOrders.map((wo) => (
+            <tr key={wo.id}>
+              <td className="px-4 py-2">{wo.description}</td>
+              <td className="px-4 py-2">{wo.status}</td>
+              <td className="px-4 py-2">{wo.owner}</td>
+            </tr>
+          ))}
         </tbody>
       </table>
     </main>
   );
 }
+
+export default function Page() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <HomeContent />
+    </QueryClientProvider>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -11,6 +11,7 @@ test('renders gantt, price curve and hats timeline', async () => {
   // @ts-ignore
   global.ResizeObserver = ResizeObserver;
 
+  vi.stubEnv('NEXT_PUBLIC_USE_API', 'true');
   const apiBase = process.env.NEXT_PUBLIC_API_URL ?? '';
   process.env.NEXT_PUBLIC_API_BASE = apiBase;
 

--- a/apps/maximo-extension-ui/src/components/ReactivePicker.test.tsx
+++ b/apps/maximo-extension-ui/src/components/ReactivePicker.test.tsx
@@ -9,6 +9,7 @@ const mockHats = [
 ];
 
 beforeEach(() => {
+  vi.stubEnv('NEXT_PUBLIC_USE_API', 'true');
   vi.spyOn(global, 'fetch').mockResolvedValue({
     ok: true,
     json: async () => mockHats

--- a/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
+++ b/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
@@ -3,28 +3,26 @@ import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '../lib/api';
 import { toastError } from '../lib/toast';
 import Skeleton from './Skeleton';
+import { fetchHats } from '../mocks/hats';
+import type { HatCandidate } from '../types/api';
 
-interface HatCandidate {
-  hat_id: string;
-  c_r: number;
-  rotation?: number;
-}
-
-async function fetchCandidates(): Promise<HatCandidate[]> {
+async function fetchCandidatesApi(): Promise<HatCandidate[]> {
   const res = await apiFetch('/hats');
   if (!res.ok) throw new Error('Failed to fetch hats');
   return (await res.json()) as HatCandidate[];
 }
 
 export default function ReactivePicker({ wo }: { wo: string }) {
+  const useApi = process.env.NEXT_PUBLIC_USE_API === 'true';
   const { data, isLoading } = useQuery({
     queryKey: ['reactive', wo],
     queryFn: async () => {
+      if (!useApi) return fetchHats();
       try {
-        return await fetchCandidates();
+        return await fetchCandidatesApi();
       } catch (err) {
         toastError('Failed to fetch reactive candidates');
-        throw err;
+        return fetchHats();
       }
     }
   });

--- a/apps/maximo-extension-ui/src/components/WizardExport.tsx
+++ b/apps/maximo-extension-ui/src/components/WizardExport.tsx
@@ -13,8 +13,26 @@ export default function WizardExport({ plan }: WizardExportProps) {
   const [hash, setHash] = useState<string | null>(null);
   const [seed, setSeed] = useState<string | null>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
+  const useApi = process.env.NEXT_PUBLIC_USE_API === 'true';
 
   async function handleExport(format: 'pdf' | 'json') {
+    if (!useApi) {
+      const blob = new Blob(
+        [JSON.stringify(plan, null, 2)],
+        { type: format === 'pdf' ? 'application/pdf' : 'application/json' }
+      );
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `plan_mock.${format}`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      setHash('mock');
+      setSeed('mock');
+      return;
+    }
     try {
       const res = await apiFetch('/blueprint', {
         method: 'POST',

--- a/apps/maximo-extension-ui/src/lib/schedule.ts
+++ b/apps/maximo-extension-ui/src/lib/schedule.ts
@@ -1,6 +1,7 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { apiFetch } from './api';
 import { toastError } from './toast';
+import { fetchSchedule as fetchScheduleMock } from '../mocks/schedule';
 
 export interface SchedulePoint {
   date: string;
@@ -39,14 +40,16 @@ export async function fetchSchedule(wo: string): Promise<ScheduleResponse> {
  * React Query hook for schedule data.
  */
 export function useSchedule(wo: string): UseQueryResult<ScheduleResponse> {
+  const useApi = process.env.NEXT_PUBLIC_USE_API === 'true';
   return useQuery({
     queryKey: ['schedule', wo],
     queryFn: async () => {
+      if (!useApi) return fetchScheduleMock(wo);
       try {
         return await fetchSchedule(wo);
       } catch (err) {
         toastError('Failed to fetch schedule');
-        throw err;
+        return fetchScheduleMock(wo);
       }
     }
   });

--- a/apps/maximo-extension-ui/src/mocks/hats.ts
+++ b/apps/maximo-extension-ui/src/mocks/hats.ts
@@ -1,0 +1,9 @@
+import type { HatCandidate } from '../types/api';
+
+export async function fetchHats(): Promise<HatCandidate[]> {
+  return [
+    { hat_id: 'h1', c_r: 0.8, rotation: 1 },
+    { hat_id: 'h2', c_r: 0.6 }
+  ];
+}
+

--- a/apps/maximo-extension-ui/src/mocks/schedule.ts
+++ b/apps/maximo-extension-ui/src/mocks/schedule.ts
@@ -1,0 +1,15 @@
+import type { ScheduleResponse } from '../lib/schedule';
+
+export async function fetchSchedule(_wo: string): Promise<ScheduleResponse> {
+  return {
+    schedule: [
+      { date: '2024-01-01', p10: 10, p50: 20, p90: 30, price: 40, hats: 1 },
+      { date: '2024-01-02', p10: 12, p50: 22, p90: 32, price: 42, hats: 2 }
+    ],
+    seed: 'mock',
+    objective: 0.95,
+    blocked_by_parts: false,
+    rulepack_sha256: 'mock-sha'
+  };
+}
+

--- a/apps/maximo-extension-ui/src/types/api.ts
+++ b/apps/maximo-extension-ui/src/types/api.ts
@@ -54,3 +54,9 @@ export interface InventoryItem {
   eta?: string;
   status: InventoryStatus;
 }
+
+export interface HatCandidate {
+  hat_id: string;
+  c_r: number;
+  rotation?: number;
+}


### PR DESCRIPTION
## Summary
- add env-based switch for schedule and hats queries with mock fallbacks
- render home page portfolio via API hook
- support mock blueprint export when API is disabled

## Testing
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files apps/maximo-extension-ui/src/app/page.test.tsx apps/maximo-extension-ui/src/app/page.tsx apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx apps/maximo-extension-ui/src/components/ReactivePicker.test.tsx apps/maximo-extension-ui/src/components/ReactivePicker.tsx apps/maximo-extension-ui/src/components/WizardExport.tsx apps/maximo-extension-ui/src/lib/schedule.ts apps/maximo-extension-ui/src/types/api.ts apps/maximo-extension-ui/src/mocks/hats.ts apps/maximo-extension-ui/src/mocks/schedule.ts`


------
https://chatgpt.com/codex/tasks/task_b_68aa807976d08322a14a731a57dbf8d5