### PR TITLE
feat: add Coupa urgent enquiry support

### DIFF
--- a/loto/integrations/coupa_adapter.py
+++ b/loto/integrations/coupa_adapter.py
@@ -112,13 +112,50 @@ class HttpCoupaAdapter(CoupaAdapter):
             return cast(Dict[str, Any], resp.json())
         raise RuntimeError("Unreachable")
 
-    # Real implementations would call Coupa endpoints. For now these
-    # methods simply raise ``NotImplementedError`` to satisfy the abstract
-    # interface without performing any actions.
-    def raise_urgent_enquiry(
-        self, part_number: str, quantity: int
-    ) -> str:  # pragma: no cover - stub
-        raise NotImplementedError
+    def _post(self, path: str, json: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
+        headers = {"apikey": self.apikey} if self.apikey else {}
+        backoff = 1.0
+        for attempt in range(self._retries):
+            try:
+                resp = self._session.post(
+                    url, headers=headers, json=json, timeout=self._timeout
+                )
+            except requests.RequestException as exc:
+                if attempt == self._retries - 1:
+                    raise AdapterRequestError(status_code=0, retry_after=None) from exc
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+
+            status = resp.status_code
+            if status == 429 or status >= 500:
+                retry_after_header = resp.headers.get("Retry-After")
+                try:
+                    retry_after = (
+                        float(retry_after_header) if retry_after_header else None
+                    )
+                except ValueError:
+                    retry_after = None
+                if attempt == self._retries - 1:
+                    raise AdapterRequestError(
+                        status_code=status, retry_after=retry_after
+                    )
+                time.sleep(retry_after or backoff)
+                backoff *= 2
+                continue
+
+            if status >= 400:
+                raise AdapterRequestError(status_code=status, retry_after=None)
+
+            return cast(Dict[str, Any], resp.json())
+        raise RuntimeError("Unreachable")
+
+    def raise_urgent_enquiry(self, part_number: str, quantity: int) -> str:
+        """Raise an urgent enquiry (RFQ) for a part via Coupa."""
+        payload = {"part_number": part_number, "quantity": quantity}
+        data = self._post("rfqs", json=payload)
+        return cast(str, data.get("id", ""))
 
     def get_po_status(self, po_number: str) -> str:  # pragma: no cover - stub
         data = self._get(f"po/{po_number}")

--- a/tests/integrations/test_coupa_raise_urgent_enquiry.py
+++ b/tests/integrations/test_coupa_raise_urgent_enquiry.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+import pytest
+from pytest import MonkeyPatch
+
+from loto.integrations._errors import AdapterRequestError
+from loto.integrations.coupa_adapter import HttpCoupaAdapter
+
+
+class DummyResponse:
+    def __init__(
+        self,
+        status_code: int,
+        data: Dict[str, Any] | None = None,
+        headers: Dict[str, str] | None = None,
+    ):
+        self.status_code = status_code
+        self._data = data or {}
+        self.headers = headers or {}
+
+    def json(self) -> Dict[str, Any]:
+        return self._data
+
+
+def _set_coupa_env(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("COUPA_BASE_URL", "http://coupa.local")
+    monkeypatch.setenv("COUPA_APIKEY", "secret")
+
+
+def test_raise_urgent_enquiry_retry(monkeypatch: MonkeyPatch) -> None:
+    _set_coupa_env(monkeypatch)
+    adapter = HttpCoupaAdapter()
+    calls = {"count": 0}
+
+    def fake_post(
+        url: str,
+        headers: Dict[str, str] | None = None,
+        json: Dict[str, Any] | None = None,
+        timeout: tuple[float, float] | None = None,
+    ) -> DummyResponse:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return DummyResponse(429, headers={"Retry-After": "2"})
+        assert json == {"part_number": "P-1", "quantity": 5}
+        return DummyResponse(201, data={"id": "RFQ-123"})
+
+    monkeypatch.setattr(adapter._session, "post", fake_post)
+
+    sleeps: list[float] = []
+
+    def fake_sleep(s: float) -> None:
+        sleeps.append(s)
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+    rfq_id = adapter.raise_urgent_enquiry("P-1", 5)
+    assert rfq_id == "RFQ-123"
+    assert sleeps == [2.0]
+
+
+def test_raise_urgent_enquiry_error(monkeypatch: MonkeyPatch) -> None:
+    _set_coupa_env(monkeypatch)
+    adapter = HttpCoupaAdapter()
+
+    def fake_post(
+        url: str,
+        headers: Dict[str, str] | None = None,
+        json: Dict[str, Any] | None = None,
+        timeout: tuple[float, float] | None = None,
+    ) -> DummyResponse:
+        return DummyResponse(500)
+
+    monkeypatch.setattr(adapter._session, "post", fake_post)
+
+    def fake_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+    with pytest.raises(AdapterRequestError) as excinfo:
+        adapter.raise_urgent_enquiry("P-1", 5)
+    err = excinfo.value
+    assert err.status_code == 500
+    assert err.retry_after is None


### PR DESCRIPTION
## Summary
- add HTTP POST helper with retry/backoff for Coupa requests
- implement `raise_urgent_enquiry` to create RFQs via Coupa API
- cover Coupa urgent enquiry with retry and error tests

## Testing
- `pre-commit run --files loto/integrations/coupa_adapter.py tests/integrations/test_coupa_raise_urgent_enquiry.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ab922c434c8322a48599b793009244