### PR TITLE
feat: gate work orders by low inventory

### DIFF
--- a/apps/api/demo_data.py
+++ b/apps/api/demo_data.py
@@ -16,7 +16,11 @@ class DemoDataSource:
         self.locations: List[Dict[str, Any]] = self._load_list("locations.json")
         self.inventory: List[Dict[str, Any]] = self._load_list("inventory.json")
         self.blueprints: Dict[str, Dict[str, Any]] = self._load_dict("blueprints.json")
+        self.boms: List[Dict[str, Any]] = self._load_list("bom.json")
         self._work_orders_by_id = {wo["id"]: wo for wo in self.work_orders}
+        self._bom_by_wo: Dict[str, List[Dict[str, Any]]] = {}
+        for line in self.boms:
+            self._bom_by_wo.setdefault(line["workorder"], []).append(line)
         self.asset_ids = {asset["id"] for asset in self.assets}
         self.location_ids = {loc["id"] for loc in self.locations}
 
@@ -40,6 +44,11 @@ class DemoDataSource:
 
     def get_blueprint(self, work_order_id: str) -> Dict[str, Any] | None:
         return self.blueprints.get(work_order_id)
+
+    def get_bom(self, work_order_id: str) -> List[Dict[str, Any]]:
+        """Return bill-of-material lines for ``work_order_id``."""
+
+        return list(self._bom_by_wo.get(work_order_id, []))
 
     def validate(self) -> Dict[str, List[Dict[str, str | None]]]:
         """Check referential integrity of work orders.

--- a/apps/api/demo_data/bom.json
+++ b/apps/api/demo_data/bom.json
@@ -1,0 +1,4 @@
+[
+  {"workorder": "WO-1", "item_id": "P-100", "quantity": 1, "critical": false},
+  {"workorder": "WO-1", "item_id": "P-200", "quantity": 1, "critical": true}
+]

--- a/apps/api/demo_data/inventory.json
+++ b/apps/api/demo_data/inventory.json
@@ -1,4 +1,4 @@
 [
-  {"id": "P-100", "available": 5},
-  {"id": "P-200", "available": 1}
+  {"id": "P-100", "available": 5, "reorder_point": 0},
+  {"id": "P-200", "available": 1, "reorder_point": 0}
 ]

--- a/apps/maximo-extension-ui/src/mocks/workorder.ts
+++ b/apps/maximo-extension-ui/src/mocks/workorder.ts
@@ -4,7 +4,8 @@ export async function fetchWorkOrder(id: string): Promise<WorkOrderSummary> {
   return {
     id,
     description: 'Example work order',
-    status: 'WAPPR'
+    status: 'WAPPR',
+    blocked_by_parts: false
   };
 }
 

--- a/apps/maximo-extension-ui/src/types/api.ts
+++ b/apps/maximo-extension-ui/src/types/api.ts
@@ -5,6 +5,7 @@ export interface WorkOrderSummary {
   owner?: string;
   plannedStart?: string;
   plannedFinish?: string;
+  blocked_by_parts?: boolean;
 }
 
 export interface BlueprintStep {

--- a/loto/integrations/stores_adapter.py
+++ b/loto/integrations/stores_adapter.py
@@ -40,8 +40,8 @@ class DemoStoresAdapter(StoresAdapter):
     """Dry-run stores adapter that fabricates pick list identifiers."""
 
     _INVENTORY = {
-        "P-100": {"available": 5},
-        "P-200": {"available": 1},
+        "P-100": {"available": 5, "reorder_point": 0},
+        "P-200": {"available": 1, "reorder_point": 0},
     }
 
     def create_pick_list(self, part_number: str, quantity: int) -> str:

--- a/tests/api/test_schedule.py
+++ b/tests/api/test_schedule.py
@@ -35,9 +35,9 @@ def test_schedule_inventory_gating(monkeypatch):
     importlib.reload(main)
     client = TestClient(main.app)
     monkeypatch.setattr(main, "authenticate_user", lambda *a, **kw: _planner())
-    original = DemoStoresAdapter._INVENTORY["P-200"]["available"]
+    original = DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"]
     try:
-        DemoStoresAdapter._INVENTORY["P-200"]["available"] = 0
+        DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"] = 2
         res = client.post(
             "/schedule",
             json={"workorder": "WO-1"},
@@ -50,16 +50,16 @@ def test_schedule_inventory_gating(monkeypatch):
         assert data["schedule"] == []
         assert data["rulepack_sha256"] == main.RULE_PACK_HASH
     finally:
-        DemoStoresAdapter._INVENTORY["P-200"]["available"] = original
+        DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"] = original
 
 
 def test_schedule_inventory_gating_strict(monkeypatch):
     importlib.reload(main)
     client = TestClient(main.app)
     monkeypatch.setattr(main, "authenticate_user", lambda *a, **kw: _planner())
-    original = DemoStoresAdapter._INVENTORY["P-200"]["available"]
+    original = DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"]
     try:
-        DemoStoresAdapter._INVENTORY["P-200"]["available"] = 0
+        DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"] = 2
         res = client.post(
             "/schedule?strict=true",
             json={"workorder": "WO-1"},
@@ -73,4 +73,4 @@ def test_schedule_inventory_gating_strict(monkeypatch):
             {"item_id": "P-200", "quantity": 1}
         ]
     finally:
-        DemoStoresAdapter._INVENTORY["P-200"]["available"] = original
+        DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"] = original

--- a/tests/api/test_workorder_parts.py
+++ b/tests/api/test_workorder_parts.py
@@ -1,0 +1,30 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+import apps.api.main as main
+from loto.integrations.stores_adapter import DemoStoresAdapter
+
+
+def _client():
+    importlib.reload(main)
+    return TestClient(main.app)
+
+
+def test_workorder_blocked_by_parts(monkeypatch):
+    client = _client()
+    original = DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"]
+    try:
+        DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"] = 2
+        res = client.get("/workorders/WO-1")
+        assert res.status_code == 200
+        assert res.json()["blocked_by_parts"] is True
+    finally:
+        DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"] = original
+
+
+def test_workorder_not_blocked(monkeypatch):
+    client = _client()
+    res = client.get("/workorders/WO-1")
+    assert res.status_code == 200
+    assert res.json()["blocked_by_parts"] is False

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -55,23 +55,23 @@ def test_blueprint_inventory_gating(monkeypatch):
         "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
     )
     client = TestClient(app)
-    original = DemoStoresAdapter._INVENTORY["P-200"]["available"]
+    original = DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"]
     try:
-        DemoStoresAdapter._INVENTORY["P-200"]["available"] = 0
+        DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"] = 2
         res = client.post("/blueprint", json={"workorder_id": "WO-1"})
         assert res.status_code == 202
         job = res.json()["job_id"]
         data = wait_for_job(client, job)["result"]
         assert data["blocked_by_parts"] is True
 
-        DemoStoresAdapter._INVENTORY["P-200"]["available"] = 1
+        DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"] = 0
         res = client.post("/blueprint", json={"workorder_id": "WO-1"})
         assert res.status_code == 202
         job = res.json()["job_id"]
         data = wait_for_job(client, job)["result"]
         assert data["blocked_by_parts"] is False
     finally:
-        DemoStoresAdapter._INVENTORY["P-200"]["available"] = original
+        DemoStoresAdapter._INVENTORY["P-200"]["reorder_point"] = original
 
 
 def test_ingest_inventory_normalizes_units():


### PR DESCRIPTION
## Summary
- block planning when critical BOM items fall below reorder level
- expose `blocked_by_parts` on work order API responses and UI types
- cover part gating in schedule, blueprint, and work order tests

## Testing
- `make lint`
- `make typecheck`
- `pnpm -F maximo-extension-ui test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68aa9e7a2d6c8322bffbf19b28192765