### PR TITLE
fix: use pnpm 9 in UI Dockerfile

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -4,7 +4,7 @@
 FROM node:20.10.0-alpine AS builder
 WORKDIR /app
 
-RUN npm install -g pnpm@8.15.1
+RUN npm install -g pnpm@9.0.0
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/maximo-extension-ui/package.json apps/maximo-extension-ui/
@@ -16,7 +16,7 @@ RUN pnpm -F maximo-extension-ui build
 FROM node:20.10.0-alpine
 WORKDIR /app
 
-RUN npm install -g pnpm@8.15.1
+RUN npm install -g pnpm@9.0.0
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/maximo-extension-ui/package.json apps/maximo-extension-ui/


### PR DESCRIPTION
## Summary
- use pnpm 9 in Dockerfile for maximo-extension-ui to match lockfile

## Testing
- `pre-commit run --files Dockerfile.ui`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68aebf5fbf8c8322a1e83bfded2cb028