### PR TITLE
Enforce permit readiness before starting work orders

### DIFF
--- a/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx
@@ -20,6 +20,14 @@ test('renders 6 tabs', async () => {
   expect(tabs).toHaveLength(6);
 });
 
+test('renders permit controls', async () => {
+  render(<Page params={{ wo: 'WO-1' }} />);
+  await screen.findByText('Permit Controls');
+  expect(screen.getByDisplayValue('PRM-MOCK')).toBeInTheDocument();
+  const checkbox = screen.getByLabelText('Permit Verified') as HTMLInputElement;
+  expect(checkbox.disabled).toBe(true);
+});
+
 test('renders export buttons', () => {
   render(<Page params={{ wo: 'WO-1' }} />);
   expect(screen.getAllByText('Export PDF').length).toBeGreaterThan(0);

--- a/loto/permits.py
+++ b/loto/permits.py
@@ -1,0 +1,85 @@
+"""Permit readiness utilities and conditional expression management."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+
+class ConditionalExpressionManager:
+    """Simple manager for named conditional expressions.
+
+    Expressions use a limited SQL-like syntax with ``:name`` placeholders.
+    Currently supported operations:
+    - ``:field IS NOT NULL``
+    - ``:field = <literal>`` with integer or quoted string literals
+    Expressions may be combined using ``AND``.
+    """
+
+    def __init__(self) -> None:
+        self._exprs: Dict[str, str] = {}
+
+    def register(self, name: str, expression: str) -> None:
+        """Register a new expression under ``name``."""
+
+        self._exprs[name] = expression
+
+    def evaluate(self, name: str, values: Mapping[str, Any]) -> bool:
+        """Evaluate expression ``name`` against ``values``."""
+
+        expr = self._exprs[name]
+        parts = [p.strip() for p in expr.split("AND")]
+        return all(self._eval_part(part, values) for part in parts)
+
+    def _eval_part(self, part: str, values: Mapping[str, Any]) -> bool:
+        if part.endswith("IS NOT NULL"):
+            field = part.split()[0][1:]
+            return values.get(field) is not None
+        if "=" in part:
+            left, right = [p.strip() for p in part.split("=", 1)]
+            field = left[1:] if left.startswith(":") else left
+            value: Any
+            if right.startswith("'") and right.endswith("'"):
+                value = right[1:-1]
+            elif right.isdigit():
+                value = int(right)
+            else:
+                value = right
+            return bool(values.get(field) == value)
+        raise ValueError(f"Unsupported condition: {part}")
+
+
+_expr_manager = ConditionalExpressionManager()
+_expr_manager.register(
+    "PERMIT_READY", ":permit_id IS NOT NULL AND :permit_verified = 1"
+)
+
+
+def permit_ready(values: Mapping[str, Any]) -> bool:
+    """Return True if the permit is recorded and verified."""
+
+    return _expr_manager.evaluate("PERMIT_READY", values)
+
+
+class StatusValidationError(RuntimeError):
+    """Raised when a status transition is not allowed."""
+
+
+def validate_status_change(
+    workorder: Mapping[str, Any], from_status: str, to_status: str
+) -> None:
+    """Validate a work order status change.
+
+    The transition from ``SCHED`` to ``INPRG`` requires the ``PERMIT_READY``
+    condition to be satisfied.  When the condition is not met a
+    ``StatusValidationError`` is raised.
+    """
+
+    if from_status == "SCHED" and to_status == "INPRG":
+        values = {
+            "permit_id": workorder.get("permit_id"),
+            "permit_verified": int(bool(workorder.get("permit_verified"))),
+        }
+        if not permit_ready(values):
+            raise StatusValidationError(
+                "Permit must be recorded and verified before work can start."
+            )

--- a/tests/api/test_workorder_status.py
+++ b/tests/api/test_workorder_status.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from loto.permits import StatusValidationError, validate_status_change
+
+client = TestClient(app)
+
+
+def test_parent_workorder_requires_permit() -> None:
+    payload = {"status": "INPRG", "currentStatus": "SCHED"}
+    resp = client.post("/workorders/WO-1/status", json=payload)
+    assert resp.status_code == 400
+    assert "Permit must be recorded and verified before work can start." in resp.text
+
+
+def test_parent_workorder_allows_when_permit_verified() -> None:
+    payload = {"status": "INPRG", "currentStatus": "SCHED"}
+    resp = client.post("/workorders/WO-2/status", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "INPRG"
+
+
+def test_child_task_validation() -> None:
+    child = {"permit_id": None, "permit_verified": False}
+    with pytest.raises(StatusValidationError):
+        validate_status_change(child, "SCHED", "INPRG")


### PR DESCRIPTION
## Summary
- add ConditionalExpressionManager with PERMIT_READY expression
- validate SCHED→INPRG transitions via new /workorders/{id}/status endpoint
- add tests for parent/child work orders and planner UI permit controls

## Testing
- `pre-commit run --files apps/api/workorder_endpoints.py loto/permits.py tests/api/test_workorder_status.py apps/maximo-extension-ui/src/app/planner/[wo]/page.test.tsx`
- `make lint`
- `make typecheck`
- `make test` (226 passed)
- `pnpm -F maximo-extension-ui test` (53 passed)


------
https://chatgpt.com/codex/tasks/task_b_68abd871f4c08322ba58519b702c4f79