### PR TITLE
Plumb callback time into planner weights

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -50,6 +50,7 @@ from loto.errors import GenerationError
 from loto.errors import ImportError as LotoImportError
 from loto.errors import LotoError, ValidationError
 from loto.impact_config import load_impact_config
+from loto.integrations import get_permit_adapter
 from loto.integrations.stores_adapter import DemoStoresAdapter
 from loto.inventory import (
     CANONICAL_UNITS,
@@ -767,6 +768,8 @@ def _generate_blueprint(payload: BlueprintRequest) -> BlueprintResponse:
     adapter = DemoMaximoAdapter()
     ctx = adapter.load_context(payload.workorder_id)
     impact_cfg = ctx["impact_cfg"]
+    permit = get_permit_adapter().fetch_permit(payload.workorder_id)
+    cfg: Dict[str, Any] = {"callback_time_min": permit.get("callback_time_min", 0)}
 
     global STATE
     STATE = dict(inventory_state(work_order, check_parts, STATE))
@@ -792,6 +795,7 @@ def _generate_blueprint(payload: BlueprintRequest) -> BlueprintResponse:
                 unit_areas=impact_cfg.unit_areas,
                 penalties=impact_cfg.penalties,
                 asset_areas=impact_cfg.asset_areas,
+                config=cfg,
             )
             plans_generated_total.inc()
         except Exception:

--- a/loto/integrations/ellipse_adapter.py
+++ b/loto/integrations/ellipse_adapter.py
@@ -42,11 +42,13 @@ class DemoEllipseAdapter(EllipseAdapter):
             "id": "PRM-1",
             "status": "Active",
             "applied_isolations": ["ISO-1", "ISO-2"],
+            "callback_time_min": 0,
         },
         "WO-2": {
             "id": "PRM-2",
             "status": "Authorised",
             "applied_isolations": ["ISO-3"],
+            "callback_time_min": 0,
         },
     }
 
@@ -61,7 +63,12 @@ class DemoEllipseAdapter(EllipseAdapter):
         """Return fixture permit data for the work order."""
         return self._PERMITS.get(
             work_order_id,
-            {"id": None, "status": "Unknown", "applied_isolations": []},
+            {
+                "id": None,
+                "status": "Unknown",
+                "applied_isolations": [],
+                "callback_time_min": 0,
+            },
         )
 
 
@@ -136,7 +143,9 @@ class HttpEllipseAdapter(EllipseAdapter):
 
     def fetch_permit(self, work_order_id: str) -> Dict[str, Any]:
         """Fetch permit data for ``work_order_id`` via the Ellipse API."""
-        return self._get(f"permits/{work_order_id}")
+        data = self._get(f"permits/{work_order_id}")
+        data["callback_time_min"] = data.pop("callbackTimeMin", 0)
+        return data
 
 
 __all__ = ["EllipseAdapter", "DemoEllipseAdapter", "HttpEllipseAdapter"]

--- a/loto/service/blueprints.py
+++ b/loto/service/blueprints.py
@@ -89,6 +89,7 @@ def plan_and_evaluate(
     penalties: Dict[str, float] | None = None,
     asset_areas: Dict[str, str] | None = None,
     seed: int | None = None,
+    config: Mapping[str, object] | None = None,
 ) -> Tuple[IsolationPlan, SimReport, ImpactResult, Provenance]:
     """Run builder → planner → simulator → impact evaluation pipeline.
 
@@ -120,7 +121,9 @@ def plan_and_evaluate(
 
     planner = IsolationPlanner()
     start = time.perf_counter()
-    plan = planner.compute(graphs, asset_tag=asset_tag, rule_pack=rule_pack)
+    plan = planner.compute(
+        graphs, asset_tag=asset_tag, rule_pack=rule_pack, config=config
+    )
     duration = time.perf_counter() - start
     logger.info("plan_generated", duration=duration)
 

--- a/tests/integrations/test_ellipse_adapter.py
+++ b/tests/integrations/test_ellipse_adapter.py
@@ -10,4 +10,5 @@ def test_demo_adapter_returns_work_order_and_permit() -> None:
         "id": "PRM-1",
         "status": "Active",
         "applied_isolations": ["ISO-1", "ISO-2"],
+        "callback_time_min": 0,
     }

--- a/tests/planner/test_weighted_cut.py
+++ b/tests/planner/test_weighted_cut.py
@@ -10,8 +10,8 @@ def test_weighted_cut_prefers_cheapest() -> None:
     g.add_node("N")
     g.add_node("T", tag="asset")
 
-    g.add_edge("S", "N", is_isolation_point=True, isolation_cost=5.0)
-    g.add_edge("N", "T", is_isolation_point=True, isolation_cost=1.0)
+    g.add_edge("S", "N", is_isolation_point=True, op_cost_min=5.0)
+    g.add_edge("N", "T", is_isolation_point=True, op_cost_min=1.0)
 
     planner = IsolationPlanner()
     pack = RulePack(risk_policies=None)


### PR DESCRIPTION
## Summary
- plumb callback_time_min from permits into planning
- weight isolation capacities using operation, risk, and callback factors

## Testing
- `pre-commit run --files apps/api/main.py loto/integrations/ellipse_adapter.py loto/isolation_planner.py loto/service/blueprints.py tests/planner/test_weighted_cut.py tests/integrations/test_ellipse_adapter.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad3e7505f08322895c6a0d922b09a3