### PR TITLE
Add warnings to PID overlay builder

### DIFF
--- a/apps/api/pid_endpoints.py
+++ b/apps/api/pid_endpoints.py
@@ -110,7 +110,11 @@ async def post_overlay(payload: OverlayRequest) -> OverlayResponse:
             sim_fail_paths=cast(List[Iterable[str]], payload.sim_fail_paths),
             map_path=map_path,
         )
-        warnings: List[str] = []
+
+        # Start with any warnings generated while building the overlay.  These
+        # typically indicate missing tag mappings.  We then extend this list
+        # with warnings discovered when validating the SVG against the tag map.
+        warnings: List[str] = list(cast(List[str], data.pop("warnings", [])))
         if svg_path_raw:
             svg_path = Path(svg_path_raw)
             if not svg_path.is_absolute():

--- a/loto/pid/overlay.py
+++ b/loto/pid/overlay.py
@@ -89,6 +89,7 @@ def build_overlay(
     badges: List[Dict[str, str]] = []
     paths: List[Dict[str, object]] = []
     missing: Set[str] = set()
+    warnings: List[str] = []
 
     asset_selectors = _selectors(asset, mapping)
     if asset_selectors:
@@ -130,12 +131,20 @@ def build_overlay(
                 if not _selectors(node, mapping):
                     missing.add(node)
 
-    if missing and asset_selectors:
-        for sel in asset_selectors:
-            badges.append({"selector": sel, "type": "warning"})
+    if missing:
+        # If any tag is missing a selector, attach a warning badge to the
+        # asset (if available) and surface the missing tags in the warnings
+        # list.  This allows the front-end to draw attention to the asset and
+        # display an explanatory message to the user.
+        if asset_selectors:
+            for sel in asset_selectors:
+                badges.append({"selector": sel, "type": "warning"})
+        for tag in sorted(missing):
+            warnings.append(f"missing selector for tag '{tag}'")
 
     return {
         "highlight": sorted(highlight),
         "badges": badges,
         "paths": paths,
+        "warnings": warnings,
     }

--- a/tests/test_overlay_golden.golden.json
+++ b/tests/test_overlay_golden.golden.json
@@ -1,0 +1,17 @@
+{
+  "highlight": [
+    "#A100",
+    "#SRC",
+    "#V101",
+    "#V102A",
+    "#V102B"
+  ],
+  "badges": [
+    {"selector": "#A100", "type": "asset"},
+    {"selector": "#SRC", "type": "source"}
+  ],
+  "paths": [
+    {"id": "path0", "selectors": ["#SRC", "#V101", "#A100"]}
+  ],
+  "warnings": []
+}

--- a/tests/test_overlay_golden.py
+++ b/tests/test_overlay_golden.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loto.models import IsolationAction, IsolationPlan
+from loto.pid import build_overlay
+
+
+@pytest.fixture
+def golden(request):
+    path = Path(request.node.fspath).with_suffix(".golden.json")
+    expected = json.loads(path.read_text())
+
+    def check(data: object) -> None:
+        assert data == expected
+
+    return check
+
+
+def test_overlay_golden(golden) -> None:
+    """Ensure overlay generation matches expected demo output."""
+
+    map_path = Path(__file__).resolve().parent.parent / "demo/pids/pid_map.yaml"
+
+    plan = IsolationPlan(
+        plan_id="P1",
+        actions=[
+            IsolationAction(component_id="process:src->V-101", method="lock"),
+            IsolationAction(component_id="process:src->V-102", method="lock"),
+        ],
+    )
+
+    overlay = build_overlay(
+        sources=["src"],
+        asset="A-100",
+        plan=plan,
+        sim_fail_paths=[["src", "V-101", "A-100"]],
+        map_path=map_path,
+    )
+
+    golden(overlay)


### PR DESCRIPTION
## Summary
- surface missing PID tag mappings as warnings
- combine overlay and validation warnings in PID API
- add golden test verifying overlay JSON for demo map

## Testing
- `pre-commit run --files apps/api/pid_endpoints.py loto/pid/overlay.py tests/test_overlay_golden.py tests/test_overlay_golden.golden.json`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68aa91b7c6fc8322b6da12759f78b068