### PR TITLE
Add HATS permit competency mapping and checks

### DIFF
--- a/config/hats_permit_map.yaml
+++ b/config/hats_permit_map.yaml
@@ -1,0 +1,7 @@
+ConfinedSpace:
+  - CS-ENTRY
+  - GAS-TEST
+Electrical:
+  - ELEC
+HighVoltage:
+  - HV

--- a/tests/integrations/test_hats_adapter.py
+++ b/tests/integrations/test_hats_adapter.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import yaml
+
 from loto.integrations.hats_adapter import DemoHatsAdapter, HatsAdapter
 
 
@@ -5,3 +9,16 @@ def test_demo_hats_adapter_get_profile_keys() -> None:
     adapter: HatsAdapter = DemoHatsAdapter()
     profile = adapter.get_profile("DEMO-1")
     assert {"inductions", "competencies", "roster"} <= set(profile)
+
+
+def test_hats_permit_map_loads() -> None:
+    cfg = yaml.safe_load(Path("config/hats_permit_map.yaml").read_text())
+    assert "ConfinedSpace" in cfg
+
+
+def test_demo_hats_adapter_has_required() -> None:
+    adapter: HatsAdapter = DemoHatsAdapter()
+    ok, missing = adapter.has_required(["DEMO-1"], ["Electrical", "HighVoltage"])
+    assert ok and not missing
+    ok, missing = adapter.has_required(["DEMO-1"], ["ConfinedSpace"])
+    assert not ok and missing == ["DEMO-1"]


### PR DESCRIPTION
## Summary
- map permit types to competency/induction codes
- validate HATS profiles against permit requirements
- test permit map loading and has_required logic

## Testing
- `pre-commit run --files config/hats_permit_map.yaml loto/integrations/hats_adapter.py tests/integrations/test_hats_adapter.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad79353e708322a41034028ee2f44e