### PR TITLE
Improve container health checks and demo startup

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -41,6 +41,7 @@ RUN apt-get update \
         libpangoft2-1.0-0 \
         libgdk-pixbuf-2.0-0 \
         fontconfig \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy installed packages and application source
@@ -56,6 +57,6 @@ USER appuser
 
 EXPOSE 8000
 
-HEALTHCHECK CMD python -c "import urllib.request,sys; urllib.request.urlopen('http://localhost:8000/healthz')" || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 CMD curl --fail http://localhost:8000/healthz || exit 1
 
 CMD ["./apps/api/entrypoint.sh"]

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -16,7 +16,8 @@ RUN pnpm -F maximo-extension-ui build
 FROM node:20.10.0-alpine
 WORKDIR /app
 
-RUN npm install -g pnpm@9.0.0
+RUN apk add --no-cache curl \
+    && npm install -g pnpm@9.0.0
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/maximo-extension-ui/package.json apps/maximo-extension-ui/
@@ -30,6 +31,6 @@ USER appuser
 
 EXPOSE 3000
 
-HEALTHCHECK CMD wget -qO- http://localhost:3000/ || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 CMD curl --fail http://localhost:3000/ || exit 1
 
 CMD ["pnpm", "-F", "maximo-extension-ui", "start"]

--- a/Makefile
+++ b/Makefile
@@ -13,49 +13,48 @@ typecheck:
 test:
 	pytest
 
-run-demo:
-	$(MAKE) demo-up
+run-demo: demo-up
 
 demo-up:
-        @COMPOSE="docker compose"; \
-        if docker compose version >/dev/null 2>&1; then \
-        COMPOSE="docker compose"; \
-        elif command -v docker-compose >/dev/null 2>&1; then \
-        COMPOSE="docker-compose"; \
-        else \
-        echo "Docker Compose is not installed. Install Docker and Docker Compose."; \
-        exit 1; \
-        fi; \
-        $$COMPOSE --profile demo --profile pilot up --build -d; \
-        end_time=$$(($(date +%s)+30)); \
-        until curl --silent http://localhost:8000/healthz >/dev/null 2>&1; do \
-        [ $$(date +%s) -ge $$end_time ] && { echo "API failed to start"; exit 1; }; \
-        sleep 1; \
-        done; \
-        $(MAKE) seed-demo; \
-        end_time=$$(($(date +%s)+30)); \
-        until curl --silent --fail http://localhost:8000/healthz >/dev/null 2>&1; do \
-        [ $$(date +%s) -ge $$end_time ] && { echo "Health check failed"; exit 1; }; \
-        sleep 1; \
-        done; \
-        if command -v xdg-open >/dev/null 2>&1; then \
-        xdg-open http://localhost:3000; \
-        elif command -v open >/dev/null 2>&1; then \
-        open http://localhost:3000; \
-        fi; \
-        $$COMPOSE --profile demo --profile pilot logs -f
+	@COMPOSE="docker compose"; \
+	if docker compose version >/dev/null 2>&1; then \
+	COMPOSE="docker compose"; \
+	elif command -v docker-compose >/dev/null 2>&1; then \
+	COMPOSE="docker-compose"; \
+	else \
+	echo "Docker Compose is not installed. Install Docker and Docker Compose."; \
+	exit 1; \
+	fi; \
+	$$COMPOSE --profile demo --profile pilot up --build -d; \
+	end_time=$$(($(date +%s)+60)); \
+	until curl --silent --fail http://localhost:8000/healthz >/dev/null 2>&1; do \
+	[ $$(date +%s) -ge $$end_time ] && { echo "API failed to start"; exit 1; }; \
+	sleep 1; \
+	done; \
+	$(MAKE) seed-demo; \
+	end_time=$$(($(date +%s)+60)); \
+	until curl --silent --fail http://localhost:8000/healthz >/dev/null 2>&1; do \
+	[ $$(date +%s) -ge $$end_time ] && { echo "Health check failed"; exit 1; }; \
+	sleep 1; \
+	done; \
+	if command -v xdg-open >/dev/null 2>&1; then \
+	xdg-open http://localhost:3000; \
+	elif command -v open >/dev/null 2>&1; then \
+	open http://localhost:3000; \
+	fi; \
+	$$COMPOSE --profile demo --profile pilot logs -f
 
 demo-down:
-        @COMPOSE="docker compose"; \
-        if docker compose version >/dev/null 2>&1; then \
-        COMPOSE="docker compose"; \
-        elif command -v docker-compose >/dev/null 2>&1; then \
-        COMPOSE="docker-compose"; \
-        else \
-        echo "Docker Compose is not installed. Install Docker and Docker Compose."; \
-        exit 1; \
-        fi; \
-        $$COMPOSE --profile demo --profile pilot down -v
+	@COMPOSE="docker compose"; \
+	if docker compose version >/dev/null 2>&1; then \
+	COMPOSE="docker compose"; \
+	elif command -v docker-compose >/dev/null 2>&1; then \
+	COMPOSE="docker-compose"; \
+	else \
+	echo "Docker Compose is not installed. Install Docker and Docker Compose."; \
+	exit 1; \
+	fi; \
+	$$COMPOSE --profile demo --profile pilot down -v
 
 check-prereqs:
 	./scripts/check-prereqs.sh


### PR DESCRIPTION
## Summary
- Install curl in API container and use curl-based healthcheck
- Add curl-based healthcheck to UI container
- Extend demo-up make target health checks with longer timeout
- Fix demo Makefile targets and make run-demo depend on demo-up

## Testing
- `pre-commit run --files Dockerfile.api Dockerfile.ui Makefile`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68b22e183d7c8322abcbc2af12888379