### PR TITLE
Use tmpfs for demo SQLite DB

### DIFF
--- a/apps/api/alembic/alembic.ini
+++ b/apps/api/alembic/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = apps/api/alembic
-sqlalchemy.url = sqlite:///./loto.db
+sqlalchemy.url = sqlite:////tmp/loto.db
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/apps/api/audit.py
+++ b/apps/api/audit.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
 import json
 import os
 import sqlite3
 import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import structlog
 
-DB_PATH = Path(__file__).resolve().parents[2] / "loto.db"
+DB_PATH = Path("/tmp/loto.db")
 
 
 logger = structlog.get_logger(__name__)

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -574,7 +574,7 @@ async def healthz(request: Request) -> dict[str, Any]:
         head = None
         for path in sorted(versions_dir.glob("*.py")):
             head = path.stem.split("_")[0]
-        db_path = Path(__file__).resolve().parents[2] / "loto.db"
+        db_path = Path("/tmp/loto.db")
         revision = None
         if db_path.exists():
             conn = sqlite3.connect(db_path)


### PR DESCRIPTION
## Summary
- store demo SQLite DB under /tmp so the read-only container can initialize it

## Testing
- `make fmt`
- `pre-commit run --files apps/api/alembic/alembic.ini apps/api/audit.py apps/api/main.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ac2bff24c08322b0be6f72d7ddf403