### PR TITLE
Add single-command demo Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint typecheck test run-demo demo-up check-prereqs seed-demo
+.PHONY: fmt lint typecheck test run-demo demo-up demo-down check-prereqs seed-demo
 
 fmt:
 	black loto apps/api tests
@@ -14,7 +14,7 @@ test:
 	pytest
 
 run-demo:
-	python -m loto.cli demo
+	$(MAKE) demo-up
 
 demo-up:
 	@COMPOSE="docker compose"; \
@@ -26,7 +26,7 @@ demo-up:
 	echo "Docker Compose is not installed. Install Docker and Docker Compose."; \
 	exit 1; \
 	fi; \
-	$$COMPOSE up --build -d; \
+        $$COMPOSE --profile demo up --build -d; \
 	end_time=$$(($(date +%s)+30)); \
 	until curl --silent --fail http://localhost:8000/healthz >/dev/null 2>&1; do \
 	[ $$(date +%s) -ge $$end_time ] && { echo "Health check failed"; exit 1; }; \
@@ -37,7 +37,19 @@ demo-up:
 	elif command -v open >/dev/null 2>&1; then \
 	open http://localhost:3000; \
 	fi; \
-	$$COMPOSE logs -f
+        $$COMPOSE --profile demo logs -f
+
+demo-down:
+        @COMPOSE="docker compose"; \
+        if docker compose version >/dev/null 2>&1; then \
+        COMPOSE="docker compose"; \
+        elif command -v docker-compose >/dev/null 2>&1; then \
+        COMPOSE="docker-compose"; \
+        else \
+        echo "Docker Compose is not installed. Install Docker and Docker Compose."; \
+        exit 1; \
+        fi; \
+        $$COMPOSE --profile demo down -v
 
 check-prereqs:
 	./scripts/check-prereqs.sh

--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ launch the API with `uvicorn loto.main:app --reload` which will listen on
 Run the API and UI with demo data using Docker. Ensure Docker and Docker Compose are installed and the Docker daemon is running:
 
 ```bash
-docker compose --profile demo up
+make run-demo
+```
+
+This builds the API and UI, waits for the health check to pass, and opens the UI in your browser. To stop the stack:
+
+```bash
+make demo-down
 ```
 
 To start the pilot stack, which includes a Postgres service:
@@ -100,10 +106,10 @@ curl :8000/version
 Open the UI in your browser to view the Portfolio page at
 <http://localhost:3000>.
 
-To run the CLI demo instead:
+To run the CLI demo:
 
 ```bash
-make run-demo
+python -m loto.cli demo
 ```
 
 ## On-Call Support


### PR DESCRIPTION
## Summary
- Add run-demo target that builds services, waits for health check, and opens the UI
- Provide demo-up and demo-down helpers using Docker Compose demo profile
- Update README with new demo instructions and CLI demo command

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files Makefile README.md`


------
https://chatgpt.com/codex/tasks/task_b_68ab54ac491483228e5f43af2d128503