### PR TITLE
feat: add observability

### DIFF
--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+import json
 
 import pytest
 
 from loto.config import ConfigError, validate_env_vars
+from loto.loggers import configure_logging
 
 
 def test_validate_env_vars_reports_missing(monkeypatch, capsys):
@@ -13,11 +15,11 @@ def test_validate_env_vars_reports_missing(monkeypatch, capsys):
     assert any(line.startswith(f"{key}=") for line in example.read_text().splitlines())
     monkeypatch.delenv(key, raising=False)
 
+    configure_logging()
     with pytest.raises(ConfigError):
         validate_env_vars(example)
 
-    out = capsys.readouterr().out
-    assert key in out
-    lines = out.strip().splitlines()
-    row = next(line for line in lines if key in line)
-    assert row.rstrip().endswith("N")
+    captured = capsys.readouterr()
+    lines = (captured.out + captured.err).strip().splitlines()
+    msgs = [json.loads(json.loads(line)["msg"])["msg"] for line in lines if line]
+    assert any(key in msg and msg.rstrip().endswith("N") for msg in msgs)


### PR DESCRIPTION
## Summary
- export request, rate-limit, and job metrics at `/metrics`
- instrument blueprint and schedule jobs with OpenTelemetry spans
- emit structured JSON logs with request IDs and optional trace export

## Testing
- `pre-commit run --files loto/loggers.py apps/api/main.py tests/api/test_logging.py tests/test_env_validation.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68aad05396348322b1ca877a2d15c5bb