### PR TITLE
Infer exposure_mode from work scope hints and expose inference metadata

### DIFF
--- a/apps/api/planning_service.py
+++ b/apps/api/planning_service.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict
 
+import structlog
+
 from loto.impact import ImpactResult
 from loto.impact_config import load_impact_config
 from loto.integrations import get_permit_adapter
@@ -24,8 +26,11 @@ from loto.normalization import (
 )
 from loto.service import plan_and_evaluate
 from loto.service.blueprints import Provenance, inventory_state
+from loto.work_scope import infer_exposure_mode
 
 from .demo_data import demo_data
+
+logger = structlog.get_logger()
 
 
 @dataclass
@@ -196,7 +201,7 @@ def load_work_order_plan(
             inferred.append("temperature")
         return inferred or ["mechanical"]
 
-    def infer_exposure_mode(normalized_hazards: list[str]) -> str:
+    def fallback_exposure_mode(normalized_hazards: list[str]) -> str:
         permit_exposure = canonicalize_exposure_mode(permit.get("exposure_mode"))
         if isinstance(permit_exposure, str) and permit_exposure:
             return permit_exposure
@@ -209,7 +214,8 @@ def load_work_order_plan(
             return "thermal_only"
         return "none"
 
-    normalized_work_type = canonicalize_work_type(work_type) or infer_work_type()
+    provided_work_type = canonicalize_work_type(work_type)
+    normalized_work_type = provided_work_type or infer_work_type()
     normalized_hazard_class: list[str]
     if isinstance(hazard_class, list):
         normalized_hazard_class = [
@@ -223,9 +229,36 @@ def load_work_order_plan(
         normalized_hazard_class = []
     if not normalized_hazard_class:
         normalized_hazard_class = infer_hazard_class()
-    normalized_exposure_mode = canonicalize_exposure_mode(
-        exposure_mode
-    ) or infer_exposure_mode(normalized_hazard_class)
+    provided_exposure_mode = canonicalize_exposure_mode(exposure_mode)
+    scope_inference = infer_exposure_mode(description, permit=permit)
+    inferred_exposure_mode = scope_inference.exposure_mode or fallback_exposure_mode(
+        normalized_hazard_class
+    )
+    normalized_exposure_mode = provided_exposure_mode or inferred_exposure_mode
+
+    escalation_applied = (
+        scope_inference.escalate_to_intrusive_mech
+        and not provided_work_type
+        and normalized_work_type != "intrusive_mech"
+    )
+    if escalation_applied:
+        normalized_work_type = "intrusive_mech"
+
+    inference_meta = {
+        "exposure_mode": {
+            "provided": provided_exposure_mode,
+            "inferred": inferred_exposure_mode,
+            "final": normalized_exposure_mode,
+            "source": "request" if provided_exposure_mode else "inferred",
+            "matched_terms": list(scope_inference.matched_terms),
+        },
+        "work_type": {
+            "provided": provided_work_type,
+            "final": normalized_work_type,
+            "escalated_to_intrusive_mech": escalation_applied,
+        },
+    }
+    logger.info("work_scope_inference", **inference_meta)
 
     cfg: Dict[str, Any] = {
         "callback_time_min": permit.get("callback_time_min", 0),
@@ -267,6 +300,12 @@ def load_work_order_plan(
             hazard_class=normalized_hazard_class,
             exposure_mode=normalized_exposure_mode,
         )
+
+    provenance = Provenance(
+        seed=provenance.seed,
+        rule_hash=provenance.rule_hash,
+        context=inference_meta,
+    )
 
     return (
         WorkOrderPlanBundle(

--- a/loto/service/blueprints.py
+++ b/loto/service/blueprints.py
@@ -8,7 +8,7 @@ import random
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, Dict, Iterable, Mapping, Tuple
+from typing import IO, Any, Dict, Iterable, Mapping, Tuple
 
 import structlog
 
@@ -41,6 +41,7 @@ class Provenance:
 
     seed: int | None
     rule_hash: str
+    context: Mapping[str, Any] | None = None
 
 
 def _parse_component_id(component_id: str) -> tuple[str, str, str]:

--- a/loto/work_scope.py
+++ b/loto/work_scope.py
@@ -1,0 +1,100 @@
+"""Work-scope inference helpers used by planning entrypoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class ExposureInference:
+    """Inference output for exposure mode and related escalation hints."""
+
+    exposure_mode: str | None
+    escalate_to_intrusive_mech: bool
+    matched_terms: tuple[str, ...]
+
+
+_RELEASE_POSSIBLE_TERMS = (
+    "packing leak",
+    "gland",
+    "clamp",
+    "actuator swap",
+)
+_THERMAL_ONLY_TERMS = (
+    "support",
+    "insulation",
+)
+_BOUNDARY_OPEN_TERMS = (
+    "boundary open",
+    "boundary-open",
+    "open boundary",
+    "line break",
+    "break containment",
+    "open line",
+    "flange break",
+)
+
+
+def _permit_hints_text(permit: Mapping[str, Any] | None) -> str:
+    if not permit:
+        return ""
+    fields = (
+        "scope_hint",
+        "scope_hints",
+        "work_scope",
+        "workscope",
+        "job_scope",
+        "permit_hints",
+    )
+    parts: list[str] = []
+    for key in fields:
+        value = permit.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(value)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            parts.extend(str(item) for item in value if str(item).strip())
+    return " ".join(parts)
+
+
+def infer_exposure_mode(
+    description: str | None,
+    *,
+    permit: Mapping[str, Any] | None = None,
+) -> ExposureInference:
+    """Infer exposure mode from description and permit hints.
+
+    Boundary-open terms force escalation to ``intrusive_mech``.
+    """
+
+    source = f"{description or ''} {_permit_hints_text(permit)}".lower()
+
+    matched_boundary = tuple(term for term in _BOUNDARY_OPEN_TERMS if term in source)
+    if matched_boundary:
+        return ExposureInference(
+            exposure_mode="release_possible",
+            escalate_to_intrusive_mech=True,
+            matched_terms=matched_boundary,
+        )
+
+    matched_release = tuple(term for term in _RELEASE_POSSIBLE_TERMS if term in source)
+    if matched_release:
+        return ExposureInference(
+            exposure_mode="release_possible",
+            escalate_to_intrusive_mech=False,
+            matched_terms=matched_release,
+        )
+
+    matched_thermal = tuple(term for term in _THERMAL_ONLY_TERMS if term in source)
+    if matched_thermal:
+        return ExposureInference(
+            exposure_mode="thermal_only",
+            escalate_to_intrusive_mech=False,
+            matched_terms=matched_thermal,
+        )
+
+    return ExposureInference(
+        exposure_mode=None,
+        escalate_to_intrusive_mech=False,
+        matched_terms=(),
+    )

--- a/tests/api/test_planning_service_normalization.py
+++ b/tests/api/test_planning_service_normalization.py
@@ -119,3 +119,120 @@ def test_load_work_order_plan_legacy_defaults_from_permit_and_description(
     assert captured["work_type"] == "hot_work"
     assert captured["hazard_class"] == ["temperature", "pressure"]
     assert captured["exposure_mode"] == "ignition_possible"
+
+
+def test_load_work_order_plan_infers_exposure_from_scope_terms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
+    )
+
+    class _PermitAdapter:
+        def fetch_permit(self, workorder_id: str) -> dict[str, Any]:
+            return {
+                "description": "Support replacement and insulation touch-up",
+                "callback_time_min": 5,
+                "applied_isolations": [],
+            }
+
+    monkeypatch.setattr(
+        planning_service, "get_permit_adapter", lambda: _PermitAdapter()
+    )
+
+    bundle, _ = planning_service.load_work_order_plan(
+        "WO-1", strict_pre_applied_isolations=False, state={}
+    )
+
+    assert bundle.provenance.context is not None
+    assert bundle.provenance.context["exposure_mode"]["final"] == "thermal_only"
+    assert bundle.provenance.context["exposure_mode"]["source"] == "inferred"
+
+
+def test_load_work_order_plan_boundary_open_escalates_when_work_type_not_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
+    )
+
+    class _PermitAdapter:
+        def fetch_permit(self, workorder_id: str) -> dict[str, Any]:
+            return {
+                "description": "Hot work with open boundary for tie-in",
+                "callback_time_min": 5,
+                "applied_isolations": [],
+            }
+
+    captured: dict[str, Any] = {}
+
+    def _capturing_plan_and_evaluate(*args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        from loto.service.blueprints import plan_and_evaluate as real_plan_and_evaluate
+
+        return real_plan_and_evaluate(*args, **kwargs)
+
+    monkeypatch.setattr(
+        planning_service, "get_permit_adapter", lambda: _PermitAdapter()
+    )
+    monkeypatch.setattr(
+        planning_service, "plan_and_evaluate", _capturing_plan_and_evaluate
+    )
+
+    bundle, _ = planning_service.load_work_order_plan(
+        "WO-1",
+        strict_pre_applied_isolations=False,
+        state={},
+        work_type="hot_work",
+        exposure_mode="none",
+    )
+
+    assert captured["work_type"] == "hot_work"
+    assert captured["exposure_mode"] == "none"
+    assert bundle.provenance.context is not None
+    assert (
+        bundle.provenance.context["work_type"]["escalated_to_intrusive_mech"] is False
+    )
+    assert bundle.provenance.context["exposure_mode"]["source"] == "request"
+
+
+def test_load_work_order_plan_boundary_open_escalates_to_intrusive_mech(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
+    )
+
+    class _PermitAdapter:
+        def fetch_permit(self, workorder_id: str) -> dict[str, Any]:
+            return {
+                "description": "Hot work with open boundary for tie-in",
+                "callback_time_min": 5,
+                "applied_isolations": [],
+            }
+
+    captured: dict[str, Any] = {}
+
+    def _capturing_plan_and_evaluate(*args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        from loto.service.blueprints import plan_and_evaluate as real_plan_and_evaluate
+
+        return real_plan_and_evaluate(*args, **kwargs)
+
+    monkeypatch.setattr(
+        planning_service, "get_permit_adapter", lambda: _PermitAdapter()
+    )
+    monkeypatch.setattr(
+        planning_service, "plan_and_evaluate", _capturing_plan_and_evaluate
+    )
+
+    bundle, _ = planning_service.load_work_order_plan(
+        "WO-1",
+        strict_pre_applied_isolations=False,
+        state={},
+    )
+
+    assert captured["work_type"] == "intrusive_mech"
+    assert captured["exposure_mode"] == "release_possible"
+    assert bundle.provenance.context is not None
+    assert bundle.provenance.context["work_type"]["escalated_to_intrusive_mech"] is True

--- a/tests/test_work_scope.py
+++ b/tests/test_work_scope.py
@@ -1,0 +1,29 @@
+from loto.work_scope import infer_exposure_mode
+
+
+def test_infer_exposure_mode_release_possible_terms() -> None:
+    inferred = infer_exposure_mode("Repair packing leak near valve gland")
+    assert inferred.exposure_mode == "release_possible"
+    assert inferred.escalate_to_intrusive_mech is False
+    assert "packing leak" in inferred.matched_terms
+
+
+def test_infer_exposure_mode_thermal_only_terms() -> None:
+    inferred = infer_exposure_mode("Replace insulation support")
+    assert inferred.exposure_mode == "thermal_only"
+    assert inferred.escalate_to_intrusive_mech is False
+
+
+def test_infer_exposure_mode_boundary_open_escalates() -> None:
+    inferred = infer_exposure_mode("Line break required for spool removal")
+    assert inferred.exposure_mode == "release_possible"
+    assert inferred.escalate_to_intrusive_mech is True
+    assert "line break" in inferred.matched_terms
+
+
+def test_infer_exposure_mode_uses_permit_hints() -> None:
+    inferred = infer_exposure_mode(
+        "Routine maintenance", permit={"scope_hint": "actuator swap"}
+    )
+    assert inferred.exposure_mode == "release_possible"
+    assert inferred.escalate_to_intrusive_mech is False


### PR DESCRIPTION
### Motivation
- Improve planning accuracy by inferring `exposure_mode` from free-text work descriptions and permit hints when callers omit an explicit exposure override.  
- Surface the inference decision and any escalation intent so downstream consumers and logs can explain why a particular mode or escalation was chosen.

### Description
- Added `loto/work_scope.py` providing `infer_exposure_mode(description, permit=...)` which returns an `ExposureInference` capturing inferred `exposure_mode`, whether boundary-open terms should escalate to `intrusive_mech`, and matched terms; it recognizes `release_possible` terms (`packing leak`, `gland`, `clamp`, `actuator swap`), `thermal_only` terms (`support`, `insulation`) and a set of boundary-open indicators that flag escalation.  
- Updated `apps/api/planning_service.py` to apply scope-based inference only when the request does not provide `exposure_mode`, to prefer explicit request fields over inferred values, and to escalate `work_type` to `intrusive_mech` only when inference indicates boundary-open and the caller did not provide a `work_type`.  
- Added structured trace/debug metadata (`inference_meta`) logged as `work_scope_inference` and attached the metadata into the returned plan provenance so callers can see `provided`, `inferred`, `final`, `matched_terms`, and any `escalated_to_intrusive_mech` decision.  
- Extended the `Provenance` dataclass in `loto/service/blueprints.py` to accept an optional `context` mapping so inference metadata can be carried in plan outputs, and added unit tests exercising inference, precedence, and escalation behavior.

### Testing
- Ran formatting (`make fmt`) and linting (`make lint`) successfully.  
- Ran static typing (`make typecheck`) with no issues.  
- Ran the full test suite (`make test`) and all tests passed: `362 passed` (with warnings only).  
- Ran `pre-commit` checks on changed files which passed (black, ruff, mypy).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a7fcf60f2883228177f40970d48409)