### PR TITLE
Coalesce scheduling slots for hat availability

### DIFF
--- a/tests/scheduling/test_assign_coalesce.py
+++ b/tests/scheduling/test_assign_coalesce.py
@@ -1,0 +1,19 @@
+from loto.scheduling.assign import Hat, coalesce_slots, is_available
+
+
+def test_coalesce_slots_merges_ranges() -> None:
+    assert coalesce_slots([0, 1, 2, 4, 5, 7]) == [(0, 2), (4, 5), (7, 7)]
+
+
+def test_hat_calendar_coalesces() -> None:
+    hat = Hat(id="h", skills={"w"}, calendar=[0, 1, 2, 4], rank=1)
+    assert hat.calendar == [(0, 2), (4, 4)]
+
+
+def test_is_available() -> None:
+    ranges = [(0, 2), (4, 4)]
+    assert is_available(1, ranges)
+    assert not is_available(3, ranges)
+    hat = Hat(id="h", skills={"w"}, calendar=ranges, rank=1)
+    assert is_available(4, hat.calendar)
+    assert not is_available(3, hat.calendar)

--- a/tests/scheduling/test_assign_ranked.py
+++ b/tests/scheduling/test_assign_ranked.py
@@ -9,10 +9,10 @@ class _Bias:
         return duration_s + rank
 
 
-def test_prefers_higher_rank():
+def test_prefers_higher_rank() -> None:
     hats = [
-        Hat(id="h1", skills={"w"}, calendar={0}, rank=2),
-        Hat(id="h2", skills={"w"}, calendar={0}, rank=1),
+        Hat(id="h1", skills={"w"}, calendar=[(0, 0)], rank=2),
+        Hat(id="h2", skills={"w"}, calendar=[(0, 0)], rank=1),
     ]
     task = Task(skill="w", start=0, duration_s=1)
     chosen = simulate(task, hats, _Bias())
@@ -20,10 +20,10 @@ def test_prefers_higher_rank():
     assert chosen.id == "h2"
 
 
-def test_respects_calendar():
+def test_respects_calendar() -> None:
     hats = [
         Hat(id="h1", skills={"w"}, calendar={1}, rank=1),
-        Hat(id="h2", skills={"w"}, calendar={0}, rank=2),
+        Hat(id="h2", skills={"w"}, calendar=[0], rank=2),
     ]
     task = Task(skill="w", start=0, duration_s=1)
     chosen = simulate(task, hats, _Bias())


### PR DESCRIPTION
## Summary
- add `coalesce_slots` and `is_available` helpers for calendar ranges
- allow `Hat` to accept calendar ranges and coalesce slots on init
- use range availability in assignment and test coalescing behaviour

## Testing
- `pre-commit run --files loto/scheduling/assign.py tests/scheduling/test_assign_ranked.py tests/scheduling/test_assign_coalesce.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad38996cec8322a3722c1f37a94583