### PR TITLE
Enforce external permit state during SCHED→INPRG

### DIFF
--- a/tests/api/test_workorder_status.py
+++ b/tests/api/test_workorder_status.py
@@ -89,3 +89,26 @@ def test_hold_and_resume() -> None:
     body = resp.json()
     assert body["status"] == "INPRG"
     assert body.get("holdReason") is None
+
+
+def test_external_permit_verification(monkeypatch: pytest.MonkeyPatch) -> None:
+    wo = {
+        "id": "WO-1",
+        "maximo_wo": "MX-1",
+        "permit_id": "PRM-1",
+        "permit_verified": True,
+    }
+    monkeypatch.setenv("REQUIRE_EXTERNAL_PERMIT", "1")
+    validate_status_change(wo, "SCHED", "INPRG")
+
+
+def test_external_permit_verification_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    wo = {
+        "id": "WO-999",
+        "maximo_wo": "MX-999",
+        "permit_id": "PRM-999",
+        "permit_verified": True,
+    }
+    monkeypatch.setenv("REQUIRE_EXTERNAL_PERMIT", "1")
+    with pytest.raises(StatusValidationError):
+        validate_status_change(wo, "SCHED", "INPRG")


### PR DESCRIPTION
## Summary
- enforce external permit status when transitioning SCHED→INPRG, gated by REQUIRE_EXTERNAL_PERMIT
- add tests covering external permit validation success and failure cases

## Testing
- `pre-commit run --files loto/permits.py tests/api/test_workorder_status.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68acf2be326c8322ade8ecc210e9839a