### PR TITLE
Add HATS fail-close and warn-only feature flags

### DIFF
--- a/loto/constants.py
+++ b/loto/constants.py
@@ -1,10 +1,25 @@
 """Project-wide constants."""
 
+from __future__ import annotations
+
+import os
+
 DOC_CATEGORY = "Permit/LOTO"
 DOC_CATEGORY_DIR = DOC_CATEGORY.replace("/", "_")
 
 # Checklist item verifying the permit has been closed and uploaded.
 CHECKLIST_HAND_BACK = "Permit Closed & Hand-back uploaded"
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    """Return a boolean environment flag with ``default`` fallback."""
+
+    return os.getenv(name, str(default)).lower() in {"1", "true", "yes"}
+
+
+# Feature flags for HATS compliance checks.
+HATS_FAILCLOSE_CRITICAL = _env_flag("HATS_FAILCLOSE_CRITICAL", True)
+HATS_WARN_ONLY_MECH = _env_flag("HATS_WARN_ONLY_MECH", False)
 
 # Work order status domain descriptions
 WOSTATUS_DESCRIPTIONS = {

--- a/tests/api/test_hats_policy.py
+++ b/tests/api/test_hats_policy.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+import apps.api.workorder_endpoints as work_endpoints
+import loto.constants as constants
+from apps.api import main as main_module
+
+
+class StubHatsAdapter:
+    def has_required(
+        self, hats_ids: list[str], permit_types: list[str]
+    ) -> tuple[bool, list[str]]:
+        return False, ["MISSING"]
+
+
+class StubPermitAdapter:
+    def __init__(self, permit_types: list[str]) -> None:
+        self.permit_types = permit_types
+
+    def fetch_permit(
+        self, workorder_id: str
+    ) -> dict[str, list[str]]:  # pragma: no cover - simple stub
+        return {"permitTypes": self.permit_types}
+
+
+def setup_client(
+    monkeypatch: pytest.MonkeyPatch,
+    permit_types: list[str],
+    *,
+    failclose: bool = True,
+    warn_only_mech: bool = False,
+) -> TestClient:
+    monkeypatch.setenv("HATS_FAILCLOSE_CRITICAL", "1" if failclose else "0")
+    monkeypatch.setenv("HATS_WARN_ONLY_MECH", "1" if warn_only_mech else "0")
+    monkeypatch.setenv("RATE_LIMIT_CAPACITY", "100000")
+    importlib.reload(constants)
+    importlib.reload(work_endpoints)
+    importlib.reload(main_module)
+    monkeypatch.setattr(work_endpoints, "get_hats_adapter", lambda: StubHatsAdapter())
+    monkeypatch.setattr(
+        work_endpoints, "get_permit_adapter", lambda: StubPermitAdapter(permit_types)
+    )
+    return TestClient(main_module.app)
+
+
+@pytest.mark.parametrize("failclose,expected", [(True, 400), (False, 200)])  # type: ignore[misc]
+def test_hats_failclose_critical(
+    monkeypatch: pytest.MonkeyPatch, failclose: bool, expected: int
+) -> None:
+    client = setup_client(monkeypatch, ["Electrical"], failclose=failclose)
+    resp = client.post(
+        "/workorders/WO-2/status", json={"status": "INPRG", "currentStatus": "SCHED"}
+    )
+    assert resp.status_code == expected
+
+
+@pytest.mark.parametrize("warn_only,expected", [(False, 400), (True, 200)])  # type: ignore[misc]
+def test_hats_warn_only_mech(
+    monkeypatch: pytest.MonkeyPatch, warn_only: bool, expected: int
+) -> None:
+    client = setup_client(monkeypatch, ["Mechanical"], warn_only_mech=warn_only)
+    resp = client.post(
+        "/workorders/WO-2/status", json={"status": "INPRG", "currentStatus": "SCHED"}
+    )
+    assert resp.status_code == expected


### PR DESCRIPTION
## Summary
- add environment-driven HATS_FAILCLOSE_CRITICAL and HATS_WARN_ONLY_MECH flags
- block or warn on missing HATS training based on permit type and flags
- test policy behaviour for critical vs mechanical permits

## Testing
- `pre-commit run --files apps/api/workorder_endpoints.py loto/constants.py tests/api/test_hats_policy.py`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad7fe881648322bcd9ae96df650ead