### PR TITLE
Add HATS health check

### DIFF
--- a/tests/api/test_healthz.py
+++ b/tests/api/test_healthz.py
@@ -21,6 +21,8 @@ def test_healthz_reports_components(monkeypatch: MonkeyPatch) -> None:
     assert data["adapters"]["maximo"]["status"] == "mock"
     assert data["adapters"]["coupa"]["status"] == "mock"
     assert data["adapters"]["permit"]["status"] == "mock"
+    assert data["hats"]["mode"] == "DEMO"
+    assert data["hats"]["ok"]
     assert data["db"]["head"] == "0002"
     assert data["integrity"]["missing_assets"] == 0
     assert data["integrity"]["missing_locations"] == 0


### PR DESCRIPTION
## Summary
- report HATS adapter status in `/healthz`
- validate health endpoint covers HATS section

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ad8e81dd188322bd7f18d9ba84c631