### PR TITLE
Enforce env prerequisites and document configuration

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,11 @@ MAXIMO_BASE_URL=https://example.com
 MAXIMO_APIKEY=changeme
 MAXIMO_OS_WORKORDER=WORKORDER
 MAXIMO_OS_ASSET=ASSET
+OIDC_CLIENT_ID=your-client-id
+OIDC_CLIENT_SECRET=your-client-secret
+OIDC_ISSUER=https://example.com/
+OIDC_SERVER=https://example.com/
+OIDC_AUDIENCE=your-client-id
 NEXT_PUBLIC_USE_API=false
 # Allowed origins for the pilot deployment
 CORS_ORIGINS=http://localhost:3000,https://loto.example.com

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,15 @@ COUPA_APIKEY=changeme
 HATS_LEDGER_PATH=hats_ledger.jsonl
 HATS_SNAPSHOT_PATH=hats_snapshot.json
 
+# OIDC configuration
+OIDC_CLIENT_ID=your-client-id
+OIDC_CLIENT_SECRET=your-client-secret
+OIDC_ISSUER=https://example.com/
+OIDC_SERVER=https://example.com/
+OIDC_AUDIENCE=your-client-id
+OIDC_CACHE_TTL=3600
+PLANNER_EMAIL_DOMAIN=
+
 ## API configuration
 NEXT_PUBLIC_USE_API=false
 NEXT_PUBLIC_ROLE=TEST

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Copy `.env.example` to `.env` and fill in values as needed:
 cp .env.example .env
 ```
 
-Required variables:
+Mandatory variables:
 
 ```dotenv
 MAXIMO_BASE_URL=https://example.com
@@ -52,7 +52,14 @@ MAXIMO_APIKEY=changeme
 MAXIMO_OS_WORKORDER=WORKORDER
 MAXIMO_OS_ASSET=ASSET
 NEXT_PUBLIC_USE_API=false
+OIDC_CLIENT_ID=your-client-id
+OIDC_CLIENT_SECRET=your-client-secret
+OIDC_ISSUER=https://example.com/
 ```
+
+Optional settings such as `SENTRY_DSN`, `WAPR_*`, `COUPA_*`, and
+authentication toggles (`AUTH_REQUIRED`, `JWT_SECRET`, etc.) are documented in
+`.env.example`.
 
 ## Local Development
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -86,6 +86,17 @@ from .audit import add_record
 configure_logging()
 validate_env_vars()
 
+_required_env = [
+    "MAXIMO_BASE_URL",
+    "MAXIMO_APIKEY",
+    "OIDC_CLIENT_ID",
+    "OIDC_CLIENT_SECRET",
+    "OIDC_ISSUER",
+]
+_missing = [k for k in _required_env if not os.getenv(k)]
+if _missing:
+    raise RuntimeError("Missing required environment variables: " + ", ".join(_missing))
+
 ENV = os.getenv("APP_ENV", "").lower()
 if ENV == "live":
     ENV_BADGE = "PROD"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,6 +2,18 @@
 
 The `prod.env` file contains non-secret configuration. Real credentials such as `MAXIMO_APIKEY` are stored in the team vault.
 
+## Environment variables
+
+Mandatory:
+
+- `MAXIMO_BASE_URL`
+- `MAXIMO_APIKEY`
+- `OIDC_CLIENT_ID`
+- `OIDC_CLIENT_SECRET`
+- `OIDC_ISSUER`
+
+Optional values like `SENTRY_DSN` or `WAPR_*` are documented in `.env.example`.
+
 To populate `prod.env` with secrets:
 
 1. Authenticate to the vault (`op signin` for 1Password or `vault login` for HashiCorp Vault).

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 missing=0
 
+if [ -f .env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source .env
+    set +a
+fi
+
 check_cmd() {
     local cmd="$1"
     local hint="$2"
@@ -24,5 +31,19 @@ else
     echo "python3 not installed. Install from your package manager or https://www.python.org/downloads/"
     missing=1
 fi
+
+check_env() {
+    local var="$1"
+    if [ -z "${!var:-}" ]; then
+        echo "$var not set. Populate it in .env or the environment."
+        missing=1
+    fi
+}
+
+check_env MAXIMO_BASE_URL
+check_env MAXIMO_APIKEY
+check_env OIDC_CLIENT_ID
+check_env OIDC_CLIENT_SECRET
+check_env OIDC_ISSUER
 
 exit "$missing"


### PR DESCRIPTION
## Summary
- add OIDC variables to environment templates and validate required secrets on API startup
- extend `check-prereqs.sh` to verify mandatory environment variables alongside tool dependencies
- document mandatory vs optional variables in README and deployment guide

## Testing
- `pre-commit run --files .env.example .env scripts/check-prereqs.sh apps/api/main.py README.md docs/DEPLOYMENT.md`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make check-prereqs`

------
https://chatgpt.com/codex/tasks/task_b_68aaa10f523c83229ab786a6ccffad53