### PR TITLE
Add HOLD work order status with reason capture

### DIFF
--- a/apps/api/demo_data/workorders.json
+++ b/apps/api/demo_data/workorders.json
@@ -13,7 +13,8 @@
     "permitRequired": true,
     "isolationRef": "ISO-1",
     "attachments": [],
-    "checklist": {}
+    "checklist": {},
+    "holdReason": null
   },
   {
     "id": "WO-2",
@@ -33,7 +34,8 @@
     ],
     "checklist": {
       "Permit Closed & Hand-back uploaded": true
-    }
+    },
+    "holdReason": null
   },
   {
     "id": "WO-3",
@@ -49,7 +51,8 @@
     "permitRequired": true,
     "isolationRef": "ISO-3",
     "attachments": [],
-    "checklist": {}
+    "checklist": {},
+    "holdReason": null
   },
   {
     "id": "WO-4",
@@ -67,6 +70,7 @@
     "attachments": [],
     "checklist": {
       "Permit Closed & Hand-back uploaded": true
-    }
+    },
+    "holdReason": null
   }
 ]

--- a/loto/constants.py
+++ b/loto/constants.py
@@ -5,3 +5,11 @@ DOC_CATEGORY_DIR = DOC_CATEGORY.replace("/", "_")
 
 # Checklist item verifying the permit has been closed and uploaded.
 CHECKLIST_HAND_BACK = "Permit Closed & Hand-back uploaded"
+
+# Work order status domain descriptions
+WOSTATUS_DESCRIPTIONS = {
+    "SCHED": "Scheduled",
+    "INPRG": "In Progress",
+    "HOLD": "On Hold",
+    "COMP": "Completed",
+}

--- a/loto/permits.py
+++ b/loto/permits.py
@@ -67,14 +67,27 @@ class StatusValidationError(RuntimeError):
 
 
 def validate_status_change(
-    workorder: Mapping[str, Any], from_status: str, to_status: str
+    workorder: Mapping[str, Any],
+    from_status: str,
+    to_status: str,
+    reason: str | None = None,
 ) -> None:
     """Validate a work order status change.
 
     The transition from ``SCHED`` to ``INPRG`` requires the ``PERMIT_READY``
-    condition to be satisfied.  When the condition is not met a
-    ``StatusValidationError`` is raised.
+    condition to be satisfied. When moving from ``INPRG`` to ``HOLD`` a
+    reason must be supplied.
     """
+
+    if from_status == "INPRG" and to_status == "HOLD":
+        if not reason:
+            raise StatusValidationError(
+                "Hold reason is required when placing work order on hold."
+            )
+        return
+
+    if from_status == "HOLD" and to_status == "INPRG":
+        return
 
     if from_status == "SCHED" and to_status == "INPRG":
         values = {


### PR DESCRIPTION
## Summary
- add HOLD status to work order domain configuration
- enable INPRG↔HOLD transitions with reason capture via API
- cover HOLD transitions with tests and sample data
- reload API module in inventory gating test to reset rate limiter

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `pre-commit run --files tests/test_inventory.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68abea3f4de48322a438a9c47740d794