### PR TITLE
feat: enhance planner tabs

### DIFF
--- a/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import { test, expect, vi, afterEach } from 'vitest';
+import { test, expect, vi, afterEach, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import CommitPanel from './CommitPanel';
+
+beforeEach(() => {
+  vi.stubGlobal('alert', vi.fn());
+});
 
 afterEach(() => {
   cleanup();
@@ -17,7 +21,7 @@ test('renders audit metadata and disables commit in TEST role', async () => {
   const queryClient = new QueryClient();
   render(
     <QueryClientProvider client={queryClient}>
-      <CommitPanel wo="WO-1" />
+      <CommitPanel wo="WO-1" simOk />
     </QueryClientProvider>
   );
   await screen.findByTestId('diff');
@@ -38,11 +42,13 @@ test('requires typing COMMIT to confirm', async () => {
   const queryClient = new QueryClient();
   render(
     <QueryClientProvider client={queryClient}>
-      <CommitPanel wo="WO-1" />
+      <CommitPanel wo="WO-1" simOk />
     </QueryClientProvider>
   );
   await screen.findByTestId('diff');
   const button = screen.getByRole('button', { name: 'Commit' });
+  const checks = screen.getAllByRole('checkbox');
+  checks.forEach((c) => fireEvent.click(c));
   fireEvent.click(button);
   expect(fetchMock).toHaveBeenCalledTimes(1);
   prompt.mockReturnValue('COMMIT');

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
@@ -63,6 +63,7 @@ export default function PidTab({ wo }: { wo: string }) {
   const [showSimFails, setShowSimFails] = useState(false);
   const [showSourcePath, setShowSourcePath] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
 
   useEffect(() => {
     if (!data || !containerRef.current) return;
@@ -78,11 +79,12 @@ export default function PidTab({ wo }: { wo: string }) {
     if (showSourcePath) highlight.push(...sourcePath);
     if (showSimFails) highlight.push(...simFailSelectors);
 
-    applyPidOverlay(svg as unknown as SVGSVGElement, {
+    const w = applyPidOverlay(svg as unknown as SVGSVGElement, {
       highlight,
       badges: data.badges,
       paths: []
     });
+    setWarnings(w);
   }, [data, showSimFails, showSourcePath]);
 
   if (blueprintLoading || isLoading) {
@@ -113,7 +115,7 @@ export default function PidTab({ wo }: { wo: string }) {
         </label>
       </div>
       <div ref={containerRef} className="flex-1">
-        <PidViewer src={src} />
+        <PidViewer src={src} warnings={warnings} />
       </div>
     </div>
   );

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import { test, expect, vi, afterEach } from 'vitest';
+import { test, expect, vi, afterEach, beforeEach } from 'vitest';
 import Page from './page';
+
+beforeEach(() => {
+  vi.stubGlobal('alert', vi.fn());
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 test('renders 6 tabs', async () => {
@@ -17,6 +22,14 @@ test('renders export buttons', () => {
   render(<Page params={{ wo: 'WO-1' }} />);
   expect(screen.getAllByText('Export PDF').length).toBeGreaterThan(0);
   expect(screen.getAllByText('Export JSON').length).toBeGreaterThan(0);
+});
+
+test('plan tab filters steps and allows copy', async () => {
+  render(<Page params={{ wo: 'WO-1' }} />);
+  const search = await screen.findByPlaceholderText('Search steps');
+  fireEvent.change(search, { target: { value: 'install' } });
+  expect(screen.getByText('Install')).toBeInTheDocument();
+  expect(screen.queryByText('Remove')).toBeNull();
 });
 
 test('renders material status chips', async () => {
@@ -39,4 +52,16 @@ test('renders material status chips', async () => {
   await screen.findByText('P-200');
   expect(screen.getByText('OK')).toBeInTheDocument();
   expect(screen.getByText('Short')).toBeInTheDocument();
+});
+
+test('commit button gated by policies', async () => {
+  vi.stubEnv('NEXT_PUBLIC_ROLE', 'ADMIN');
+  render(<Page params={{ wo: 'WO-1' }} />);
+  const commitTab = await screen.findByRole('tab', { name: 'Commit' });
+  fireEvent.click(commitTab);
+  const btn = await screen.findByRole('button', { name: 'Commit' });
+  expect(btn).toBeDisabled();
+  const checks = screen.getAllByRole('checkbox');
+  checks.forEach((c) => fireEvent.click(c));
+  expect(btn).not.toBeDisabled();
 });

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { notFound } from 'next/navigation';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useWorkOrderApi, useBlueprintApi } from '../../../lib/hooks';
@@ -16,15 +16,31 @@ const queryClient = new QueryClient();
 
 function PlannerContent({ wo }: { wo: string }) {
   const [activeTab, setActiveTab] = useState('Plan');
+  const [planFilter, setPlanFilter] = useState('');
   const { data: workOrder } = useWorkOrderApi(wo);
   const { data: blueprint } = useBlueprintApi(wo);
-
-  if (!workOrder) return null;
 
   const plan = blueprint?.steps ?? [];
   const unavailable = blueprint?.unavailable_assets ?? [];
   const impact = blueprint?.unit_mw_delta ?? {};
   const materials = blueprint?.parts_status ?? {};
+  const simStatus = unavailable.length
+    ? 'red'
+    : blueprint?.blocked_by_parts
+      ? 'yellow'
+      : 'green';
+
+  const filteredPlan = useMemo(
+    () =>
+      plan.filter(
+        (p) =>
+          p.component_id.toLowerCase().includes(planFilter.toLowerCase()) ||
+          p.method.toLowerCase().includes(planFilter.toLowerCase())
+      ),
+    [plan, planFilter]
+  );
+
+  if (!workOrder) return null;
 
   const statusStyles: Record<MaterialStatus, string> = {
     ok: 'bg-green-100 text-green-800',
@@ -64,24 +80,74 @@ function PlannerContent({ wo }: { wo: string }) {
             ))}
           </div>
           {activeTab === 'Plan' && (
-            <table className="min-w-full border border-[var(--mxc-border)]">
-              <thead className="bg-[var(--mxc-nav-bg)] text-left">
-                <tr>
-                  <th className="px-4 py-2">Step</th>
-                  <th className="px-4 py-2">Component</th>
-                  <th className="px-4 py-2">Method</th>
-                </tr>
-              </thead>
-              <tbody>
-                {plan.map((p, idx) => (
-                  <tr key={idx}>
-                    <td className="px-4 py-2">{idx + 1}</td>
-                    <td className="px-4 py-2">{p.component_id}</td>
-                    <td className="px-4 py-2">{p.method}</td>
+            <div>
+              <div className="mb-2 flex items-center gap-2">
+                <input
+                  type="text"
+                  placeholder="Search steps"
+                  value={planFilter}
+                  onChange={(e) => setPlanFilter(e.target.value)}
+                  className="border px-2 py-1"
+                />
+                <button
+                  type="button"
+                  className="badge"
+                  onClick={() => {
+                    const txt = filteredPlan
+                      .map(
+                        (p, idx) => `${idx + 1}\t${p.component_id}\t${p.method}`
+                      )
+                      .join('\n');
+                    navigator.clipboard?.writeText(txt).catch(() => {});
+                  }}
+                >
+                  Copy
+                </button>
+                <button
+                  type="button"
+                  className="badge"
+                  onClick={() => {
+                    const csv =
+                      'Step,Component,Method\n' +
+                      filteredPlan
+                        .map(
+                          (p, idx) =>
+                            `${idx + 1},${p.component_id},${p.method}`
+                        )
+                        .join('\n');
+                    const blob = new Blob([csv], { type: 'text/csv' });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `WO-${wo}_plan.csv`;
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                    URL.revokeObjectURL(url);
+                  }}
+                >
+                  Export CSV
+                </button>
+              </div>
+              <table className="min-w-full border border-[var(--mxc-border)]">
+                <thead className="bg-[var(--mxc-nav-bg)] text-left">
+                  <tr>
+                    <th className="px-4 py-2">Step</th>
+                    <th className="px-4 py-2">Component</th>
+                    <th className="px-4 py-2">Method</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {filteredPlan.map((p, idx) => (
+                    <tr key={idx}>
+                      <td className="px-4 py-2">{idx + 1}</td>
+                      <td className="px-4 py-2">{p.component_id}</td>
+                      <td className="px-4 py-2">{p.method}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
           {activeTab === 'Materials' && (
             <table className="min-w-full border border-[var(--mxc-border)]">
@@ -89,6 +155,7 @@ function PlannerContent({ wo }: { wo: string }) {
                 <tr>
                   <th className="px-4 py-2">Item</th>
                   <th className="px-4 py-2">Status</th>
+                  <th className="px-4 py-2">Flag</th>
                 </tr>
               </thead>
               <tbody>
@@ -102,6 +169,10 @@ function PlannerContent({ wo }: { wo: string }) {
                         {statusLabels[status as MaterialStatus]}
                       </span>
                     </td>
+                    <td className="px-4 py-2">
+                      {status === 'short' && 'Stock-out'}
+                      {status === 'low' && 'Below reorder'}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -109,20 +180,28 @@ function PlannerContent({ wo }: { wo: string }) {
           )}
           {activeTab === 'P&ID' && <PidTab wo={wo} />}
           {activeTab === 'Simulation' && (
-            <table className="min-w-full border border-[var(--mxc-border)]">
-              <thead className="bg-[var(--mxc-nav-bg)] text-left">
-                <tr>
-                  <th className="px-4 py-2">Unavailable Asset</th>
-                </tr>
-              </thead>
-              <tbody>
+            <div>
+              <div className="mb-2 font-semibold">
+                Status:{' '}
+                <span
+                  className={
+                    simStatus === 'green'
+                      ? 'text-green-600'
+                      : simStatus === 'yellow'
+                        ? 'text-yellow-600'
+                        : 'text-red-600'
+                  }
+                >
+                  {simStatus}
+                </span>
+              </div>
+              <ul className="mb-2 list-disc pl-5">
+                {unavailable.length === 0 && <li>No warnings</li>}
                 {unavailable.map((u) => (
-                  <tr key={u}>
-                    <td className="px-4 py-2">{u}</td>
-                  </tr>
+                  <li key={u}>{u}</li>
                 ))}
-              </tbody>
-            </table>
+              </ul>
+            </div>
           )}
           {activeTab === 'Impact' && (
             <table className="min-w-full border border-[var(--mxc-border)]">
@@ -130,19 +209,34 @@ function PlannerContent({ wo }: { wo: string }) {
                 <tr>
                   <th className="px-4 py-2">Unit</th>
                   <th className="px-4 py-2">ΔMW</th>
+                  <th className="px-4 py-2">Risk</th>
                 </tr>
               </thead>
               <tbody>
-                {Object.entries(impact).map(([unit, delta]) => (
-                  <tr key={unit}>
-                    <td className="px-4 py-2">{unit}</td>
-                    <td className="px-4 py-2">{delta}</td>
-                  </tr>
-                ))}
+                {Object.entries(impact).map(([unit, delta]) => {
+                  const risk = Math.abs(delta) > 10 ? 'High' : 'Low';
+                  const riskClass =
+                    risk === 'High'
+                      ? 'bg-red-100 text-red-800'
+                      : 'bg-green-100 text-green-800';
+                  return (
+                    <tr key={unit}>
+                      <td className="px-4 py-2">{unit}</td>
+                      <td className="px-4 py-2">{delta}</td>
+                      <td className="px-4 py-2">
+                        <span
+                          className={`inline-block rounded-full px-2 py-1 text-xs font-medium ${riskClass}`}
+                        >
+                          {risk}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           )}
-          {activeTab === 'Commit' && <CommitPanel wo={wo} />}
+          {activeTab === 'Commit' && <CommitPanel wo={wo} simOk={simStatus === 'green'} />}
         </div>
         <aside className="w-64 shrink-0 border-l border-[var(--mxc-border)] bg-[var(--mxc-drawer-bg)] p-4 text-[var(--mxc-drawer-fg)]">
           Warnings placeholder


### PR DESCRIPTION
## Summary
- add plan step search, copy, and CSV export
- surface material stock flags and simulation status
- gate commits behind policy checks and simulation pass

## Testing
- `pnpm -F maximo-extension-ui test`
- `pre-commit run --files apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.tsx apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx apps/maximo-extension-ui/src/app/planner/[wo]/CommitPanel.test.tsx`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68aa84bad1988322a5c0f1dd07593cb3