### PR TITLE
Use HATS CBT in planner capacity

### DIFF
--- a/loto/isolation_planner.py
+++ b/loto/isolation_planner.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Dict, List, Mapping, Set, Tuple
 
 import networkx as nx
+
+from loto.integrations import get_hats_adapter
 
 from .models import IsolationAction, IsolationPlan, RulePack
 
@@ -140,7 +143,16 @@ class IsolationPlanner:
 
         plan: Dict[str, List[Tuple[str, str]]] = {}
 
-        cbt = float((config or {}).get("callback_time_min", 0))
+        cfg = dict(config or {})
+        primary_craft = cfg.get("primary_craft") or ""
+        site = cfg.get("site") or ""
+        window_start = cfg.get("window_start") or datetime.utcnow()
+        cbt = (
+            get_hats_adapter().cbt_minutes(primary_craft, site, window_start)
+            or cfg.get("callback_time_min")
+            or 0
+        )
+        cbt = float(cbt)
 
         node_split = os.getenv("PLANNER_NODE_SPLIT", "1") not in ("0", "")
         work_graphs: Dict[str, nx.MultiDiGraph] = {}

--- a/tests/planner/test_cbt.py
+++ b/tests/planner/test_cbt.py
@@ -1,0 +1,71 @@
+import networkx as nx
+import pytest
+from datetime import datetime
+
+from loto import isolation_planner as ip
+from loto.rule_engine import RulePack  # type: ignore[attr-defined]
+
+
+def test_cbt_prefers_fast_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
+    monkeypatch.setattr(ip, "CB_SCALE", 1000.0)
+    monkeypatch.setattr(ip, "RST_SCALE", 10.0)
+    monkeypatch.setattr(ip, "ZETA", 0.1)
+
+    g = nx.MultiDiGraph()
+    g.add_node("S", is_source=True)
+    g.add_node("A")
+    g.add_node("B")
+    g.add_node("T", tag="asset")
+
+    g.add_edge(
+        "S",
+        "A",
+        is_isolation_point=True,
+        op_cost_min=1.0,
+        reset_time_min=10.0,
+    )
+    g.add_edge(
+        "A",
+        "B",
+        is_isolation_point=True,
+        op_cost_min=4.0,
+        reset_time_min=1.0,
+    )
+    g.add_edge(
+        "B",
+        "T",
+        is_isolation_point=True,
+        op_cost_min=1.0,
+        reset_time_min=10.0,
+    )
+
+    planner = ip.IsolationPlanner()
+    pack = RulePack(risk_policies=None)
+
+    class Adapter0:
+        def cbt_minutes(self, craft: str, site: str, when: datetime) -> int:
+            return 0
+
+    monkeypatch.setattr(ip, "get_hats_adapter", lambda: Adapter0())
+    baseline = planner.compute({"process": g.copy()}, "asset", pack)
+    baseline_edges = {
+        action.component_id.split(":", 1)[1]
+        for action in baseline.actions
+        if action.component_id.startswith("process:")
+    }
+
+    class Adapter60:
+        def cbt_minutes(self, craft: str, site: str, when: datetime) -> int:
+            return 60
+
+    monkeypatch.setattr(ip, "get_hats_adapter", lambda: Adapter60())
+    adjusted = planner.compute({"process": g.copy()}, "asset", pack)
+    adjusted_edges = {
+        action.component_id.split(":", 1)[1]
+        for action in adjusted.actions
+        if action.component_id.startswith("process:")
+    }
+
+    assert baseline_edges == {"B->T"}
+    assert adjusted_edges == {"A->B"}


### PR DESCRIPTION
## Summary
- pull CBT minutes from HATS with fallback to config and apply to isolation planner capacity calculation
- add regression test proving CBT-aware planning prefers faster-reset isolations

## Testing
- `pre-commit run --files loto/isolation_planner.py tests/planner/test_cbt.py`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68ad82f7fbbc8322b029552ab8f96ca7