### PR TITLE
feat: add Permit/LOTO doclink category

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -63,3 +63,11 @@ SENTRY_DSN=https://public@example.ingest.sentry.io/0
 ```
 
 Omit the variable to disable Sentry in a given environment.
+
+## Doclinks configuration
+
+Configure Maximo Doclinks with a document category of `Permit/LOTO`. Ensure the
+category is active for the `WORKORDER` object so attachment dialogs like
+WOTRACK and Quick Reporting offer it as a selectable option. This enables permit
+documents produced by the planner to be stored under the correct category on the
+work order.

--- a/loto/cli.py
+++ b/loto/cli.py
@@ -20,6 +20,7 @@ import typer
 import yaml
 from tqdm import tqdm
 
+from .constants import DOC_CATEGORY_DIR
 from .graph_builder import GraphBuilder
 from .isolation_planner import IsolationPlanner
 from .models import SimReport, Stimulus
@@ -200,7 +201,7 @@ def demo(out: Path = Path("./out"), open_pdf: bool = False) -> None:
             main(["--demo", "--output", str(out)])
             progress.update(1)
 
-        doclinks_dir = out / "doclinks"
+        doclinks_dir = out / "doclinks" / DOC_CATEGORY_DIR
         doclinks_dir.mkdir(parents=True, exist_ok=True)
         doc_id = uuid4().hex
         shutil.copy(out / "LOTO_A.pdf", doclinks_dir / f"{doc_id}.pdf")

--- a/loto/constants.py
+++ b/loto/constants.py
@@ -1,0 +1,4 @@
+"""Project-wide constants."""
+
+DOC_CATEGORY = "Permit/LOTO"
+DOC_CATEGORY_DIR = DOC_CATEGORY.replace("/", "_")

--- a/loto/integrations/demo_adapter.py
+++ b/loto/integrations/demo_adapter.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, TypedDict, cast
 import structlog
 import yaml
 
+from ..constants import DOC_CATEGORY_DIR
 from . import IntegrationAdapter
 
 logger = structlog.get_logger()
@@ -102,8 +103,8 @@ class DemoIntegrationAdapter(IntegrationAdapter):
         as_json: Dict[str, Any],
         pdf_bytes: bytes,
     ) -> None:
-        """Write artifacts to ``out/doclinks`` relative to the CWD."""
-        output_dir = Path("out") / "doclinks"
+        """Write artifacts to ``out/doclinks/<category>`` relative to the CWD."""
+        output_dir = Path("out") / "doclinks" / DOC_CATEGORY_DIR
         output_dir.mkdir(parents=True, exist_ok=True)
         json_path = output_dir / f"{parent_object_id}.json"
         pdf_path = output_dir / f"{parent_object_id}.pdf"

--- a/tests/test_cli_golden.py
+++ b/tests/test_cli_golden.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from loto.constants import DOC_CATEGORY_DIR
+
 
 def test_demo_command_creates_doclinks(tmp_path: Path) -> None:
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -16,7 +18,7 @@ def test_demo_command_creates_doclinks(tmp_path: Path) -> None:
         text=True,
     )
     assert result.returncode == 0, result.stderr
-    doclinks_dir = tmp_path / "out" / "doclinks"
+    doclinks_dir = tmp_path / "out" / "doclinks" / DOC_CATEGORY_DIR
     assert doclinks_dir.is_dir()
     pdfs = list(doclinks_dir.glob("*.pdf"))
     jsons = list(doclinks_dir.glob("*.json"))

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,7 +1,9 @@
+from pathlib import Path
 from typing import Any, Type
 
 import pytest
 
+from loto.constants import DOC_CATEGORY_DIR
 from loto.errors import (
     ConfigError,
     GenerationError,
@@ -19,7 +21,7 @@ from loto.errors import (
 @pytest.mark.parametrize(
     "exc_cls",
     [ConfigError, RulesError, GraphError, PlanError, IntegrationError, RenderError],
-)
+)  # type: ignore[misc]
 def test_error_subclassing(exc_cls: type[LotoError]) -> None:
     err = exc_cls("E001", "something went wrong")
     assert isinstance(err, LotoError)
@@ -37,7 +39,7 @@ def test_error_subclassing(exc_cls: type[LotoError]) -> None:
         (ImportError, "IMPORT_ERROR"),
         (GenerationError, "GENERATION_ERROR"),
     ],
-)
+)  # type: ignore[misc]
 def test_fixed_code_errors(exc_cls: Type[Any], code: str) -> None:
     err = exc_cls("something went wrong")
     assert err.code == code
@@ -54,9 +56,9 @@ def test_loto_error_str_contains_code() -> None:
     assert "oops" in str(err)
 
 
-def test_demo_adapter_used_when_env_missing(monkeypatch, tmp_path) -> None:
-    from pathlib import Path
-
+def test_demo_adapter_used_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     from loto.integrations import DemoIntegrationAdapter, get_integration_adapter
     from loto.models import IsolationAction, IsolationPlan, SimReport
 
@@ -78,13 +80,13 @@ def test_demo_adapter_used_when_env_missing(monkeypatch, tmp_path) -> None:
 
     plan = IsolationPlan(
         plan_id="P1",
-        actions=[IsolationAction(component_id="C1", method="lock")],
+        actions=[IsolationAction(component_id="C1", method="lock", duration_s=0.0)],
     )
     child_ids = adapter.create_child_work_orders("WO-1", plan)
     assert child_ids and child_ids[0].startswith("WO-1")
 
     sim_report = SimReport(results=[], total_time_s=0.0)
     adapter.attach_artifacts("WO-1", plan, sim_report, {"k": "v"}, b"pdf")
-    doc_dir = Path("out") / "doclinks"
+    doc_dir = Path("out") / "doclinks" / DOC_CATEGORY_DIR
     assert (doc_dir / "WO-1.json").exists()
     assert (doc_dir / "WO-1.pdf").exists()


### PR DESCRIPTION
## Summary
- route generated permit artifacts into a dedicated Permit/LOTO doclinks category
- document how to enable the Permit/LOTO category for work order attachments

## Testing
- `pre-commit run --files docs/DEPLOYMENT.md loto/constants.py loto/cli.py loto/integrations/demo_adapter.py tests/test_cli_golden.py tests/test_errors.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68abc9ad6a908322a5192c6fa2026e0a