### PR TITLE
Support isolation cost weighting in planner

### DIFF
--- a/loto/isolation_planner.py
+++ b/loto/isolation_planner.py
@@ -93,7 +93,11 @@ class IsolationPlanner:
             # Build weighted graph for min-cut computations
             weighted = nx.DiGraph()
             for u, v, data in graph.edges(data=True):
-                cap = 1.0 if data.get("is_isolation_point") else float("inf")
+                cap = (
+                    data.get("isolation_cost", 1.0)
+                    if data.get("is_isolation_point")
+                    else float("inf")
+                )
                 if weighted.has_edge(u, v):
                     # Keep the lowest capacity if multiple edges exist
                     weighted[u][v]["capacity"] = min(weighted[u][v]["capacity"], cap)

--- a/tests/planner/test_weighted_cut.py
+++ b/tests/planner/test_weighted_cut.py
@@ -1,0 +1,27 @@
+import networkx as nx
+
+from loto.isolation_planner import IsolationPlanner
+from loto.rule_engine import RulePack  # type: ignore[attr-defined]
+
+
+def test_weighted_cut_prefers_cheapest() -> None:
+    g = nx.MultiDiGraph()
+    g.add_node("S", is_source=True)
+    g.add_node("N")
+    g.add_node("T", tag="asset")
+
+    g.add_edge("S", "N", is_isolation_point=True, isolation_cost=5.0)
+    g.add_edge("N", "T", is_isolation_point=True, isolation_cost=1.0)
+
+    planner = IsolationPlanner()
+    pack = RulePack(risk_policies=None)
+    plan = planner.compute({"process": g}, asset_tag="asset", rule_pack=pack)
+
+    edges = []
+    for action in plan.actions:
+        domain, edge = action.component_id.split(":", 1)
+        if domain == "process":
+            u, v = edge.split("->")
+            edges.append((u, v))
+
+    assert edges == [("N", "T")]


### PR DESCRIPTION
## Summary
- parse optional isolation_cost from CSV line and valve records and propagate to isolation edges
- weight isolation edges by isolation_cost when computing min cuts
- ensure planner picks cheapest isolation option via new weighted cut test

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files loto/graph_builder.py loto/isolation_planner.py tests/planner/test_weighted_cut.py`


------
https://chatgpt.com/codex/tasks/task_b_68acfbd8b54c8322afcc12a10523bde1