### PR TITLE
docs: expand pilot runbook

### DIFF
--- a/docs/PILOT_RUNBOOK.md
+++ b/docs/PILOT_RUNBOOK.md
@@ -9,6 +9,53 @@ This runbook describes the pilot workflow from generation through attachment.
 3. **Export** – Convert the reviewed artifact into the approved format.
 4. **Attach** – Upload the exported bundle to the system of record.
 
+## Demo quickstart
+
+1. **Set environment**
+   ```bash
+   cp .env.example .env
+   export MAXIMO_BASE_URL=https://example.com
+   export MAXIMO_APIKEY=changeme
+   export MAXIMO_OS_WORKORDER=WORKORDER
+   export MAXIMO_OS_ASSET=ASSET
+   export NEXT_PUBLIC_USE_API=false
+   ```
+   Ensure Docker is running and the above variables reflect your test endpoints.
+
+2. **Start demo stack**
+   ```bash
+   make run-demo
+   ```
+   The API health check at `http://localhost:8000/healthz` must return `{"status":"ok"}` before continuing.
+
+3. **Use sample work orders**
+   - `WO-1` – Pump replacement
+   - `WO-2` – Motor upgrade
+   - `WO-3` – Energy audit
+
+4. **Export a PDF**
+   ```bash
+   python -m loto.cli demo --out out
+   ```
+   The file `out/LOTO_A.pdf` is ready for distribution. Remove the output with `rm -rf out` if regeneration is required.
+
+5. **Stop demo stack**
+   ```bash
+   make demo-down
+   ```
+
+## Rollback
+
+- Stop all services and remove volumes:
+  ```bash
+  make demo-down
+  ```
+- Rebuild from a clean state:
+  ```bash
+  make run-demo
+  ```
+- Escalate to on-call support for prod rollbacks. All deadlines remain in New Zealand time; e.g. `2024-08-15 09:00 NZST (UTC+12)`.
+
 ## Data flow
 
 Source data enters the pipeline, is processed by the pilot tools,


### PR DESCRIPTION
## Summary
- document demo quickstart with environment variables and sample work orders
- describe commands to export PDFs and stop the stack
- outline rollback steps with New Zealand time references

## Testing
- `pre-commit run --files docs/PILOT_RUNBOOK.md`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ab57e6bf3c8322b13a39dbee50ba38