### PR TITLE
Add permit status to DemoEllipseAdapter

### DIFF
--- a/loto/integrations/ellipse_adapter.py
+++ b/loto/integrations/ellipse_adapter.py
@@ -38,8 +38,16 @@ class DemoEllipseAdapter(EllipseAdapter):
         "WO-2": {"id": "WO-2", "description": "Demo WO", "asset_id": "ASSET-2"},
     }
     _PERMITS: Dict[str, Dict[str, Any]] = {
-        "WO-1": {"applied_isolations": ["ISO-1", "ISO-2"]},
-        "WO-2": {"applied_isolations": ["ISO-3"]},
+        "WO-1": {
+            "id": "PRM-1",
+            "status": "Active",
+            "applied_isolations": ["ISO-1", "ISO-2"],
+        },
+        "WO-2": {
+            "id": "PRM-2",
+            "status": "Authorised",
+            "applied_isolations": ["ISO-3"],
+        },
     }
 
     def fetch_work_order(self, work_order_id: str) -> Dict[str, Any]:
@@ -51,7 +59,10 @@ class DemoEllipseAdapter(EllipseAdapter):
 
     def fetch_permit(self, work_order_id: str) -> Dict[str, Any]:
         """Return fixture permit data for the work order."""
-        return self._PERMITS.get(work_order_id, {"applied_isolations": []})
+        return self._PERMITS.get(
+            work_order_id,
+            {"id": None, "status": "Unknown", "applied_isolations": []},
+        )
 
 
 class HttpEllipseAdapter(EllipseAdapter):

--- a/tests/integrations/test_ellipse_adapter.py
+++ b/tests/integrations/test_ellipse_adapter.py
@@ -6,4 +6,8 @@ def test_demo_adapter_returns_work_order_and_permit() -> None:
     wo = adapter.fetch_work_order("WO-1")
     permit = adapter.fetch_permit("WO-1")
     assert wo["id"] == "WO-1"
-    assert permit == {"applied_isolations": ["ISO-1", "ISO-2"]}
+    assert permit == {
+        "id": "PRM-1",
+        "status": "Active",
+        "applied_isolations": ["ISO-1", "ISO-2"],
+    }


### PR DESCRIPTION
## Summary
- include id and status in DemoEllipseAdapter fixture permit data
- default to Unknown status when no permit is found
- adjust tests for new permit structure

## Testing
- `make fmt`
- `pre-commit run --files loto/integrations/ellipse_adapter.py tests/integrations/test_ellipse_adapter.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68acdf328c948322a25e5279db0003a1