### PR TITLE
Add planner/blueprint policy-context tests and RulePack schema validation

### DIFF
--- a/tests/api/test_blueprint_request_schema.py
+++ b/tests/api/test_blueprint_request_schema.py
@@ -12,3 +12,29 @@ def test_blueprint_request_normalizes_optional_fields() -> None:
     assert payload.work_type == "intrusive_mech"
     assert payload.hazard_class == ["pressure", "chemical"]
     assert payload.exposure_mode == "release_possible"
+
+
+def test_blueprint_request_accepts_string_hazard_class_and_none_defaults() -> None:
+    payload = BlueprintRequest(
+        workorder_id="WO-2",
+        work_type=None,
+        hazard_class=" Steam-Pressure ",
+        exposure_mode=None,
+    )
+
+    assert payload.work_type is None
+    assert payload.hazard_class == "steam_pressure"
+    assert payload.exposure_mode is None
+
+
+def test_blueprint_request_defaults_optional_fields_when_omitted() -> None:
+    payload = BlueprintRequest(
+        workorder_id="WO-3",
+        work_type=None,
+        hazard_class=None,
+        exposure_mode=None,
+    )
+
+    assert payload.work_type is None
+    assert payload.hazard_class is None
+    assert payload.exposure_mode is None

--- a/tests/planner/test_policy_resolution.py
+++ b/tests/planner/test_policy_resolution.py
@@ -4,6 +4,7 @@ import pytest
 from loto.errors import UnisolatablePathError
 from loto.isolation_planner import IsolationPlanner
 from loto.models import (
+    ExposureMode,
     IsolationPolicyEntry,
     IsolationPolicyWorkTypeMatrix,
     RequiredActions,
@@ -103,3 +104,116 @@ def test_external_maintenance_prefers_closest_cut(
         },
     )
     assert local.actions[0].component_id.endswith("n->t")
+
+
+def test_external_maintenance_pressure_thermal_only_does_not_require_intrusive_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
+    g = nx.MultiDiGraph()
+    g.add_node("s", is_source=True)
+    g.add_node("u")
+    g.add_node("n")
+    g.add_node("t", tag="asset")
+    g.add_edge("s", "u", is_isolation_point=True, op_cost_min=1.0)
+    g.add_edge("u", "n")
+    g.add_edge("n", "t", is_isolation_point=True, op_cost_min=1.3)
+
+    planner = IsolationPlanner()
+    pack = RulePack(risk_policies=None)
+    plan = planner.compute(
+        {"steam": g},
+        asset_tag="asset",
+        rule_pack=pack,
+        config={
+            "work_type": "external_maintenance",
+            "hazard_class": ["pressure"],
+            "exposure_mode": "thermal_only",
+        },
+    )
+
+    assert plan.actions[0].component_id.endswith("n->t")
+    assert not any("DDBB" in item for item in plan.verifications)
+
+
+def test_external_maintenance_release_possible_requires_local_block_depressurize_and_prove(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
+    g = nx.MultiDiGraph()
+    g.add_node("s", is_source=True)
+    g.add_node("u")
+    g.add_node("n")
+    g.add_node("t", tag="asset")
+    g.add_node("sink", safe_sink=True)
+    g.add_edge("s", "u", is_isolation_point=True, op_cost_min=1.0)
+    g.add_edge("u", "n")
+    g.add_edge("n", "t", is_isolation_point=True, op_cost_min=1.3)
+    g.add_edge("n", "sink", is_bleed=True)
+
+    custom_matrix = {
+        WorkType.EXTERNAL_MAINTENANCE: IsolationPolicyWorkTypeMatrix(
+            pressure=IsolationPolicyEntry(
+                default=RequiredActions(block_sources=True, prove_zero=True),
+                exposure_overrides={
+                    ExposureMode.RELEASE_POSSIBLE: RequiredActions(
+                        block_sources=True,
+                        depressurize_to_sink=True,
+                        prove_zero=True,
+                    )
+                },
+            )
+        )
+    }
+
+    planner = IsolationPlanner()
+    pack = RulePack(risk_policies=None, isolation_policy_matrix=custom_matrix)
+    plan = planner.compute(
+        {"steam": g},
+        asset_tag="asset",
+        rule_pack=pack,
+        config={
+            "work_type": "external_maintenance",
+            "hazard_class": ["pressure"],
+            "exposure_mode": "release_possible",
+        },
+    )
+
+    assert plan.actions[0].component_id.endswith("n->t")
+    assert any("PT=0" in item for item in plan.verifications)
+    assert "path-check: depressurization path to safe sink" in plan.verifications
+    assert any("depressurize_to_sink verified" in item for item in plan.verifications)
+
+
+def test_intrusive_mech_outputs_action_category_strings_for_boundary_open_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
+    g = nx.MultiDiGraph()
+    g.add_node("s", is_source=True)
+    g.add_node("v1")
+    g.add_node("v2")
+    g.add_node("t", tag="asset")
+    g.add_node("sink", safe_sink=True)
+    g.add_edge("s", "v1", is_isolation_point=True)
+    g.add_edge("v1", "v2", is_isolation_point=True)
+    g.add_edge("v2", "t")
+    g.add_edge("v1", "sink", is_bleed=True)
+
+    planner = IsolationPlanner()
+    pack = RulePack(risk_policies=None)
+    plan = planner.compute(
+        {"steam": g},
+        asset_tag="asset",
+        rule_pack=pack,
+        config={
+            "work_type": "intrusive_mech",
+            "hazard_class": ["pressure"],
+            "exposure_mode": "release_possible",
+        },
+    )
+
+    assert any("PT=0" in item for item in plan.verifications)
+    assert any("DDBB" in item for item in plan.verifications)
+    assert "path-check: depressurization path to safe sink" in plan.verifications
+    assert any("pressure relief routed to safe sink" in item for item in plan.controls)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -193,6 +193,27 @@ def test_rulepack_defaults_policy_matrix_for_backward_compatibility() -> None:
     assert effective[WorkType.INTRUSIVE_MECH].chemical.default.require_ddbb
 
 
+def test_rulepack_rejects_unknown_exposure_override_mode() -> None:
+    with pytest.raises(ValidationError):
+        RulePack.model_validate(
+            {
+                "domain_rules": [],
+                "verification_rules": [],
+                "risk_policies": None,
+                "isolation_policy_matrix": {
+                    "external_maintenance": {
+                        "pressure": {
+                            "default": {"block_sources": True},
+                            "exposure_overrides": {
+                                "unknown_mode": {"depressurize_to_sink": True}
+                            },
+                        }
+                    }
+                },
+            }
+        )
+
+
 def test_invalid_type_raises_error() -> None:
     """Invalid field types should raise clear validation errors."""
 

--- a/tests/test_service_blueprints.py
+++ b/tests/test_service_blueprints.py
@@ -434,3 +434,109 @@ def test_pre_applied_permit_isolation_reduces_schedule_workload_and_makespan(
         "Expected concurrent permit benefit: pre-applied permit isolations should improve "
         f"deterministic p50 makespan proxy (baseline={base_makespan}, with_permit={permit_makespan})."
     )
+
+
+def test_plan_and_evaluate_canonicalizes_policy_context_for_planner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
+    )
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
+
+    line_df = pd.DataFrame(
+        [
+            {"domain": "steam", "from_tag": "S", "to_tag": "V"},
+            {"domain": "steam", "from_tag": "V", "to_tag": "DEMO_ASSET_1"},
+        ]
+    )
+    valve_df = pd.DataFrame(
+        [{"domain": "steam", "tag": "V", "fail_state": "FC", "kind": "MV"}]
+    )
+    drain_df = pd.DataFrame([{"domain": "steam", "tag": "D", "kind": "drain"}])
+    source_df = pd.DataFrame([{"domain": "steam", "tag": "S", "kind": "source"}])
+
+    captured: dict[str, object] = {}
+
+    from loto.models import IsolationPlan
+
+    def fake_compute(self, graphs, asset_tag, rule_pack, config=None):  # type: ignore[no-untyped-def]
+        captured.update(config or {})
+        return IsolationPlan(
+            plan_id=asset_tag, actions=[], verifications=[], hazards=[], controls=[]
+        )
+
+    monkeypatch.setattr(
+        "loto.service.blueprints.IsolationPlanner.compute", fake_compute
+    )
+
+    plan_and_evaluate(
+        io.StringIO(line_df.to_csv(index=False)),
+        io.StringIO(valve_df.to_csv(index=False)),
+        io.StringIO(drain_df.to_csv(index=False)),
+        io.StringIO(source_df.to_csv(index=False)),
+        asset_tag="DEMO_ASSET_1",
+        rule_pack=RulePack(risk_policies=None),
+        stimuli=[],
+        asset_units={"DEMO_ASSET_1": "U1"},
+        unit_data={"U1": {"rated": 5.0, "scheme": "SPOF"}},  # type: ignore[dict-item]
+        unit_areas={"U1": "Area1"},
+        work_type=" External-Maintenance ",
+        hazard_class=[" Pressure ", "CHEMICAL"],
+        exposure_mode=" RELEASE-POSSIBLE ",
+    )
+
+    assert captured["work_type"] == "external_maintenance"
+    assert captured["hazard_class"] == ["pressure", "chemical"]
+    assert captured["exposure_mode"] == "release_possible"
+
+
+def test_plan_and_evaluate_defaults_empty_policy_context_for_planner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "loto.service.blueprints.validate_fk_integrity", lambda *a, **k: None
+    )
+    monkeypatch.setenv("PLANNER_NODE_SPLIT", "0")
+
+    line_df = pd.DataFrame(
+        [
+            {"domain": "steam", "from_tag": "S", "to_tag": "V"},
+            {"domain": "steam", "from_tag": "V", "to_tag": "DEMO_ASSET_1"},
+        ]
+    )
+    valve_df = pd.DataFrame(
+        [{"domain": "steam", "tag": "V", "fail_state": "FC", "kind": "MV"}]
+    )
+    drain_df = pd.DataFrame([{"domain": "steam", "tag": "D", "kind": "drain"}])
+    source_df = pd.DataFrame([{"domain": "steam", "tag": "S", "kind": "source"}])
+
+    captured: dict[str, object] = {}
+    from loto.models import IsolationPlan
+
+    def fake_compute(self, graphs, asset_tag, rule_pack, config=None):  # type: ignore[no-untyped-def]
+        captured.update(config or {})
+        return IsolationPlan(
+            plan_id=asset_tag, actions=[], verifications=[], hazards=[], controls=[]
+        )
+
+    monkeypatch.setattr(
+        "loto.service.blueprints.IsolationPlanner.compute", fake_compute
+    )
+
+    plan_and_evaluate(
+        io.StringIO(line_df.to_csv(index=False)),
+        io.StringIO(valve_df.to_csv(index=False)),
+        io.StringIO(drain_df.to_csv(index=False)),
+        io.StringIO(source_df.to_csv(index=False)),
+        asset_tag="DEMO_ASSET_1",
+        rule_pack=RulePack(risk_policies=None),
+        stimuli=[],
+        asset_units={"DEMO_ASSET_1": "U1"},
+        unit_data={"U1": {"rated": 5.0, "scheme": "SPOF"}},  # type: ignore[dict-item]
+        unit_areas={"U1": "Area1"},
+    )
+
+    assert captured["work_type"] is None
+    assert captured["hazard_class"] == []
+    assert captured["exposure_mode"] is None


### PR DESCRIPTION
### Motivation
- Close gaps in policy-context and schema coverage for the planner and API layers so canonicalisation and policy-driven behaviour are validated. 
- Ensure `RulePack` rejects unknown `exposure_overrides` keys and that planner outputs include human-readable verification/control categories for downstream consumers. 
- Verify the service layer and API schema canonicalise and default optional policy context fields before calling the planner.

### Description
- Added a `RulePack` schema validation test that asserts unknown `exposure_overrides` enum keys raise `ValidationError` in `tests/test_models.py`.
- Extended planner policy tests in `tests/planner/test_policy_resolution.py` with tests that assert: `external_maintenance + pressure + thermal_only` selects a local, non-intrusive cut and does not require DDBB; `external_maintenance + release_possible` requires local block + depressurize + prove verifications using a custom policy matrix; and `intrusive_mech` boundary-open cases produce verification/control strings (PT=0, DDBB, path-check, sink control).
- Added service-layer tests in `tests/test_service_blueprints.py` to assert `plan_and_evaluate` canonicalises `work_type`, `hazard_class`, and `exposure_mode` inputs and passes `None`/empty defaults to the planner when omitted.
- Added API schema tests in `tests/api/test_blueprint_request_schema.py` to cover string hazard normalization and omitted optional fields for `BlueprintRequest`.
- Applied formatting and imports cleanup to keep tests type-check-clean and integrated with existing test harness.

### Testing
- Ran `pre-commit run --files tests/api/test_blueprint_request_schema.py tests/planner/test_policy_resolution.py tests/test_models.py tests/test_service_blueprints.py` and addressed mypy issues introduced by the new tests (pre-commit passed afterwards).
- Ran `make fmt`, `make lint`, and `make typecheck` with no issues reported.
- Ran the full test suite with `make test`; the suite completed successfully: `370 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a803c54dcc83229c8c62e903461878)