### PR TITLE
Add policy cost comparison utilities and API endpoint

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -75,6 +75,7 @@ from .audit import add_record
 from .demo_data import demo_data
 from .hats_endpoints import router as hats_router  # provides hats KPI endpoints
 from .pid_endpoints import router as pid_router
+from .policy_endpoints import router as policy_router
 from .schemas import (
     BlueprintRequest,
     BlueprintResponse,
@@ -190,6 +191,7 @@ app.add_middleware(
 app.include_router(pid_router)
 app.include_router(hats_router)
 app.include_router(workorder_router)
+app.include_router(policy_router)
 
 if os.getenv("TRACE_ENABLED", "").lower() == "true":
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor

--- a/apps/api/policy_endpoints.py
+++ b/apps/api/policy_endpoints.py
@@ -1,0 +1,55 @@
+from typing import Literal
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from loto.sim import FailureModel, compare_policies
+
+router = APIRouter(prefix="/policy", tags=["policy", "LOTO"])
+
+
+class PolicyRequest(BaseModel):
+    tau: float
+    reactive_cost: float
+    secondary_damage: float
+    planned_cost: float
+    expedite_cost: float
+    price_per_mwh: float
+    derate_mw: float
+    downtime_hours: float
+    cbt_penalty: float
+    failure_rate: float
+    shape: float | None = None
+    distribution: Literal["exponential", "weibull"] = "exponential"
+    workorder_id: str | None = None
+    permit_id: str | None = None
+    permit_verified: bool = False
+
+
+class PolicyResponse(BaseModel):
+    rtf: float
+    plan: float
+    expedite: float
+
+
+@router.post("", response_model=PolicyResponse)
+async def post_policy(payload: PolicyRequest) -> PolicyResponse:
+    model = FailureModel(
+        rate=payload.failure_rate, shape=payload.shape, dist=payload.distribution
+    )
+    costs = compare_policies(
+        model,
+        tau=payload.tau,
+        reactive_cost=payload.reactive_cost,
+        secondary_damage=payload.secondary_damage,
+        planned_cost=payload.planned_cost,
+        expedite_cost=payload.expedite_cost,
+        price_per_mwh=payload.price_per_mwh,
+        derate_mw=payload.derate_mw,
+        downtime_hours=payload.downtime_hours,
+        cbt_penalty=payload.cbt_penalty,
+        permit_id=payload.permit_id,
+        permit_verified=payload.permit_verified,
+        workorder_id=payload.workorder_id,
+    )
+    return PolicyResponse(**costs)

--- a/loto/sim/__init__.py
+++ b/loto/sim/__init__.py
@@ -1,0 +1,5 @@
+"""Simulation utilities for policy comparison."""
+
+from .policy import FailureModel, compare_policies
+
+__all__ = ["FailureModel", "compare_policies"]

--- a/loto/sim/policy.py
+++ b/loto/sim/policy.py
@@ -1,0 +1,89 @@
+"""Expected cost comparison for maintenance policies."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from loto.impact import unit_derate_curve
+from loto.integrations import get_permit_adapter
+from loto.permits import permit_ready
+
+
+@dataclass
+class FailureModel:
+    """Failure-time distribution model."""
+
+    rate: float
+    shape: float | None = None
+    dist: Literal["exponential", "weibull"] = "exponential"
+
+    def survival(self, t: float) -> float:
+        """Return survival probability ``P(T > t)``."""
+
+        if self.dist == "exponential":
+            return math.exp(-self.rate * t)
+        if self.shape is None:
+            raise ValueError("shape required for weibull distribution")
+        return math.exp(-((t / self.rate) ** self.shape))
+
+
+def _downtime_cost(mw: float, hours: float, price_per_mwh: float) -> float:
+    """Return cost of a derate ``mw`` for ``hours`` at ``price_per_mwh``."""
+
+    curve = unit_derate_curve(0.0, hours, mw)
+    loss = 0.0
+    for (t1, m1), (t2, _) in zip(curve, curve[1:]):
+        loss += (t2 - t1) * m1
+    return loss * price_per_mwh
+
+
+def compare_policies(
+    model: FailureModel,
+    *,
+    tau: float,
+    reactive_cost: float,
+    secondary_damage: float,
+    planned_cost: float,
+    expedite_cost: float,
+    price_per_mwh: float,
+    derate_mw: float,
+    downtime_hours: float,
+    cbt_penalty: float,
+    permit_id: str | None = None,
+    permit_verified: bool = False,
+    workorder_id: str | None = None,
+) -> dict[str, float]:
+    """Compare expected costs of RTF, plan-at-τ and expedite policies."""
+
+    permit_delay = 0.0
+    if not permit_ready(
+        {"permit_id": permit_id, "permit_verified": int(permit_verified)}
+    ):
+        permit_delay = 24.0
+
+    callback_min = 0.0
+    if workorder_id:
+        try:
+            adapter = get_permit_adapter()
+            permit = adapter.fetch_permit(workorder_id)
+            callback_min = float(permit.get("callback_time_min", 0))
+        except Exception:
+            callback_min = 0.0
+
+    rtf_hours = downtime_hours + permit_delay + callback_min / 60.0
+    rtf_downtime = _downtime_cost(derate_mw, rtf_hours, price_per_mwh)
+    rtf = reactive_cost + secondary_damage + rtf_downtime + cbt_penalty
+
+    planned_hours = downtime_hours
+    planned_downtime = _downtime_cost(derate_mw, planned_hours, price_per_mwh)
+    planned_base = planned_cost + planned_downtime
+    survive = model.survival(tau)
+    plan = (1.0 - survive) * rtf + survive * planned_base
+
+    exp_hours = downtime_hours
+    exp_downtime = _downtime_cost(derate_mw, exp_hours, price_per_mwh)
+    expedite = expedite_cost + exp_downtime
+
+    return {"rtf": rtf, "plan": plan, "expedite": expedite}


### PR DESCRIPTION
## Summary
- add `FailureModel` and `compare_policies` utilities to estimate RTF vs plan vs expedite costs
- expose new `/policy` endpoint for cost comparison and register router

## Testing
- `pre-commit run --files apps/api/main.py apps/api/policy_endpoints.py loto/sim/__init__.py loto/sim/policy.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad48f8586c8322a1e10beb76fed50a