### PR TITLE
fix: unify API base environment variable

### DIFF
--- a/apps/maximo-extension-ui/.env.example
+++ b/apps/maximo-extension-ui/.env.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_BASE=http://localhost:8000

--- a/apps/maximo-extension-ui/next.config.mjs
+++ b/apps/maximo-extension-ui/next.config.mjs
@@ -4,12 +4,12 @@ import { withSentryConfig } from '@sentry/nextjs';
 const nextConfig = {
   productionBrowserSourceMaps: true,
   async rewrites() {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-    if (!apiUrl) return [];
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE;
+    if (!apiBase) return [];
     return [
       {
         source: '/api/:path*',
-        destination: `${apiUrl}/api/:path*`,
+        destination: `${apiBase}/api/:path*`,
       },
     ];
   },

--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -12,8 +12,7 @@ test('renders virtualized gantt and updates conflicts', async () => {
   global.ResizeObserver = ResizeObserver;
 
   vi.stubEnv('NEXT_PUBLIC_USE_API', 'true');
-  const apiBase = process.env.NEXT_PUBLIC_API_URL ?? '';
-  process.env.NEXT_PUBLIC_API_BASE = apiBase;
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE ?? '';
 
   const sample = {
     schedule: [


### PR DESCRIPTION
## Summary
- align Next.js rewrites with `NEXT_PUBLIC_API_BASE`
- update scheduler test and env example to use `NEXT_PUBLIC_API_BASE`

## Testing
- `pnpm -F maximo-extension-ui test`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files apps/maximo-extension-ui/.env.example apps/maximo-extension-ui/next.config.mjs apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68ac30b792088322b969570d3de5e997