### PR TITLE
feat(ui): update triage timeline API

### DIFF
--- a/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
+++ b/apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx
@@ -46,7 +46,7 @@ test('renders virtualized gantt and updates conflicts', async () => {
       if (typeof input === 'string' && input === apiBase + '/schedule') {
         return Promise.resolve({ ok: true, json: async () => sample } as Response);
       }
-      if (typeof input === 'string' && input === apiBase + '/triage') {
+      if (typeof input === 'string' && input === apiBase + '/triage/snapshot') {
         return Promise.resolve({ ok: true, json: async () => [] } as Response);
       }
       return Promise.resolve({ ok: true, json: async () => ({}) } as Response);

--- a/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
+++ b/apps/maximo-extension-ui/src/components/ReactivePicker.tsx
@@ -7,7 +7,7 @@ import { fetchHats } from '../mocks/hats';
 import type { HatCandidate } from '../types/api';
 
 async function fetchCandidatesApi(): Promise<HatCandidate[]> {
-  const res = await apiFetch('/triage');
+  const res = await apiFetch('/triage/snapshot');
   if (!res.ok) throw new Error('Failed to fetch triage scores');
   return (await res.json()) as HatCandidate[];
 }

--- a/apps/maximo-extension-ui/src/components/TriageTimeline.tsx
+++ b/apps/maximo-extension-ui/src/components/TriageTimeline.tsx
@@ -10,7 +10,7 @@ export interface TriageLane {
 }
 
 /**
- * Render a simple timeline for hats with rank badges and accessible tooltips.
+ * Render a simple triage timeline with rank badges and accessible tooltips.
  */
 export default function TriageTimeline({ lanes }: { lanes: TriageLane[] }) {
   return (


### PR DESCRIPTION
## Summary
- switch reactive candidate fetch to `/triage/snapshot`
- clarify TriageTimeline docs to reference triage timeline
- adjust scheduler test to stub new triage snapshot endpoint

## Testing
- `pre-commit run --files apps/maximo-extension-ui/src/components/TriageTimeline.tsx apps/maximo-extension-ui/src/components/ReactivePicker.tsx "apps/maximo-extension-ui/src/app/scheduler/[wo]/page.test.tsx"`
- `pnpm install`
- `pnpm -F maximo-extension-ui test`
- `make fmt`
- `make lint`
- `pip install types-requests`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad72c1c3d4832297a743dfce085a1c