### PR TITLE
Add permit controls to work order

### DIFF
--- a/apps/api/demo_data/workorders.json
+++ b/apps/api/demo_data/workorders.json
@@ -7,7 +7,11 @@
     "plannedStart": "2024-05-01",
     "plannedFinish": "2024-05-03",
     "assetnum": "A-1",
-    "location": "L-1"
+    "location": "L-1",
+    "permitId": "PRM-1",
+    "permitVerified": false,
+    "permitRequired": true,
+    "isolationRef": "ISO-1"
   },
   {
     "id": "WO-2",
@@ -17,7 +21,11 @@
     "plannedStart": "2024-05-10",
     "plannedFinish": "2024-05-12",
     "assetnum": "A-2",
-    "location": "L-2"
+    "location": "L-2",
+    "permitId": "PRM-2",
+    "permitVerified": true,
+    "permitRequired": true,
+    "isolationRef": "ISO-2"
   },
   {
     "id": "WO-3",
@@ -27,6 +35,10 @@
     "plannedStart": "2024-04-20",
     "plannedFinish": "2024-04-21",
     "assetnum": "A-1",
-    "location": "L-1"
+    "location": "L-1",
+    "permitId": "PRM-3",
+    "permitVerified": false,
+    "permitRequired": true,
+    "isolationRef": "ISO-3"
   }
 ]

--- a/apps/api/workorder_endpoints.py
+++ b/apps/api/workorder_endpoints.py
@@ -26,6 +26,24 @@ class WorkOrderSummary(BaseModel):
     )
     assetnum: str | None = Field(None, description="Associated asset identifier")
     location: str | None = Field(None, description="Associated location identifier")
+    permit_id: str | None = Field(
+        None,
+        alias="permitId",
+        description="Permit identifier",
+        max_length=40,
+    )
+    permit_verified: bool | None = Field(
+        False, alias="permitVerified", description="Permit has been verified"
+    )
+    permit_required: bool = Field(
+        True, alias="permitRequired", description="Permit is required"
+    )
+    isolation_ref: str | None = Field(
+        None,
+        alias="isolationRef",
+        description="Reference to isolation procedure",
+        max_length=80,
+    )
     blocked_by_parts: bool = Field(
         False, description="True if scheduling is blocked due to parts"
     )

--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx
@@ -64,6 +64,47 @@ function PlannerContent({ wo }: { wo: string }) {
         WO Planner: {workOrder.id}
       </h1>
       <Exports wo={workOrder.id} />
+      <section className="mb-4 border p-4">
+        <h2 className="mb-2 font-semibold">Permit Controls</h2>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <label className="flex flex-col">
+            <span className="text-sm font-medium">Permit ID</span>
+            <input
+              type="text"
+              value={workOrder.permitId ?? ''}
+              readOnly
+              className="border px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col">
+            <span className="text-sm font-medium">Permit Required</span>
+            <input
+              type="text"
+              value={workOrder.permitRequired ? 'Y' : 'N'}
+              readOnly
+              className="border px-2 py-1"
+            />
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={workOrder.permitVerified ?? false}
+              disabled
+              className="h-4 w-4"
+            />
+            <span className="text-sm font-medium">Permit Verified</span>
+          </label>
+          <label className="flex flex-col sm:col-span-2">
+            <span className="text-sm font-medium">Isolation Reference</span>
+            <input
+              type="text"
+              value={workOrder.isolationRef ?? ''}
+              readOnly
+              className="border px-2 py-1"
+            />
+          </label>
+        </div>
+      </section>
       <div className="flex h-full">
         <div className="flex-1 pr-4">
           <div role="tablist" className="mb-4 border-b">

--- a/apps/maximo-extension-ui/src/mocks/workorder.ts
+++ b/apps/maximo-extension-ui/src/mocks/workorder.ts
@@ -5,6 +5,10 @@ export async function fetchWorkOrder(id: string): Promise<WorkOrderSummary> {
     id,
     description: 'Example work order',
     status: 'WAPPR',
+    permitId: 'PRM-MOCK',
+    permitVerified: false,
+    permitRequired: true,
+    isolationRef: 'ISO-MOCK',
     blocked_by_parts: false
   };
 }

--- a/apps/maximo-extension-ui/src/types/api.ts
+++ b/apps/maximo-extension-ui/src/types/api.ts
@@ -5,6 +5,10 @@ export interface WorkOrderSummary {
   owner?: string;
   plannedStart?: string;
   plannedFinish?: string;
+  permitId?: string;
+  permitVerified?: boolean;
+  permitRequired?: boolean;
+  isolationRef?: string;
   blocked_by_parts?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- extend work order model with permit metadata
- surface permit fields in planner UI

## Testing
- `pre-commit run --files apps/api/workorder_endpoints.py apps/api/demo_data/workorders.json apps/maximo-extension-ui/src/app/planner/[wo]/page.tsx apps/maximo-extension-ui/src/mocks/workorder.ts apps/maximo-extension-ui/src/types/api.ts`
- `make lint`
- `make typecheck`
- `make test`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`


------
https://chatgpt.com/codex/tasks/task_b_68abc406d74c8322a7c56c58b8038887