### PR TITLE
Add flag to control unit penalty application

### DIFF
--- a/tests/test_impact_engine.py
+++ b/tests/test_impact_engine.py
@@ -54,7 +54,7 @@ def test_derates_and_unavailable_sets() -> None:
     asset_groups = {"uA": "gA", "uB1": "gB", "uB2": "gB"}
     group_caps = {"gA": 100.0, "gB": 70.0}
     unit_areas = {"UnitA": "North", "UnitB": "North"}
-    penalties = {"local1": 5.0}
+    penalties = {"local1": 5.0, "uA": 10.0}
     asset_areas = {"local1": "South"}
 
     result = engine.evaluate(
@@ -72,3 +72,57 @@ def test_derates_and_unavailable_sets() -> None:
     assert result.unavailable_assets == {"uA", "uB1", "uB2", "local1"}
     assert result.unit_mw_delta == {"UnitA": 100.0, "UnitB": 70.0}
     assert result.area_mw_delta == {"North": 170.0, "South": 5.0}
+
+
+def test_include_unit_penalties() -> None:
+    original = build_graph()
+    plan = IsolationPlan(
+        plan_id="p1",
+        actions=[
+            IsolationAction(
+                component_id="steam:source->uA", method="lock", duration_s=0
+            ),
+            IsolationAction(
+                component_id="steam:source->uB1", method="lock", duration_s=0
+            ),
+            IsolationAction(
+                component_id="steam:source->uB2", method="lock", duration_s=0
+            ),
+            IsolationAction(
+                component_id="steam:source->local1", method="lock", duration_s=0
+            ),
+        ],
+    )
+
+    sim = SimEngine()
+    applied = sim.apply(plan, {"steam": original})
+
+    engine = ImpactEngine()
+    asset_units = {"uA": "UnitA", "uB1": "UnitB", "uB2": "UnitB"}
+    unit_data = {
+        "UnitA": {"rated": 100.0, "scheme": "SPOF"},
+        "UnitB": {"rated": 90.0, "scheme": "N+1"},
+    }
+    asset_mw = {"uA": 100.0, "uB1": 60.0, "uB2": 40.0}
+    asset_groups = {"uA": "gA", "uB1": "gB", "uB2": "gB"}
+    group_caps = {"gA": 100.0, "gB": 70.0}
+    unit_areas = {"UnitA": "North", "UnitB": "North"}
+    penalties = {"local1": 5.0, "uA": 10.0}
+    asset_areas = {"local1": "South"}
+
+    result = engine.evaluate(
+        applied,
+        asset_units=asset_units,
+        unit_data=unit_data,
+        unit_areas=unit_areas,
+        asset_mw=asset_mw,
+        asset_groups=asset_groups,
+        group_caps=group_caps,
+        penalties=penalties,
+        include_unit_penalties=True,
+        asset_areas=asset_areas,
+    )
+
+    assert result.unavailable_assets == {"uA", "uB1", "uB2", "local1"}
+    assert result.unit_mw_delta == {"UnitA": 110.0, "UnitB": 70.0}
+    assert result.area_mw_delta == {"North": 180.0, "South": 5.0}


### PR DESCRIPTION
## Summary
- allow `ImpactEngine.evaluate` to optionally include penalties for assets within units
- validate penalty assets in `load_impact_config` and warn on unit conflicts
- test penalty precedence when assets belong to units

## Testing
- `pre-commit run --files loto/impact.py loto/impact_config.py tests/test_impact_engine.py`
- `make test` *(fails: 68 errors during collection)*
- `pytest tests/test_impact_engine.py`


------
https://chatgpt.com/codex/tasks/task_b_68ad294327f083229dc29cc8f85ad1d6