### PR TITLE
Add round-robin hat selection for equal reactive scores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-PyYAML, pydantic, fastapi, pydantic-settings, typer]
+        additional_dependencies: [types-PyYAML, pydantic, fastapi, pydantic-settings, typer, types-requests]
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v9.33.0
     hooks:

--- a/loto/integrations/coupa_adapter.py
+++ b/loto/integrations/coupa_adapter.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from typing import Any, Dict, cast
 
-import requests  # type: ignore[import-untyped]
+import requests
 
 from ._errors import AdapterRequestError
 

--- a/loto/integrations/ellipse_adapter.py
+++ b/loto/integrations/ellipse_adapter.py
@@ -13,7 +13,7 @@ import os
 import time
 from typing import Any, Dict, cast
 
-import requests  # type: ignore[import-untyped]
+import requests
 
 from ._errors import AdapterRequestError
 

--- a/loto/integrations/maximo_adapter.py
+++ b/loto/integrations/maximo_adapter.py
@@ -6,7 +6,7 @@ import os
 import time
 from typing import Any, Dict, List, TypedDict, cast
 
-import requests  # type: ignore[import-untyped]
+import requests
 
 from ._errors import AdapterRequestError
 

--- a/tests/scheduling/test_reactive_round_robin.py
+++ b/tests/scheduling/test_reactive_round_robin.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Any
+
+from loto.scheduling import choose_hats_for_reactive
+
+
+@dataclass
+class Snap:
+    c_r: float
+
+
+def test_round_robin_rotation_without_replacement() -> None:
+    wo = object()
+    candidates = ["h1", "h2", "h3"]
+    snapshot = {hat: Snap(0.0) for hat in candidates}
+    policy: dict[str, Any] = {
+        "rotation": {},
+        "rotation_penalty": 0.0,
+        "rotation_limit": None,
+        "utilization": {},
+        "utilization_cap": 1.0,
+        "crew_size": 2,
+        "round_robin": {"next": 0},
+    }
+
+    chosen = choose_hats_for_reactive(wo, candidates, snapshot, policy)
+    assert chosen == ["h1", "h2"]
+    assert policy["round_robin"]["next"] == 2
+
+    chosen = choose_hats_for_reactive(wo, candidates, snapshot, policy)
+    assert chosen == ["h3", "h1"]
+    assert policy["round_robin"]["next"] == 1


### PR DESCRIPTION
## Summary
- add optional `round_robin` policy to choose_hats_for_reactive for deterministic rotation when weights are equal
- document the new policy and add tests
- include types-requests in pre-commit config and clean up unused mypy ignores

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `pre-commit run --files .pre-commit-config.yaml loto/scheduling/reactive.py tests/scheduling/test_reactive_round_robin.py loto/integrations/maximo_adapter.py loto/integrations/ellipse_adapter.py loto/integrations/coupa_adapter.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad35c8514083228de50fc3c6c4fa1f