### PR TITLE
docs: track saved queries

### DIFF
--- a/docs/SAVED_QUERIES.md
+++ b/docs/SAVED_QUERIES.md
@@ -1,0 +1,19 @@
+# Saved Queries
+
+Use these Maximo saved queries to monitor work-order exceptions.
+
+## Work orders started without a permit
+
+```
+status='INPRG' AND (permit_id IS NULL OR permit_verified=0)
+```
+
+## Missing closure evidence
+
+```
+status='COMP' AND (closure_evidence IS NULL OR closure_evidence='')
+```
+
+## Review cadence
+
+Review the results of each query weekly and track exception counts. After cutover, counts should trend toward zero.


### PR DESCRIPTION
## Summary
- document saved queries for work order exceptions

## Testing
- `pre-commit run --files docs/SAVED_QUERIES.md`
- `npx markdownlint docs/SAVED_QUERIES.md` *(fails: could not determine executable)*
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68ac238751bc8322b62921b7492a7d07