### PR TITLE
feat: expand health checks

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -4,7 +4,7 @@ This directory contains a minimal [FastAPI](https://fastapi.tiangolo.com/) servi
 
 ## Endpoints
 
-- `GET /healthz` – basic health check.
+- `GET /healthz` – readiness check reporting rate limits, adapter and database status.
 - `GET /version` – return the application version.
 - `POST /blueprint` – placeholder accepting a CSV upload or work order ID.
 - `POST /schedule` – placeholder endpoint for creating schedules.

--- a/tests/api/test_healthz.py
+++ b/tests/api/test_healthz.py
@@ -3,7 +3,7 @@ import importlib
 from fastapi.testclient import TestClient
 
 
-def test_healthz_reports_rate_limit(monkeypatch):
+def test_healthz_reports_components(monkeypatch):
     monkeypatch.setenv("RATE_LIMIT_CAPACITY", "5")
     monkeypatch.setenv("RATE_LIMIT_INTERVAL", "30")
     import apps.api.main as main
@@ -16,12 +16,32 @@ def test_healthz_reports_rate_limit(monkeypatch):
     data = res.json()
     assert data["rate_limit"]["capacity"] == 5
     assert data["rate_limit"]["interval"] == 30.0
-    for path in main.RATE_LIMIT_PATHS:
-        assert path in data["rate_limit"]["counters"]
-    assert res.headers["X-Env"] == main.ENV_BADGE
+    assert data["adapters"]["maximo"]["status"] == "mock"
+    assert data["adapters"]["coupa"]["status"] == "mock"
+    assert data["db"]["head"] == "0002"
     assert data["integrity"]["missing_assets"] == 0
     assert data["integrity"]["missing_locations"] == 0
 
     monkeypatch.setenv("RATE_LIMIT_CAPACITY", "100000")
     monkeypatch.setenv("RATE_LIMIT_INTERVAL", "60")
     importlib.reload(main)
+
+
+def test_healthz_fails_on_missing_demo_data(monkeypatch):
+    import apps.api.main as main
+
+    importlib.reload(main)
+    monkeypatch.setattr(
+        main.demo_data,
+        "validate",
+        lambda: {
+            "missing_assets": [{"workorder": "1", "assetnum": None}],
+            "missing_locations": [],
+        },
+    )
+    client = TestClient(main.app)
+    res = client.get("/healthz")
+    assert res.status_code == 503
+    data = res.json()
+    assert data["missing_assets"] == 1
+    assert data["missing_locations"] == 0


### PR DESCRIPTION
## Summary
- expand `/healthz` with adapter pings and database revision info
- error when demo data integrity fails
- document enriched health endpoint

## Testing
- `pre-commit run --files apps/api/main.py apps/api/README.md tests/api/test_healthz.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68aad52a140c83228c977f2fd779251f