### PR TITLE
Log exceptions instead of swallowing

### DIFF
--- a/apps/api/hats_endpoints.py
+++ b/apps/api/hats_endpoints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from datetime import datetime
 from pathlib import Path
@@ -7,8 +8,8 @@ from typing import Any, Dict, List, Tuple, cast
 
 from fastapi import APIRouter
 
-from loto.roster import storage
 from loto.hats import compute_ranking
+from loto.roster import storage
 
 from .schemas import HatKpiRequest, HatSnapshot
 
@@ -133,7 +134,7 @@ async def post_hat_kpi(event: HatKpiRequest) -> HatSnapshot:
     try:
         storage.append_ledger(ledger_path, entry)
     except ValueError:
-        pass
+        logging.debug("failed to append ledger entry", exc_info=True)
 
     entries = storage.read_ledger(ledger_path)
     snapshot = storage.compute_snapshot(entries)

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -606,7 +606,7 @@ async def healthz(request: Request) -> dict[str, Any]:
             user = current_user_from_header(auth_header)
             role = user.roles[0] if user.roles else role
         except HTTPException:
-            pass
+            logging.debug("failed to resolve current user from header", exc_info=True)
     return {
         "status": "ok",
         "role": role,


### PR DESCRIPTION
## Summary
- log health check auth parsing failures for debugging
- record ledger append failures in hat KPIs at debug level

## Testing
- `pre-commit run --files apps/api/main.py apps/api/hats_endpoints.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ac386e0b548322b89916f7dfb84086