### PR TITLE
feat: enhance simulation invariants

### DIFF
--- a/tests/sim/test_invariants.py
+++ b/tests/sim/test_invariants.py
@@ -11,6 +11,8 @@ def build_graph() -> nx.MultiDiGraph:
     g.add_node("asset", tag="asset")
     g.add_edge("source", "valve1", is_isolation_point=True)
     g.add_edge("valve1", "asset")
+    g.add_node("bleed", safe_sink=True)
+    g.add_edge("asset", "bleed", is_bleed=True)
     return g
 
 
@@ -75,3 +77,75 @@ def test_reports_multiple_offending_paths() -> None:
     assert len(paths) == 2
     assert ["source", "valve1", "asset"] in paths
     assert ["source", "valve2", "asset"] in paths
+
+
+def test_trapped_component_without_bleed_fails() -> None:
+    g = nx.MultiDiGraph()
+    g.add_node("s", is_source=True)
+    g.add_node("v")
+    g.add_node("t", tag="asset")
+    g.add_edge("s", "v", is_isolation_point=True)
+    g.add_edge("v", "t")
+
+    plan = IsolationPlan(
+        plan_id="p1",
+        actions=[
+            IsolationAction(component_id="steam:s->v", method="lock", duration_s=1.0)
+        ],
+    )
+    engine = SimEngine()
+    applied = engine.apply(plan, {"steam": g})
+    stim = Stimulus(name="REMOTE_OPEN", magnitude=1.0, duration_s=1.0)
+
+    report = engine.run_stimuli(applied, [stim])
+    res = report.results[0]
+    assert not res.success
+    assert res.paths is not None and ["t"] in res.paths
+    assert res.hint is not None and "bleed" in res.hint
+
+
+def test_trapped_component_can_bleed_through_check_valve() -> None:
+    g = nx.MultiDiGraph()
+    g.add_node("s", is_source=True)
+    g.add_node("v")
+    g.add_node("cv")
+    g.add_node("t", tag="asset")
+    g.add_node("b", safe_sink=True)
+    g.add_edge("s", "v", is_isolation_point=True)
+    g.add_edge("v", "cv")
+    g.add_edge("cv", "t", kind="check valve")
+    g.add_edge("cv", "b", is_bleed=True)
+
+    plan = IsolationPlan(
+        plan_id="p1",
+        actions=[
+            IsolationAction(component_id="steam:s->v", method="lock", duration_s=1.0)
+        ],
+    )
+    engine = SimEngine()
+    applied = engine.apply(plan, {"steam": g})
+    stim = Stimulus(name="REMOTE_OPEN", magnitude=1.0, duration_s=1.0)
+
+    report = engine.run_stimuli(applied, [stim])
+    res = report.results[0]
+    assert res.success
+
+
+def test_check_valve_blocks_reverse_flow() -> None:
+    g = nx.MultiDiGraph()
+    g.add_node("s", is_source=True)
+    g.add_node("cv")
+    g.add_node("t", tag="asset")
+    g.add_node("b", safe_sink=True)
+    g.add_edge("t", "cv", kind="check valve")
+    g.add_edge("cv", "s")
+    g.add_edge("t", "b", is_bleed=True)
+
+    plan = IsolationPlan(plan_id="p1", actions=[])
+    engine = SimEngine()
+    applied = engine.apply(plan, {"steam": g})
+    stim = Stimulus(name="REMOTE_OPEN", magnitude=1.0, duration_s=1.0)
+
+    report = engine.run_stimuli(applied, [stim])
+    res = report.results[0]
+    assert res.success


### PR DESCRIPTION
## Summary
- add traversal builder that treats check valves as one-way and adds optional reverse leak edges
- flag trapped components lacking a path to a safe sink
- extend invariant tests for bleeds and non-return valves

## Testing
- `pre-commit run --files loto/sim_engine.py tests/sim/test_invariants.py tests/test_sim_stimuli.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad4659ff6c8322bb260954878ee7af