### PR TITLE
Add virtualized scheduler with conflict badges

### DIFF
--- a/apps/maximo-extension-ui/package.json
+++ b/apps/maximo-extension-ui/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.0.0",
+    "@tanstack/react-virtual": "^3.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "html2canvas": "^1.4.1",

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx
@@ -2,22 +2,37 @@
 
 import { notFound } from 'next/navigation';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import Gantt from '../../../components/Gantt';
+import { useState } from 'react';
 import ReactivePicker from '../../../components/ReactivePicker';
-import { useSchedule } from '../../../lib/schedule';
+import VirtualizedGantt from '../../../components/VirtualizedGantt';
+import ConflictsList from '../../../components/ConflictsList';
+import { useSchedule, SchedulePoint } from '../../../lib/schedule';
 import { isFeatureEnabled } from '../../../lib/featureFlags';
 
 const queryClient = new QueryClient();
 
 function SchedulerContent({ wo }: { wo: string }) {
   const { data } = useSchedule(wo);
+  const [conflicts, setConflicts] = useState<string[]>([]);
   if (!data) return null;
   const { schedule, seed, objective } = data;
+
+  const handleSelect = (point: SchedulePoint) => {
+    setConflicts(point.conflicts ?? []);
+  };
+
+  const candidates = conflicts.map((c, i) => ({
+    id: `c${i}`,
+    label: c,
+    explanation: `Conflict with ${c}`
+  }));
+
   return (
     <main className="h-full flex flex-col">
       <h1 className="mb-4 text-xl font-semibold">Scheduler: {wo}</h1>
-      <Gantt data={schedule} />
+      <VirtualizedGantt data={schedule} onSelect={handleSelect} />
       <ReactivePicker wo={wo} />
+      <ConflictsList candidates={candidates} />
       <footer className="mt-4 text-sm text-gray-500" data-testid="schedule-meta">
         Seed: {seed} Objective: {objective}
       </footer>

--- a/apps/maximo-extension-ui/src/components/VirtualizedGantt.test.tsx
+++ b/apps/maximo-extension-ui/src/components/VirtualizedGantt.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
+import { expect, test } from 'vitest';
+import VirtualizedGantt from './VirtualizedGantt';
+import ConflictsList from './ConflictsList';
+import type { SchedulePoint } from '../lib/schedule';
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// @ts-ignore
+global.ResizeObserver = ResizeObserver;
+
+const data: SchedulePoint[] = [
+  {
+    date: '2024-01-01',
+    p10: 1,
+    p50: 2,
+    p90: 3,
+    price: 4,
+    hats: 1,
+    conflicts: ['A']
+  },
+  {
+    date: '2024-01-02',
+    p10: 1,
+    p50: 2,
+    p90: 3,
+    price: 4,
+    hats: 1,
+    conflicts: []
+  }
+];
+
+function Wrapper() {
+  const [conflicts, setConflicts] = useState<string[]>([]);
+  return (
+    <>
+      <VirtualizedGantt
+        data={data}
+        onSelect={(p) => setConflicts(p.conflicts ?? [])}
+      />
+      <ConflictsList
+        candidates={conflicts.map((c, i) => ({
+          id: `c${i}`,
+          label: c,
+          explanation: c
+        }))}
+      />
+    </>
+  );
+}
+
+test('conflicts list updates on row selection', async () => {
+  render(<Wrapper />);
+  const firstRow = await screen.findAllByTestId('gantt-row-date');
+  fireEvent.click(firstRow[0]);
+  expect(screen.getByLabelText('A')).toBeInTheDocument();
+});

--- a/apps/maximo-extension-ui/src/components/VirtualizedGantt.tsx
+++ b/apps/maximo-extension-ui/src/components/VirtualizedGantt.tsx
@@ -1,0 +1,85 @@
+import React, { useRef, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { SchedulePoint } from '../lib/schedule';
+
+interface Props {
+  data: SchedulePoint[];
+  onSelect?: (point: SchedulePoint) => void;
+}
+
+export default function VirtualizedGantt({ data, onSelect }: Props) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: data.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 32
+  });
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const handleSelect = (idx: number) => {
+    setSelected(idx);
+    onSelect?.(data[idx]);
+  };
+
+  return (
+    <div
+      ref={parentRef}
+      className="overflow-auto border"
+      style={{ height: 256 }}
+    >
+      <div
+        style={{
+          height: `${rowVirtualizer.getTotalSize()}px`,
+          width: '100%',
+          position: 'relative'
+        }}
+      >
+        {(rowVirtualizer.getVirtualItems().length
+          ? rowVirtualizer.getVirtualItems()
+          : data.slice(0, Math.min(10, data.length)).map((_, i) => ({
+              index: i,
+              key: i,
+              start: i * 32,
+              size: 32
+            }))
+        ).map((virtualRow: any) => {
+          const item = data[virtualRow.index];
+          const isSelected = virtualRow.index === selected;
+          return (
+            <div
+              key={virtualRow.key}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: `${virtualRow.size}px`,
+                transform: `translateY(${virtualRow.start}px)`
+              }}
+              className={`flex items-center px-2 cursor-pointer select-none ${
+                isSelected ? 'bg-blue-100' : ''
+              }`}
+              draggable
+              onDragStart={(e) => {
+                // Drag ghost – no data modification
+                e.dataTransfer.setData('text/plain', item.date);
+              }}
+              onClick={() => handleSelect(virtualRow.index)}
+            >
+              <span className="flex-1" data-testid="gantt-row-date">
+                {item.date}
+              </span>
+              {item.conflicts && item.conflicts.length > 0 && (
+                <span
+                  aria-label="conflict"
+                  className="ml-2 w-2 h-2 rounded-full bg-red-500"
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+

--- a/apps/maximo-extension-ui/src/lib/schedule.ts
+++ b/apps/maximo-extension-ui/src/lib/schedule.ts
@@ -10,6 +10,8 @@ export interface SchedulePoint {
   p90: number;
   price: number;
   hats: number;
+  /** Optional list of conflict identifiers for the row. */
+  conflicts?: string[];
 }
 
 export interface ScheduleResponse {

--- a/apps/maximo-extension-ui/src/mocks/schedule.ts
+++ b/apps/maximo-extension-ui/src/mocks/schedule.ts
@@ -1,11 +1,21 @@
 import type { ScheduleResponse } from '../lib/schedule';
 
 export async function fetchSchedule(_wo: string): Promise<ScheduleResponse> {
+  const schedule = Array.from({ length: 2000 }, (_, i) => {
+    const date = new Date(2024, 0, 1 + i).toISOString().slice(0, 10);
+    return {
+      date,
+      p10: 10 + i,
+      p50: 20 + i,
+      p90: 30 + i,
+      price: 40 + i,
+      hats: (i % 5) + 1,
+      conflicts: i % 15 === 0 ? [`Conflict ${i}`] : []
+    };
+  });
+
   return {
-    schedule: [
-      { date: '2024-01-01', p10: 10, p50: 20, p90: 30, price: 40, hats: 1 },
-      { date: '2024-01-02', p10: 12, p50: 22, p90: 32, price: 42, hats: 2 }
-    ],
+    schedule,
     seed: 'mock',
     objective: 0.95,
     blocked_by_parts: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.85.3(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.0.0
+        version: 3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -1860,6 +1863,15 @@ packages:
     resolution: {integrity: sha512-AqU8TvNh5GVIE8I+TUU0noryBRy7gOY0XhSayVXmOPll4UkZeLWKDwi0rtWOZbwLRCbyxorfJ5DIjDqE7GXpcQ==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
@@ -7283,6 +7295,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.85.3
       react: 18.3.1
+
+  '@tanstack/react-virtual@3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.12
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@testing-library/dom@9.3.4':
     dependencies:


### PR DESCRIPTION
## Summary
- virtualize Gantt rows and expose selection with drag ghost and conflict badges
- surface selected conflicts in scheduler page via ConflictsList
- generate large mock schedule for virtualization tests

## Testing
- `pnpm -F maximo-extension-ui test`
- `pre-commit run --files apps/maximo-extension-ui/package.json apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx apps/maximo-extension-ui/src/app/scheduler/[wo]/page.tsx apps/maximo-extension-ui/src/lib/schedule.ts apps/maximo-extension-ui/src/mocks/schedule.ts apps/maximo-extension-ui/src/components/VirtualizedGantt.tsx apps/maximo-extension-ui/src/components/VirtualizedGantt.test.tsx pnpm-lock.yaml`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68aa8bd97df88322a197ad9514702e58