### PR TITLE
Validate PID registry entries and surface warnings

### DIFF
--- a/tests/api/test_pid_overlay.py
+++ b/tests/api/test_pid_overlay.py
@@ -1,0 +1,27 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def test_overlay_returns_validation_warnings(tmp_path):
+    svg = tmp_path / "doc.svg"
+    svg.write_text("<svg xmlns='http://www.w3.org/2000/svg'><g id='a'/></svg>")
+
+    import apps.api.main as main
+
+    importlib.reload(main)
+
+    client = TestClient(main.app)
+
+    payload = {
+        "sources": [],
+        "asset": "A-100",
+        "plan": {"plan_id": "P1", "actions": [], "verifications": []},
+        "sim_fail_paths": [],
+        "pid_map": {"__svg__": str(svg), "T1": "#a", "T2": "#missing"},
+    }
+
+    res = client.post("/pid/overlay", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert "missing selector '#missing'" in data["warnings"]

--- a/tests/pid/test_schema.py
+++ b/tests/pid/test_schema.py
@@ -72,3 +72,25 @@ def test_load_registry_invalid_tag_map(tmp_path: Path) -> None:
     with pytest.raises(ValueError) as exc:
         load_registry(registry)
     assert str(tag_map) in str(exc.value)
+
+
+def test_load_registry_reports_warnings(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "doc.svg",
+        "<svg xmlns='http://www.w3.org/2000/svg'><g id='a'/></svg>",
+    )
+    _write(tmp_path, "map.yaml", "T1: '#a'\nT2: '#missing'\n")
+    registry = _write(
+        tmp_path,
+        "registry.yaml",
+        """
+        pids:
+          demo:
+            svg: doc.svg
+            tag_map: map.yaml
+        """.strip(),
+    )
+    loaded = load_registry(registry)
+    warnings = loaded.pids["demo"].warnings
+    assert "missing selector '#missing'" in warnings


### PR DESCRIPTION
## Summary
- validate P&ID registry entries against their SVGs and collect warnings
- expose registry warnings and ensure overlay endpoint returns validator messages
- test registry loading and API overlay warning propagation

## Testing
- `pre-commit run --files loto/pid/registry.py tests/pid/test_schema.py tests/api/test_pid_overlay.py`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68aa8fe29e408322a15822064314025d