### PR TITLE
Collect k shortest open paths in simulation results

### DIFF
--- a/loto/models.py
+++ b/loto/models.py
@@ -149,8 +149,8 @@ class SimResultItem(BaseModel):
     domain: Optional[str] = Field(
         None, description="Domain containing any invariant violation"
     )
-    path: Optional[List[str]] = Field(
-        None, description="Shortest offending path if a violation occurred"
+    paths: Optional[List[List[str]]] = Field(
+        None, description="Offending paths if a violation occurred"
     )
     hint: Optional[str] = Field(
         None, description="Suggested remediation for the violation"


### PR DESCRIPTION
## Summary
- report up to five open source-to-asset paths per domain using networkx's `shortest_simple_paths`
- capture all violating paths in `SimResultItem.paths`
- extend invariants tests to cover multiple routes and path-free success

## Testing
- `pre-commit run --files loto/models.py loto/sim_engine.py tests/sim/test_invariants.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad10dded348322957821d7b9c8f184