### PR TITLE
feat: add print hotkey and accessibility styles

### DIFF
--- a/apps/maximo-extension-ui/src/app/layout.tsx
+++ b/apps/maximo-extension-ui/src/app/layout.tsx
@@ -3,6 +3,7 @@ import '../styles/globals.css';
 import ThemeToggle from '../components/ThemeToggle';
 import DensityToggle from '../components/DensityToggle';
 import Footer from '../components/Footer';
+import PrintHotkey from '../components/PrintHotkey';
 import { apiFetch } from '../lib/api';
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
@@ -17,8 +18,9 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   return (
     <html lang="en" className="h-full">
       <body className="min-h-screen">
+        <PrintHotkey />
         <div className="flex min-h-screen flex-col">
-          <header className="flex h-12 items-center justify-between bg-[var(--mxc-topbar-bg)] px-4 text-[var(--mxc-topbar-fg)]">
+          <header className="flex h-12 items-center justify-between bg-[var(--mxc-topbar-bg)] px-4 text-[var(--mxc-topbar-fg)] print:hidden">
             <span className="font-semibold">Maximo Extension</span>
             <div className="flex gap-2">
               <ThemeToggle />
@@ -26,17 +28,19 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             </div>
           </header>
           <div className="flex flex-1 overflow-hidden">
-            <nav className="w-56 shrink-0 border-r border-[var(--mxc-border)] bg-[var(--mxc-nav-bg)] p-4 text-[var(--mxc-nav-fg)]">
+            <nav className="w-56 shrink-0 border-r border-[var(--mxc-border)] bg-[var(--mxc-nav-bg)] p-4 text-[var(--mxc-nav-fg)] print:hidden">
               <ul>
                 <li className="font-medium">Portfolio</li>
               </ul>
             </nav>
-            <div className="flex-1 overflow-auto p-4">{children}</div>
-            <aside className="w-64 shrink-0 border-l border-[var(--mxc-border)] bg-[var(--mxc-drawer-bg)] p-4 text-[var(--mxc-drawer-fg)]">
+            <div className="flex-1 overflow-auto p-4 print:p-0">{children}</div>
+            <aside className="w-64 shrink-0 border-l border-[var(--mxc-border)] bg-[var(--mxc-drawer-bg)] p-4 text-[var(--mxc-drawer-fg)] print:hidden">
               {/* Right drawer placeholder */}
             </aside>
           </div>
-          <Footer version={version} />
+          <div className="print:hidden">
+            <Footer version={version} />
+          </div>
         </div>
       </body>
     </html>

--- a/apps/maximo-extension-ui/src/components/PrintHotkey.tsx
+++ b/apps/maximo-extension-ui/src/components/PrintHotkey.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function PrintHotkey() {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'p' && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        const target = e.target as HTMLElement | null;
+        if (
+          target &&
+          (target instanceof HTMLInputElement ||
+            target instanceof HTMLTextAreaElement ||
+            target.isContentEditable)
+        ) {
+          return;
+        }
+        e.preventDefault();
+        window.print();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  return null;
+}

--- a/apps/maximo-extension-ui/src/styles/globals.css
+++ b/apps/maximo-extension-ui/src/styles/globals.css
@@ -9,4 +9,25 @@
     background-color: var(--mxc-bg);
     color: var(--mxc-fg);
   }
+
+  *:focus-visible {
+    outline: 2px solid var(--mxc-status-info);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation: none !important;
+      transition: none !important;
+    }
+  }
+
+  @media print {
+    body {
+      background-color: #ffffff;
+      color: #000000;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- handle "p" key to trigger browser print and apply print-friendly layout
- add focus-visible outlines and reduced-motion preference handling

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/app/layout.tsx apps/maximo-extension-ui/src/components/PrintHotkey.tsx apps/maximo-extension-ui/src/styles/globals.css`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68aa8eb76bdc832290c23720a10c2acc