### PR TITLE
Add TTL cache for HATS profiles

### DIFF
--- a/tests/integrations/test_hats_adapter.py
+++ b/tests/integrations/test_hats_adapter.py
@@ -1,8 +1,15 @@
 from pathlib import Path
+from typing import Any, Dict, cast
 
+import pytest
 import yaml
 
-from loto.integrations.hats_adapter import DemoHatsAdapter, HatsAdapter
+import loto.integrations.hats_adapter as hats_adapter
+from loto.integrations.hats_adapter import (
+    DemoHatsAdapter,
+    HatsAdapter,
+    HttpHatsAdapter,
+)
 
 
 def test_demo_hats_adapter_get_profile_keys() -> None:
@@ -22,3 +29,46 @@ def test_demo_hats_adapter_has_required() -> None:
     assert ok and not missing
     ok, missing = adapter.has_required(["DEMO-1"], ["ConfinedSpace"])
     assert not ok and missing == ["DEMO-1"]
+
+
+def test_http_hats_adapter_profile_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+    fake_time = 1_000.0
+
+    class DummyResp:
+        def __init__(self, data: Dict[str, Any]) -> None:
+            self._data = data
+
+        def json(self) -> Dict[str, Any]:
+            return self._data
+
+        def raise_for_status(self) -> None:  # pragma: no cover - no-op
+            return None
+
+    def fake_get(url: str, headers: Dict[str, str], timeout: int) -> DummyResp:
+        nonlocal calls
+        calls += 1
+        return DummyResp({"id": "H1"})
+
+    monkeypatch.setattr(cast(Any, hats_adapter).requests, "get", fake_get)
+    monkeypatch.setattr(cast(Any, hats_adapter).time, "time", lambda: fake_time)
+
+    adapter = HttpHatsAdapter("http://example.com")
+
+    adapter.get_profile("H1")
+    assert calls == 1
+
+    adapter.get_profile("H1")
+    assert calls == 1
+    assert adapter.cache_hits == 1
+
+    monkeypatch.setattr(
+        cast(Any, hats_adapter).time,
+        "time",
+        lambda: fake_time + adapter.profile_cache_ttl + 1,
+    )
+
+    adapter.get_profile("H1")
+    assert calls == 2


### PR DESCRIPTION
## Summary
- add 10 minute TTL cache for HATS profile lookups with cache hit metric
- test that HATS profile cache is used and invalidated after TTL

## Testing
- `pre-commit run --files loto/integrations/hats_adapter.py tests/integrations/test_hats_adapter.py`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68ad7b9b12bc8322bd14c33216258589