### PR TITLE
Add stimulus dispatch and handlers

### DIFF
--- a/tests/sim/test_stimulus_types.py
+++ b/tests/sim/test_stimulus_types.py
@@ -1,11 +1,19 @@
+from typing import Any
+
 import networkx as nx
 import pytest
 
+from loto.models import (
+    IsolationAction,
+    IsolationPlan,
+    SimReport,
+    SimResultItem,
+    Stimulus,
+)
 from loto.sim_engine import SimEngine
-from loto.models import IsolationAction, IsolationPlan, SimReport, SimResultItem, Stimulus
 
 
-def build_graph():
+def build_graph() -> nx.MultiDiGraph:
     g = nx.MultiDiGraph()
     g.add_node("source", is_source=True)
     g.add_node("valve1")
@@ -15,11 +23,15 @@ def build_graph():
     return g
 
 
-def test_accepts_model_stimulus():
+def test_accepts_model_stimulus() -> None:
     g = build_graph()
     plan = IsolationPlan(
         plan_id="p1",
-        actions=[IsolationAction(component_id="steam:source->valve1", method="lock")],
+        actions=[
+            IsolationAction(
+                component_id="steam:source->valve1", method="lock", duration_s=1.0
+            )
+        ],
     )
     engine = SimEngine()
     applied = engine.apply(plan, {"steam": g})
@@ -31,15 +43,58 @@ def test_accepts_model_stimulus():
     assert all(isinstance(r, SimResultItem) for r in report.results)
 
 
-def test_invalid_stimulus_type_raises():
+def test_invalid_stimulus_type_raises() -> None:
     g = build_graph()
     plan = IsolationPlan(
         plan_id="p1",
-        actions=[IsolationAction(component_id="steam:source->valve1", method="lock")],
+        actions=[
+            IsolationAction(
+                component_id="steam:source->valve1", method="lock", duration_s=1.0
+            )
+        ],
     )
     engine = SimEngine()
     applied = engine.apply(plan, {"steam": g})
 
+    invalid_stimuli: Any = [
+        {"name": "REMOTE_OPEN", "magnitude": 1.0, "duration_s": 1.0}
+    ]
     with pytest.raises(AttributeError):
-        engine.run_stimuli(applied, [{"name": "REMOTE_OPEN", "magnitude": 1.0, "duration_s": 1.0}])
+        engine.run_stimuli(applied, invalid_stimuli)
 
+
+@pytest.mark.parametrize(
+    "stim_name, edge_data, node_data, expected",
+    [
+        ("REMOTE_OPEN", {"control": "remote", "state": "closed"}, None, "open"),
+        ("LOCAL_OPEN", {"control": "local", "state": "closed"}, None, "open"),
+        ("AIR_RETURN", None, {"kind": "air_return", "state": "closed"}, "open"),
+        ("ESD_RESET", None, {"kind": "esd", "state": "closed"}, "open"),
+        ("PUMP_START", None, {"kind": "pump", "state": "off"}, "on"),
+    ],
+)  # type: ignore[misc]
+def test_handlers_mutate_state(
+    stim_name: str,
+    edge_data: dict[str, str] | None,
+    node_data: dict[str, str] | None,
+    expected: str,
+) -> None:
+    g = nx.MultiDiGraph()
+    if edge_data is not None:
+        g.add_node("u", is_source=True)
+        g.add_node("v")
+        g.add_edge("u", "v", **edge_data)
+    if node_data is not None:
+        g.add_node("n", **node_data)
+
+    plan = IsolationPlan(plan_id="p1", actions=[])
+    engine = SimEngine()
+    applied = engine.apply(plan, {"steam": g})
+    stim = Stimulus(name=stim_name, magnitude=1.0, duration_s=1.0)
+
+    engine.run_stimuli(applied, [stim])
+
+    if edge_data is not None:
+        assert applied["steam"].edges["u", "v", 0]["state"] == expected
+    if node_data is not None:
+        assert applied["steam"].nodes["n"]["state"] == expected


### PR DESCRIPTION
## Summary
- add dispatch table and handlers for supported stimuli
- invoke handlers prior to invariant checks in simulation engine
- test state mutations for remote, local, air, ESD, and pump stimuli

## Testing
- `pre-commit run --files loto/sim_engine.py tests/sim/test_stimulus_types.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad0c5798ec83228e0d00d12f507383