### PR TITLE
Add Permit/LOTO document category to generated doclinks

### DIFF
--- a/docs/LOTO_A.json
+++ b/docs/LOTO_A.json
@@ -1,5 +1,6 @@
 {
   "document": "LOTO_A",
+  "category": "Permit/LOTO",
   "annotations": [
     {"step": 1, "note": "Tagged disconnects"},
     {"step": 2, "note": "Confirm zero energy state"}

--- a/loto/cli.py
+++ b/loto/cli.py
@@ -176,6 +176,7 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     # Render outputs
     json_output = renderer.to_json(plan, sim_report)
+    json_output["category"] = "Permit/LOTO"
     rule_hash = rule_engine.hash(rule_pack)
     pdf_bytes = renderer.pdf(plan, sim_report, rule_hash, seed=None, timezone="UTC")
 

--- a/tests/test_cli_golden.py
+++ b/tests/test_cli_golden.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -23,3 +24,6 @@ def test_demo_command_creates_doclinks(tmp_path: Path) -> None:
     assert len(pdfs) == 1
     assert len(jsons) == 1
     assert pdfs[0].stem == jsons[0].stem
+    with jsons[0].open() as f:
+        data = json.load(f)
+    assert data.get("category") == "Permit/LOTO"


### PR DESCRIPTION
## Summary
- Embed `Permit/LOTO` category in generated doclink JSON
- Verify category through demo CLI golden test

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files docs/LOTO_A.json loto/cli.py tests/test_cli_golden.py`


------
https://chatgpt.com/codex/tasks/task_b_68abcc4c330c8322a193fe076dc847d8