### PR TITLE
Tighten DDBB proof with safe-sink check

### DIFF
--- a/tests/planner/test_verifications.py
+++ b/tests/planner/test_verifications.py
@@ -18,7 +18,7 @@ def ddbb_graph() -> nx.MultiDiGraph:
     g.add_node("v1")
     g.add_node("v2")
     g.add_node("t", tag="asset")
-    g.add_node("b")
+    g.add_node("b", safe_sink=True)
     g.add_edge("s", "v1", is_isolation_point=True)
     g.add_edge("v1", "v2", is_isolation_point=True)
     g.add_edge("v2", "t")


### PR DESCRIPTION
## Summary
- ensure DDBB candidates isolate sources, vent to a safe sink, and produce a certificate
- flag redundant DDBB paths when reopening a block doesn't re-energise
- mark bleed nodes in tests as safe sinks

## Testing
- `pre-commit run --files loto/isolation_planner.py tests/planner/test_verifications.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad447744e08322960231edc8804c50