### PR TITLE
Add HATS compliance gate for INPRG status updates

### DIFF
--- a/loto/integrations/__init__.py
+++ b/loto/integrations/__init__.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from .coupa_adapter import CoupaAdapter, DemoCoupaAdapter, HttpCoupaAdapter
 from .ellipse_adapter import DemoEllipseAdapter, EllipseAdapter, HttpEllipseAdapter
+from .hats_adapter import DemoHatsAdapter, HatsAdapter, HttpHatsAdapter
 from .maximo_adapter import MaximoAdapter
 from .stores_adapter import DemoStoresAdapter, StoresAdapter
 from .wapr_adapter import DemoWaprAdapter, WaprAdapter
@@ -106,11 +107,21 @@ def get_permit_adapter() -> EllipseAdapter | WaprAdapter:
     return DemoEllipseAdapter()
 
 
+def get_hats_adapter() -> HatsAdapter:
+    """Return a HATS adapter based on environment configuration."""
+
+    base_url = os.getenv("HATS_BASE_URL")
+    if base_url:
+        return HttpHatsAdapter(base_url, os.getenv("HATS_API_KEY"))
+    return DemoHatsAdapter()
+
+
 __all__ = [
     "IntegrationAdapter",
     "DemoIntegrationAdapter",
     "get_integration_adapter",
     "get_permit_adapter",
+    "get_hats_adapter",
     "CoupaAdapter",
     "DemoCoupaAdapter",
     "HttpCoupaAdapter",
@@ -121,5 +132,8 @@ __all__ = [
     "EllipseAdapter",
     "DemoEllipseAdapter",
     "HttpEllipseAdapter",
+    "HatsAdapter",
+    "DemoHatsAdapter",
+    "HttpHatsAdapter",
     "MaximoAdapter",
 ]


### PR DESCRIPTION
## Summary
- check permit receivers against HATS requirements before starting work
- expose `get_hats_adapter` for environment-based HATS integration

## Testing
- `pre-commit run --files apps/api/workorder_endpoints.py loto/integrations/__init__.py`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad7d947fb48322a304c251c08e9207