### PR TITLE
Add grouped asset capacity limits to impact engine

### DIFF
--- a/loto/impact_config.py
+++ b/loto/impact_config.py
@@ -23,6 +23,12 @@ class ImpactConfig:
         Mapping of asset identifier to MW penalty applied when unavailable.
     asset_areas:
         Mapping of penalty asset to area.
+    asset_mw:
+        Mapping of asset identifier to its MW capacity.
+    asset_groups:
+        Mapping of asset identifier to its bus/feeder group.
+    group_caps:
+        Maximum deliverable MW for each bus/feeder group.
     unknown_units:
         Set of unit names with missing or inconsistent data.
     unknown_penalties:
@@ -34,6 +40,9 @@ class ImpactConfig:
     unit_areas: Dict[str, str]
     penalties: Dict[str, float]
     asset_areas: Dict[str, str]
+    asset_mw: Dict[str, float]
+    asset_groups: Dict[str, str]
+    group_caps: Dict[str, float]
     unknown_units: Set[str]
     unknown_penalties: Set[str]
 
@@ -55,6 +64,12 @@ def load_impact_config(
                 rated: <MW>
                 area: <area_name>
                 assets: [<asset_id>, ...]
+            asset_mw:
+              <asset_id>: <MW>
+            asset_groups:
+              <asset_id>: <group_name>
+            group_caps:
+              <group_name>: <MW>
             penalties:
               <asset_id>:
                 mw: <MW>
@@ -81,12 +96,18 @@ def load_impact_config(
 
     units_info = um_data.get("units", {})
     penalties_info = um_data.get("penalties", {})
+    asset_mw_info = um_data.get("asset_mw", {})
+    asset_groups_info = um_data.get("asset_groups", {})
+    group_caps_info = um_data.get("group_caps", {})
 
     asset_units: Dict[str, str] = {}
     unit_data: Dict[str, Dict[str, Any]] = {}
     unit_areas: Dict[str, str] = {}
     penalties: Dict[str, float] = {}
     asset_areas: Dict[str, str] = {}
+    asset_mw: Dict[str, float] = {}
+    asset_groups: Dict[str, str] = {}
+    group_caps: Dict[str, float] = {}
     unknown_units: Set[str] = set()
     unknown_penalties: Set[str] = set()
 
@@ -116,6 +137,16 @@ def load_impact_config(
             continue
         penalties[asset] = float(mw)
         asset_areas[asset] = str(area)
+
+    # Asset MW and grouping information
+    for asset, mw in asset_mw_info.items():
+        asset_mw[str(asset)] = float(mw)
+
+    for asset, grp in asset_groups_info.items():
+        asset_groups[str(asset)] = str(grp)
+
+    for grp, cap in group_caps_info.items():
+        group_caps[str(grp)] = float(cap)
 
     # ------------------------------------------------------------------
     # Redundancy / derate scheme
@@ -151,6 +182,9 @@ def load_impact_config(
         unit_areas=unit_areas,
         penalties=penalties,
         asset_areas=asset_areas,
+        asset_mw=asset_mw,
+        asset_groups=asset_groups,
+        group_caps=group_caps,
         unknown_units=unknown_units,
         unknown_penalties=unknown_penalties,
     )

--- a/tests/test_impact_engine.py
+++ b/tests/test_impact_engine.py
@@ -1,11 +1,11 @@
 import networkx as nx
 
-from loto.sim_engine import SimEngine
-from loto.models import IsolationAction, IsolationPlan
 from loto.impact import ImpactEngine
+from loto.models import IsolationAction, IsolationPlan
+from loto.sim_engine import SimEngine
 
 
-def build_graph():
+def build_graph() -> nx.MultiDiGraph:
     g = nx.MultiDiGraph()
     g.add_node("source", is_source=True)
     g.add_node("uA", tag="asset")
@@ -16,19 +16,28 @@ def build_graph():
     # edges to assets; some are isolation points
     g.add_edge("source", "uA", is_isolation_point=True)
     g.add_edge("source", "uB1", is_isolation_point=True)
-    g.add_edge("source", "uB2")
+    g.add_edge("source", "uB2", is_isolation_point=True)
     g.add_edge("source", "local1", is_isolation_point=True)
     return g
 
 
-def test_derates_and_unavailable_sets():
+def test_derates_and_unavailable_sets() -> None:
     original = build_graph()
     plan = IsolationPlan(
         plan_id="p1",
         actions=[
-            IsolationAction(component_id="steam:source->uA", method="lock"),
-            IsolationAction(component_id="steam:source->uB1", method="lock"),
-            IsolationAction(component_id="steam:source->local1", method="lock"),
+            IsolationAction(
+                component_id="steam:source->uA", method="lock", duration_s=0
+            ),
+            IsolationAction(
+                component_id="steam:source->uB1", method="lock", duration_s=0
+            ),
+            IsolationAction(
+                component_id="steam:source->uB2", method="lock", duration_s=0
+            ),
+            IsolationAction(
+                component_id="steam:source->local1", method="lock", duration_s=0
+            ),
         ],
     )
 
@@ -39,8 +48,11 @@ def test_derates_and_unavailable_sets():
     asset_units = {"uA": "UnitA", "uB1": "UnitB", "uB2": "UnitB"}
     unit_data = {
         "UnitA": {"rated": 100.0, "scheme": "SPOF"},
-        "UnitB": {"rated": 90.0, "scheme": "N+1", "nplus": 2},
+        "UnitB": {"rated": 90.0, "scheme": "N+1"},
     }
+    asset_mw = {"uA": 100.0, "uB1": 60.0, "uB2": 40.0}
+    asset_groups = {"uA": "gA", "uB1": "gB", "uB2": "gB"}
+    group_caps = {"gA": 100.0, "gB": 70.0}
     unit_areas = {"UnitA": "North", "UnitB": "North"}
     penalties = {"local1": 5.0}
     asset_areas = {"local1": "South"}
@@ -50,10 +62,13 @@ def test_derates_and_unavailable_sets():
         asset_units=asset_units,
         unit_data=unit_data,
         unit_areas=unit_areas,
+        asset_mw=asset_mw,
+        asset_groups=asset_groups,
+        group_caps=group_caps,
         penalties=penalties,
         asset_areas=asset_areas,
     )
 
-    assert result.unavailable_assets == {"uA", "uB1", "local1"}
-    assert result.unit_mw_delta == {"UnitA": 100.0, "UnitB": 45.0}
-    assert result.area_mw_delta == {"North": 145.0, "South": 5.0}
+    assert result.unavailable_assets == {"uA", "uB1", "uB2", "local1"}
+    assert result.unit_mw_delta == {"UnitA": 100.0, "UnitB": 70.0}
+    assert result.area_mw_delta == {"North": 170.0, "South": 5.0}


### PR DESCRIPTION
## Summary
- extend `ImpactEngine.evaluate` with per-asset MW and grouping limits
- parse asset MW, groups and caps from impact config
- test impact engine with mixed capacities and feeder caps

## Testing
- `make lint`
- `make typecheck`
- `pre-commit run --files loto/impact.py loto/impact_config.py tests/test_impact_engine.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad2737b71883228f97350ae38c20b4