### PR TITLE
refactor: replace deprecated pydantic methods

### DIFF
--- a/loto/renderer.py
+++ b/loto/renderer.py
@@ -272,8 +272,8 @@ class Renderer:
             return {k: v for k, v in items}
 
         payload: Dict[str, Any] = {
-            "plan": plan.dict(exclude_none=True),
-            "simulation": sim_report.dict(exclude_none=True),
+            "plan": plan.model_dump(exclude_none=True),
+            "simulation": sim_report.model_dump(exclude_none=True),
         }
 
         if impact:

--- a/loto/service/blueprints.py
+++ b/loto/service/blueprints.py
@@ -137,7 +137,7 @@ def plan_and_evaluate(
         asset_areas=asset_areas,
     )
 
-    rule_hash = hashlib.sha256(rule_pack.json().encode()).hexdigest()
+    rule_hash = hashlib.sha256(rule_pack.model_dump_json().encode()).hexdigest()
     provenance = Provenance(seed=seed, rule_hash=rule_hash)
 
     return plan, report, impact, provenance


### PR DESCRIPTION
## Summary
- replace dict/json with model_dump/model_dump_json in renderer and service blueprints

## Testing
- `pre-commit run --files loto/renderer.py loto/service/blueprints.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ab819839e08322ba9685d51eebaead