### PR TITLE
docs: add permit gate job plan

### DIFF
--- a/docs/JP_PERMIT_GATE.md
+++ b/docs/JP_PERMIT_GATE.md
@@ -1,0 +1,17 @@
+# Job Plan JP_PERMIT_GATE
+
+This job plan enforces permit gating for work orders requiring an active permit.
+
+## Tasks
+
+| Seq | Description | Type |
+| --- | ----------- | ---- |
+| 10 | Permit Active | YORN |
+| 20 | Isolation boundary verified (photo required) | YORN |
+| 30 | Permit Closed & Hand-back uploaded | YORN |
+
+## Planner instructions
+
+- Add `JP_PERMIT_GATE` to work order templates or workflow steps so new work orders automatically include these tasks.
+- Confirm the isolation boundary photo is attached before marking the permit verified.
+- Upload permit closeout and hand-back documentation to satisfy the final task.


### PR DESCRIPTION
## Summary
- document JP_PERMIT_GATE job plan with permit validation tasks and planner notes

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files docs/JP_PERMIT_GATE.md`


------
https://chatgpt.com/codex/tasks/task_b_68abe805aab88322857e2dd01c77b4c1