### PR TITLE
Validate graph CSV rows with Pydantic models

### DIFF
--- a/loto/graph_models.py
+++ b/loto/graph_models.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import math
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, validator
+
+MEDIUM_WHITELIST = {"STEAM", "WATER", "AIR", "OIL", "NITROGEN"}
+
+
+class Domain(str, Enum):
+    STEAM = "steam"
+    WATER = "water"
+    PROCESS = "process"
+    ELECTRICAL = "electrical"
+    INSTRUMENT_AIR = "instrument_air"
+    CONDENSATE = "condensate"
+
+
+def _normalise_tag(cls: type[Any], value: Any) -> Any:
+    if value is None:
+        return value
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if isinstance(value, str):
+        return value.strip().replace("-", "_").upper()
+    return value
+
+
+def _normalise_domain(cls: type[Any], value: Any) -> Any:
+    if isinstance(value, str):
+        return value.strip().replace("-", "_").lower()
+    return value
+
+
+def _validate_medium(cls: type[Any], value: Any) -> Any:
+    if value is None:
+        return value
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if isinstance(value, str):
+        norm = value.strip().replace("-", "_").upper()
+        if norm not in MEDIUM_WHITELIST:
+            raise ValueError(f"medium '{norm}' not permitted")
+        return norm
+    return value
+
+
+class LineRow(BaseModel):
+    domain: Domain
+    from_tag: str
+    to_tag: str
+    line_tag: Optional[str] = None
+    isolation_cost: Optional[float] = None
+    medium: Optional[str] = None
+
+    _normalise_domain = validator("domain", pre=True, allow_reuse=True)(
+        _normalise_domain
+    )
+    _normalise_tags = validator("from_tag", "to_tag", pre=True, allow_reuse=True)(
+        _normalise_tag
+    )
+    _validate_medium = validator("medium", pre=True, allow_reuse=True)(_validate_medium)
+
+    class Config:
+        extra = "forbid"
+
+
+class ValveRow(BaseModel):
+    domain: Domain
+    tag: str
+    fail_state: Optional[str] = None
+    kind: Optional[str] = None
+    isolation_cost: Optional[float] = None
+    medium: Optional[str] = None
+
+    _normalise_domain = validator("domain", pre=True, allow_reuse=True)(
+        _normalise_domain
+    )
+    _normalise_tag = validator("tag", pre=True, allow_reuse=True)(_normalise_tag)
+    _validate_medium = validator("medium", pre=True, allow_reuse=True)(_validate_medium)
+
+    class Config:
+        extra = "forbid"
+
+
+class DrainRow(BaseModel):
+    domain: Domain
+    tag: str
+    kind: Optional[str] = None
+    medium: Optional[str] = None
+
+    _normalise_domain = validator("domain", pre=True, allow_reuse=True)(
+        _normalise_domain
+    )
+    _normalise_tag = validator("tag", pre=True, allow_reuse=True)(_normalise_tag)
+    _validate_medium = validator("medium", pre=True, allow_reuse=True)(_validate_medium)
+
+    class Config:
+        extra = "forbid"
+
+
+class SourceRow(BaseModel):
+    domain: Domain
+    tag: str
+    kind: Optional[str] = None
+    medium: Optional[str] = None
+
+    _normalise_domain = validator("domain", pre=True, allow_reuse=True)(
+        _normalise_domain
+    )
+    _normalise_tag = validator("tag", pre=True, allow_reuse=True)(_normalise_tag)
+    _validate_medium = validator("medium", pre=True, allow_reuse=True)(_validate_medium)
+
+    class Config:
+        extra = "forbid"

--- a/loto/impact.py
+++ b/loto/impact.py
@@ -113,7 +113,11 @@ class ImpactEngine:
                 for node in nx.descendants(open_graph, s) | {s}:
                     reachable.add(node)
 
-            assets = {n for n, d in g.nodes(data=True) if d.get("tag") == "asset"}
+            assets = {
+                n
+                for n, d in g.nodes(data=True)
+                if isinstance(d.get("tag"), str) and d.get("tag").upper() == "ASSET"
+            }
             unavailable.update(assets - reachable)
 
         # ------------------------------------------------------------------

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import networkx as nx
 import pandas as pd
+import pytest
 
 from loto.graph_builder import GraphBuilder
 
@@ -132,13 +133,18 @@ def test_validate_detects_missing_line_tag(tmp_path: Path) -> None:
     assert any("missing line tag" in issue.message for issue in issues)
 
 
-def test_validate_detects_missing_domain(tmp_path: Path) -> None:
+def test_validate_detects_missing_domain() -> None:
+    g = nx.MultiDiGraph()
+    builder = GraphBuilder()
+    issues = builder.validate({None: g})  # type: ignore[dict-item]
+    assert any("missing domain" in issue.message for issue in issues)
+
+
+def test_from_csvs_reports_validation_errors(tmp_path: Path) -> None:
     line_df = pd.DataFrame(
-        [{"domain": None, "from_tag": "S1", "to_tag": "V1", "line_tag": "L1"}]
+        [{"domain": "steam", "from_tag": "S1", "to_tag": "V1", "medium": "bogus"}]
     )
-    valve_df = pd.DataFrame(
-        [{"domain": None, "tag": "V1", "fail_state": "CLOSED", "kind": "MV"}]
-    )
+    valve_df = pd.DataFrame(columns=["domain", "tag", "fail_state", "kind"])
     drain_df = pd.DataFrame(columns=["domain", "tag", "kind"])
 
     line_path = tmp_path / "lines.csv"
@@ -149,10 +155,33 @@ def test_validate_detects_missing_domain(tmp_path: Path) -> None:
     drain_df.to_csv(drain_path, index=False)
 
     builder = GraphBuilder()
-    graphs = builder.from_csvs(line_path, valve_path, drain_path)
-    issues = builder.validate(graphs)
+    with pytest.raises(ValueError):
+        builder.from_csvs(line_path, valve_path, drain_path)
 
-    assert any("missing domain" in issue.message for issue in issues)
+
+def test_tags_normalised(tmp_path: Path) -> None:
+    line_df = pd.DataFrame(
+        [{"domain": "steam", "from_tag": " s-1 ", "to_tag": " v-1 "}]
+    )
+    valve_df = pd.DataFrame(
+        [{"domain": "steam", "tag": " v-1 ", "fail_state": "CLOSED", "kind": "MV"}]
+    )
+    drain_df = pd.DataFrame([{"domain": "steam", "tag": " d-1 ", "kind": "drain"}])
+
+    line_path = tmp_path / "lines.csv"
+    valve_path = tmp_path / "valves.csv"
+    drain_path = tmp_path / "drains.csv"
+    line_df.to_csv(line_path, index=False)
+    valve_df.to_csv(valve_path, index=False)
+    drain_df.to_csv(drain_path, index=False)
+
+    builder = GraphBuilder()
+    graphs = builder.from_csvs(line_path, valve_path, drain_path)
+    g = graphs["steam"]
+
+    assert "S_1" in g.nodes
+    assert "V_1" in g.nodes
+    assert "D_1" in g.nodes
 
 
 def test_validate_reports_cycles_with_severity() -> None:

--- a/tests/test_service_blueprints.py
+++ b/tests/test_service_blueprints.py
@@ -1,12 +1,15 @@
 import io
 
 import pandas as pd
+import pytest
 
 from loto.models import RulePack
 from loto.service.blueprints import plan_and_evaluate
 
 
-def test_plan_and_evaluate_deterministic(monkeypatch):
+def test_plan_and_evaluate_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
     )
@@ -38,17 +41,17 @@ def test_plan_and_evaluate_deterministic(monkeypatch):
         io.StringIO(valve_df.to_csv(index=False)),
         io.StringIO(drain_df.to_csv(index=False)),
         io.StringIO(source_df.to_csv(index=False)),
-        asset_tag="asset",
-        rule_pack=RulePack(),
+        asset_tag="ASSET",
+        rule_pack=RulePack(risk_policies=None),
         stimuli=[],
-        asset_units={"asset": "U1"},
-        unit_data={"U1": {"rated": 5.0, "scheme": "SPOF"}},
+        asset_units={"ASSET": "U1"},
+        unit_data={"U1": {"rated": 5.0, "scheme": "SPOF"}},  # type: ignore[dict-item]
         unit_areas={"U1": "Area1"},
     )
 
-    assert [a.component_id for a in plan.actions] == ["steam:V->asset"]
+    assert [a.component_id for a in plan.actions] == ["steam:V->ASSET"]
     assert report.results == []
-    assert impact.unavailable_assets == {"asset"}
+    assert impact.unavailable_assets == {"ASSET"}
     assert impact.unit_mw_delta == {"U1": 5.0}
     assert impact.area_mw_delta == {"Area1": 5.0}
     assert prov.seed is None


### PR DESCRIPTION
## Summary
- add typed Pydantic models for graph CSV rows with tag normalization, domain enums and medium whitelist
- parse CSV rows through these models in `GraphBuilder.from_csvs`, aggregating validation errors
- treat asset tags case-insensitively in `ImpactEngine` and update tests for normalized tags

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `pre-commit run --files loto/graph_models.py loto/graph_builder.py loto/impact.py tests/test_graph_builder.py tests/test_service_blueprints.py`


------
https://chatgpt.com/codex/tasks/task_b_68ad046ec1f8832298bee931173c119d