### PR TITLE
Install WeasyPrint native libraries for KPI reporting

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -4,6 +4,21 @@
 FROM python:3.12-slim AS builder
 WORKDIR /app
 
+# Install native libraries required for WeasyPrint PDF generation
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libcairo2 \
+        libcairo2-dev \
+        libpango-1.0-0 \
+        libpango1.0-dev \
+        libpangocairo-1.0-0 \
+        libpangoft2-1.0-0 \
+        libgdk-pixbuf-2.0-0 \
+        libffi-dev \
+        fontconfig \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install application and API dependencies into a temporary prefix
 COPY pyproject.toml README.md ./
 COPY config ./config
@@ -16,6 +31,17 @@ RUN pip install --no-cache-dir --prefix=/install -r apps/api/requirements.txt \
 # Final stage
 FROM python:3.12-slim
 WORKDIR /app
+
+# Install runtime libraries for WeasyPrint
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libcairo2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libpangoft2-1.0-0 \
+        libgdk-pixbuf-2.0-0 \
+        fontconfig \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy installed packages and application source
 COPY --from=builder /install /usr/local


### PR DESCRIPTION
## Summary
- install Cairo, Pango, and Fontconfig libraries in API Docker image so WeasyPrint can build PDFs

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files Dockerfile.api`


------
https://chatgpt.com/codex/tasks/task_b_68ac32bee60c8322a1d8487ff77a5cf4