### PR TITLE
Expose planner weights via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,18 @@ DATA_IN=data/in
 DATA_OUT=data/out
 RULEPACK_FILE=config/hswa_rules_v1.1.yaml
 
+# Planner weighting
+W_ALPHA=1.0
+W_BETA=5.0
+W_GAMMA=0.5
+W_DELTA=1.0
+W_EPSILON=2.0
+W_ZETA=0.5
+CB_SCALE=30.0
+CB_MAX=120.0
+RST_SCALE=30.0
+PLANNER_NODE_SPLIT=1
+
 # Sentry error reporting (optional)
 SENTRY_DSN=
 

--- a/loto/isolation_planner.py
+++ b/loto/isolation_planner.py
@@ -21,15 +21,23 @@ import networkx as nx
 
 from .models import IsolationAction, IsolationPlan, RulePack
 
-ALPHA = 1.0
-BETA = 5.0
-GAMMA = 0.5
-DELTA = 1.0
-EPSILON = 2.0
-ZETA = 0.5
-CB_SCALE = 30.0
-CB_MAX = 120.0
-RST_SCALE = 30.0
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+ALPHA = _env_float("W_ALPHA", 1.0)
+BETA = _env_float("W_BETA", 5.0)
+GAMMA = _env_float("W_GAMMA", 0.5)
+DELTA = _env_float("W_DELTA", 1.0)
+EPSILON = _env_float("W_EPSILON", 2.0)
+ZETA = _env_float("W_ZETA", 0.5)
+CB_SCALE = _env_float("CB_SCALE", 30.0)
+CB_MAX = _env_float("CB_MAX", 120.0)
+RST_SCALE = _env_float("RST_SCALE", 30.0)
 
 
 def _split_nodes(graph: nx.MultiDiGraph) -> nx.MultiDiGraph:
@@ -134,7 +142,7 @@ class IsolationPlanner:
 
         cbt = float((config or {}).get("callback_time_min", 0))
 
-        node_split = os.getenv("PLANNER_NODE_SPLIT") not in ("0", "", None)
+        node_split = os.getenv("PLANNER_NODE_SPLIT", "1") not in ("0", "")
         work_graphs: Dict[str, nx.MultiDiGraph] = {}
 
         for domain, base_graph in graphs.items():

--- a/tests/planner/test_isolationplan_type.py
+++ b/tests/planner/test_isolationplan_type.py
@@ -1,18 +1,22 @@
 import networkx as nx
+import pytest
 
 from loto.isolation_planner import IsolationPlanner
-from loto.rule_engine import RulePack
+from loto.rule_engine import RulePack  # type: ignore[attr-defined]
 from loto.models import IsolationPlan
 
 
-def test_planner_returns_models_isolationplan():
+def test_planner_returns_models_isolationplan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
     g = nx.MultiDiGraph()
     g.add_node("s", is_source=True)
     g.add_node("t", tag="asset")
     g.add_edge("s", "t", is_isolation_point=True)
 
     planner = IsolationPlanner()
-    pack = RulePack()
+    pack = RulePack(risk_policies=None)
     result = planner.compute({"process": g}, asset_tag="asset", rule_pack=pack)
 
     assert isinstance(result, IsolationPlan)

--- a/tests/planner/test_verifications.py
+++ b/tests/planner/test_verifications.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import pytest
 
 from loto.isolation_planner import IsolationPlanner, VerificationGate
 from loto.models import RulePack
@@ -34,7 +35,8 @@ def ddbb_with_bypass_graph() -> nx.MultiDiGraph:
     return g
 
 
-def test_basic_verifications() -> None:
+def test_basic_verifications(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
     planner = IsolationPlanner()
     plan = planner.compute(
         {"p": simple_graph()}, asset_tag="asset", rule_pack=RulePack(risk_policies=None)
@@ -44,7 +46,8 @@ def test_basic_verifications() -> None:
     assert any("no-movement" in v for v in plan.verifications)
 
 
-def test_ddbb_valid() -> None:
+def test_ddbb_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
     planner = IsolationPlanner()
     plan = planner.compute(
         {"p": ddbb_graph()}, asset_tag="asset", rule_pack=RulePack(risk_policies=None)
@@ -54,7 +57,8 @@ def test_ddbb_valid() -> None:
     assert any("DDBB" in v for v in plan.verifications)
 
 
-def test_ddbb_bypass_not_flagged() -> None:
+def test_ddbb_bypass_not_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
     planner = IsolationPlanner()
     plan = planner.compute(
         {"p": ddbb_with_bypass_graph()},

--- a/tests/planner/test_weighted_cut.py
+++ b/tests/planner/test_weighted_cut.py
@@ -1,10 +1,12 @@
 import networkx as nx
+import pytest
 
 from loto.isolation_planner import IsolationPlanner
 from loto.rule_engine import RulePack  # type: ignore[attr-defined]
 
 
-def test_weighted_cut_prefers_cheapest() -> None:
+def test_weighted_cut_prefers_cheapest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
     g = nx.MultiDiGraph()
     g.add_node("S", is_source=True)
     g.add_node("N")

--- a/tests/test_planner_min_cut.py
+++ b/tests/test_planner_min_cut.py
@@ -1,10 +1,12 @@
 import networkx as nx
+import pytest
 
 from loto.isolation_planner import IsolationPlanner
 from loto.rule_engine import RulePack  # type: ignore[attr-defined]
 
 
-def test_min_cut_blocks_targets() -> None:
+def test_min_cut_blocks_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
     g = nx.MultiDiGraph()
     g.add_node("S1", is_source=True)
     g.add_node("S2", is_source=True)
@@ -41,7 +43,8 @@ def test_min_cut_blocks_targets() -> None:
             assert not nx.has_path(g_cut, s, t)
 
 
-def test_global_cut_smaller_than_union() -> None:
+def test_global_cut_smaller_than_union(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
     g = nx.MultiDiGraph()
     g.add_node("S", is_source=True)
     g.add_node("A")

--- a/tests/test_service_blueprints.py
+++ b/tests/test_service_blueprints.py
@@ -13,6 +13,7 @@ def test_plan_and_evaluate_deterministic(
     monkeypatch.setattr(
         "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
     )
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
     line_df = pd.DataFrame(
         [
             {"domain": "steam", "from_tag": "S", "to_tag": "V"},


### PR DESCRIPTION
## Summary
- allow tuning of planner weights (W_ALPHA..W_ZETA) and CBT scaling (CB_SCALE/CB_MAX/RST_SCALE) via environment variables
- document planner weight env vars in `.env.example`
- ensure tests set `PLANNER_NODE_SPLIT=0` when relying on edge-based isolation while defaulting to split nodes

## Testing
- `pre-commit run --files loto/isolation_planner.py .env.example tests/planner/test_isolationplan_type.py tests/planner/test_verifications.py tests/planner/test_weighted_cut.py tests/test_planner_min_cut.py tests/test_service_blueprints.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad4f6f06b88322b58c431cafdc3ec1