### PR TITLE
feat: finalize PID viewer interactions

### DIFF
--- a/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx
@@ -82,7 +82,8 @@ export default function PidTab({ wo }: { wo: string }) {
     const w = applyPidOverlay(svg as unknown as SVGSVGElement, {
       highlight,
       badges: data.badges,
-      paths: []
+      paths: [],
+      warnings: data.warnings
     });
     setWarnings(w);
   }, [data, showSimFails, showSourcePath]);

--- a/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
+++ b/apps/maximo-extension-ui/src/components/PidViewer.test.tsx
@@ -1,5 +1,5 @@
-import { render, waitFor, fireEvent } from '@testing-library/react';
-import { vi, test, expect } from 'vitest';
+import { render, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import { vi, test, expect, afterEach } from 'vitest';
 import PidViewer from './PidViewer';
 
 test('toggles highlight classes', async () => {
@@ -45,6 +45,11 @@ test('adds aria-labels from title elements', async () => {
   (fetch as any).mockRestore();
 });
 
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
 test('renders warning messages and copies on click', async () => {
   const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>';
   vi.spyOn(global, 'fetch').mockResolvedValue({
@@ -54,15 +59,63 @@ test('renders warning messages and copies on click', async () => {
   const writeText = vi.fn().mockResolvedValue(undefined);
   Object.assign(navigator, { clipboard: { writeText } });
 
-  const { getByRole, findByRole } = render(
+  const { getByRole, findByRole, getAllByRole } = render(
     <PidViewer src="/test.svg" warnings={['missing tag']} />
   );
 
   const btn = await waitFor(() => getByRole('button', { name: /warnings/i }));
+  // legend uses an explicit landmark role
+  expect(getAllByRole('note', { name: 'Legend' }).length).toBeGreaterThan(0);
   fireEvent.click(btn);
   const warnBtn = await findByRole('button', { name: 'missing tag' });
+  // warnings drawer is labeled for accessibility
+  await findByRole('complementary', { name: 'Warnings' });
   fireEvent.click(warnBtn);
   expect(writeText).toHaveBeenCalledWith('missing tag');
+
+  (fetch as any).mockRestore();
+});
+
+test('supports pan and zoom interactions', async () => {
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"></svg>';
+  vi.spyOn(global, 'fetch').mockResolvedValue({
+    text: () => Promise.resolve(svg)
+  } as any);
+
+  const { container } = render(<PidViewer src="/test.svg" />);
+  const wrapper = container.querySelector('.pid-container') as HTMLDivElement;
+  Object.defineProperty(wrapper, 'clientWidth', { value: 100 });
+  Object.defineProperty(wrapper, 'clientHeight', { value: 100 });
+  wrapper.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+    right: 100,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return {};
+    }
+  });
+
+  await waitFor(() => expect(container.querySelector('svg')).toBeTruthy());
+  const svgEl = container.querySelector('svg') as SVGSVGElement;
+
+  fireEvent.wheel(wrapper, { deltaY: -100, clientX: 50, clientY: 50 });
+  await waitFor(() => {
+    expect(svgEl.style.transform).toMatch(/scale/);
+  });
+  const afterZoom = svgEl.style.transform;
+
+  fireEvent.mouseDown(wrapper, { clientX: 0, clientY: 0 });
+  fireEvent.mouseMove(wrapper, { clientX: 10, clientY: 20 });
+  fireEvent.mouseUp(wrapper);
+
+  await waitFor(() => {
+    expect(svgEl.style.transform).not.toBe(afterZoom);
+  });
 
   (fetch as any).mockRestore();
 });


### PR DESCRIPTION
## Summary
- surface overlay warnings in PID tab and pass them to viewer
- expand PID viewer tests for a11y, copy-to-clipboard, and pan/zoom interactions

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/app/planner/[wo]/PidTab.tsx apps/maximo-extension-ui/src/components/PidViewer.test.tsx`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68aa890c09b0832296dbb1df7ee4f6c4