### PR TITLE
Add permit adapter selector with env-based configuration

### DIFF
--- a/loto/integrations/__init__.py
+++ b/loto/integrations/__init__.py
@@ -79,10 +79,38 @@ def get_integration_adapter() -> IntegrationAdapter | MaximoAdapter:
     return DemoIntegrationAdapter()
 
 
+def get_permit_adapter() -> EllipseAdapter | WaprAdapter:
+    """Select a permit adapter based on environment configuration.
+
+    ``PERMIT_PROVIDER`` controls which system to target and may be set to
+    ``ELLIPSE``, ``WAPR`` or ``DEMO`` (the default). For the Ellipse provider,
+    ``ELLIPSE_MODE`` determines whether the demo or HTTP adapter is used. When
+    ``ELLIPSE_MODE=HTTP``, the variables ``ELLIPSE_BASE_URL``,
+    ``ELLIPSE_USERNAME`` and ``ELLIPSE_PASSWORD`` must also be provided.
+
+    The WAPR provider currently only supports ``WAPR_MODE=DEMO``; selecting
+    ``HTTP`` will raise :class:`NotImplementedError`.
+    """
+
+    provider = os.getenv("PERMIT_PROVIDER", "DEMO").upper()
+    if provider == "ELLIPSE":
+        mode = os.getenv("ELLIPSE_MODE", "DEMO").upper()
+        if mode == "HTTP":
+            return HttpEllipseAdapter()
+        return DemoEllipseAdapter()
+    if provider == "WAPR":
+        mode = os.getenv("WAPR_MODE", "DEMO").upper()
+        if mode == "HTTP":
+            raise NotImplementedError("HTTP WAPR adapter not implemented")
+        return DemoWaprAdapter()
+    return DemoEllipseAdapter()
+
+
 __all__ = [
     "IntegrationAdapter",
     "DemoIntegrationAdapter",
     "get_integration_adapter",
+    "get_permit_adapter",
     "CoupaAdapter",
     "DemoCoupaAdapter",
     "HttpCoupaAdapter",

--- a/tests/test_permit_adapter_selection.py
+++ b/tests/test_permit_adapter_selection.py
@@ -1,0 +1,47 @@
+"""Tests for permit adapter selection logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from loto.integrations import (
+    DemoEllipseAdapter,
+    DemoWaprAdapter,
+    HttpEllipseAdapter,
+    get_permit_adapter,
+)
+
+
+def test_default_returns_demo_ellipse(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Demo Ellipse adapter is used by default."""
+    monkeypatch.delenv("PERMIT_PROVIDER", raising=False)
+    monkeypatch.delenv("ELLIPSE_MODE", raising=False)
+    adapter = get_permit_adapter()
+    assert isinstance(adapter, DemoEllipseAdapter)
+
+
+def test_ellipse_http_selected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP Ellipse adapter is returned when configured."""
+    monkeypatch.setenv("PERMIT_PROVIDER", "ELLIPSE")
+    monkeypatch.setenv("ELLIPSE_MODE", "HTTP")
+    monkeypatch.setenv("ELLIPSE_BASE_URL", "https://example")
+    monkeypatch.setenv("ELLIPSE_USERNAME", "u")
+    monkeypatch.setenv("ELLIPSE_PASSWORD", "p")
+    adapter = get_permit_adapter()
+    assert isinstance(adapter, HttpEllipseAdapter)
+
+
+def test_wapr_demo_selected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Demo WAPR adapter is returned when provider=WAPR."""
+    monkeypatch.setenv("PERMIT_PROVIDER", "WAPR")
+    monkeypatch.setenv("WAPR_MODE", "DEMO")
+    adapter = get_permit_adapter()
+    assert isinstance(adapter, DemoWaprAdapter)
+
+
+def test_wapr_http_not_implemented(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WAPR HTTP mode currently raises NotImplementedError."""
+    monkeypatch.setenv("PERMIT_PROVIDER", "WAPR")
+    monkeypatch.setenv("WAPR_MODE", "HTTP")
+    with pytest.raises(NotImplementedError):
+        get_permit_adapter()


### PR DESCRIPTION
## Summary
- add `get_permit_adapter` to choose permit adapters (Ellipse or WAPR) based on environment variables
- expose permit adapter selector in integrations package
- test environment-driven selection including demo and HTTP modes

## Testing
- `make fmt`
- `pre-commit run --files loto/integrations/__init__.py tests/test_permit_adapter_selection.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68accde894ac83228f10738cf3205f13