### PR TITLE
Support weight columns in CSV graph models

### DIFF
--- a/loto/graph_models.py
+++ b/loto/graph_models.py
@@ -54,6 +54,12 @@ class LineRow(BaseModel):
     line_tag: Optional[str] = None
     isolation_cost: Optional[float] = None
     medium: Optional[str] = None
+    op_cost_min: Optional[float] = None
+    reset_time_min: Optional[float] = None
+    risk_weight: Optional[float] = None
+    travel_time_min: Optional[float] = None
+    elevation_penalty: Optional[float] = None
+    outage_penalty: Optional[float] = None
 
     _normalise_domain = validator("domain", pre=True, allow_reuse=True)(
         _normalise_domain
@@ -74,6 +80,12 @@ class ValveRow(BaseModel):
     kind: Optional[str] = None
     isolation_cost: Optional[float] = None
     medium: Optional[str] = None
+    op_cost_min: Optional[float] = None
+    reset_time_min: Optional[float] = None
+    risk_weight: Optional[float] = None
+    travel_time_min: Optional[float] = None
+    elevation_penalty: Optional[float] = None
+    outage_penalty: Optional[float] = None
 
     _normalise_domain = validator("domain", pre=True, allow_reuse=True)(
         _normalise_domain


### PR DESCRIPTION
## Summary
- parse optional cost and penalty columns from line and valve CSVs
- attach parsed weights to graph edges and nodes
- cover new columns with tests

## Testing
- `make fmt`
- `pre-commit run --files loto/graph_models.py loto/graph_builder.py tests/test_graph_builder.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad4cfbe6008322b53b3d313d364811