### PR TITLE
feat(sim): add reproducible seeding

### DIFF
--- a/loto/cli.py
+++ b/loto/cli.py
@@ -163,7 +163,7 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     # Run simulation if not skipped.  If the simulation engine is not
     # implemented, keep an empty report.
-    sim_report: SimReport = SimReport(results=[], total_time_s=0.0)
+    sim_report: SimReport = SimReport(results=[], total_time_s=0.0, seed=None)
     if not args.no_sim:
         try:
             applied_graphs = sim.apply(plan, graphs)

--- a/loto/models.py
+++ b/loto/models.py
@@ -168,6 +168,10 @@ class SimReport(BaseModel):
     )
     total_time_s: float = Field(..., description="Total simulation time in seconds")
 
+    seed: int | None = Field(
+        None, description="Random seed used for deterministic simulation"
+    )
+
     class Config:
         extra = "forbid"
 

--- a/loto/service/blueprints.py
+++ b/loto/service/blueprints.py
@@ -124,7 +124,7 @@ def plan_and_evaluate(
     duration = time.perf_counter() - start
     logger.info("plan_generated", duration=duration)
 
-    sim = SimEngine()
+    sim = SimEngine(seed=seed)
     applied = sim.apply(plan, graphs)
     report = sim.run_stimuli(applied, list(stimuli), rule_pack)
 

--- a/tests/sim/test_seed_reproducibility.py
+++ b/tests/sim/test_seed_reproducibility.py
@@ -1,0 +1,33 @@
+import networkx as nx
+
+from loto.models import IsolationPlan, Stimulus
+from loto.sim_engine import SimEngine
+
+
+def build_graph() -> nx.MultiDiGraph:
+    g = nx.MultiDiGraph()
+    g.add_node("source", is_source=True)
+    g.add_node("valve1")
+    g.add_node("valve2")
+    g.add_node("asset", tag="asset")
+    g.add_edge("source", "valve1")
+    g.add_edge("valve1", "asset")
+    g.add_edge("source", "valve2")
+    g.add_edge("valve2", "asset")
+    return g
+
+
+def test_repeated_runs_with_same_seed_are_identical() -> None:
+    engine = SimEngine()
+    plan = IsolationPlan(plan_id="p1")
+    stim = Stimulus(name="REMOTE_OPEN", magnitude=1.0, duration_s=1.0)
+
+    applied1 = engine.apply(plan, {"steam": build_graph()})
+    report1 = engine.run_stimuli(applied1, [stim], seed=123)
+
+    applied2 = engine.apply(plan, {"steam": build_graph()})
+    report2 = engine.run_stimuli(applied2, [stim], seed=123)
+
+    assert report1.results == report2.results
+    assert report1.results[0].paths == report2.results[0].paths
+    assert report1.seed == report2.seed == 123


### PR DESCRIPTION
## Summary
- add optional `seed` to `SimEngine` and seedable path enumeration
- capture the seed in `SimReport` and log it for reproducibility
- test that identical seeds produce identical simulation paths

## Testing
- `pre-commit run --files loto/sim_engine.py loto/models.py loto/service/blueprints.py loto/cli.py tests/sim/test_seed_reproducibility.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad17766bd083229507c55da6bb29ad